### PR TITLE
Fix bug that caused page numbers to be missed

### DIFF
--- a/src/main/java/org/mdz/search/solrocr/formats/OcrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/OcrPassageFormatter.java
@@ -48,8 +48,9 @@ public abstract class OcrPassageFormatter extends PassageFormatter {
         sb.insert(Math.min(extraChars + matchEnd, sb.length()), endHlTag);
         extraChars += endHlTag.length();
       }
-      String xmlFragment = truncateFragment(sb.toString());
+      String xmlFragment = sb.toString();
       String pageId = determinePage(xmlFragment, passage.getStartOffset(), content);
+      xmlFragment = truncateFragment(xmlFragment);
       snippets[i] = parseFragment(xmlFragment, pageId);
       snippets[i].setScore(passage.getScore());
     }

--- a/src/test/java/org/mdz/search/solrocr/solr/HocrEscapedTest.java
+++ b/src/test/java/org/mdz/search/solrocr/solr/HocrEscapedTest.java
@@ -99,4 +99,11 @@ public class HocrEscapedTest extends SolrTestCaseJ4 {
     assertQ(req,
         "count(//lst[@name='ocrHighlighting']/lst)=1");
   }
+
+  @Test
+  public void testPageNumberAtBeginningOfPage() throws Exception {
+    SolrQueryRequest req = xmlQ("q", "\"peramentvollere Glänzendere\"", "hl.weightMatches", "true");
+    assertQ(req, "//lst[@name='ocrHighlighting']//str[@name='page']/text()='page_109'");
+  }
+
 }


### PR DESCRIPTION
Previously, we would truncate a OCR snippet before we extracted the page number from the snippet. In some cases, this lead to the page number being truncated, leading to a missing page number in the results.
The PR addresses this by first extracting the page number and then truncating the snippet for further parsing.