### PR TITLE
Refactor fragment truncation logic for more code-reuse

### DIFF
--- a/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
@@ -1,5 +1,6 @@
 package org.mdz.search.solrocr.formats.alto;
 
+import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,12 +39,6 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
 
   @Override
   public String determinePage(String ocrFragment, int startOffset, IterableCharSequence content) {
-    if (ocrFragment != null) {
-      Matcher m = pagePat.matcher(ocrFragment);
-      if (m.find()) {
-        return parseAttribs(m.group("attribs")).get("ID");
-      }
-    }
     pageIter.setText(content);
     int pageOffset = pageIter.preceding(startOffset);
     String pageFragment = content.subSequence(
@@ -71,20 +66,6 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
       sb.replace(m.start(), m.end(), content);
     }
     return sb.toString().replaceAll("</?[A-Z]?.*?>?", "");
-  }
-
-  @Override
-  protected String truncateFragment(String ocrFragment) {
-    if (ocrFragment.contains(startHlTag)) {
-      pageIter.setText(ocrFragment);
-      int start = pageIter.preceding(ocrFragment.indexOf(startHlTag));
-      int end = pageIter.following(ocrFragment.lastIndexOf(endHlTag));
-      ocrFragment = ocrFragment.substring(start, end);
-    }
-    limitIter.setText(ocrFragment);
-    int start = limitIter.preceding(ocrFragment.indexOf(startHlTag));
-    int end = limitIter.following(ocrFragment.lastIndexOf(endHlTag));
-    return ocrFragment.substring(start, end);
   }
 
   @Override
@@ -144,5 +125,15 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
             .collect(Collectors.toList()))
         .forEach(bs -> snip.addHighlightRegion(this.mergeBoxes(bs)));
     return snip;
+  }
+
+  @Override
+  protected BreakIterator getPageBreakIterator() {
+    return pageIter;
+  }
+
+  @Override
+  protected BreakIterator getLimitBreakIterator() {
+    return limitIter;
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -1,5 +1,6 @@
 package org.mdz.search.solrocr.formats.hocr;
 
+import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -41,18 +42,6 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
       return m.group("pageId");
     }
     return null;
-  }
-
-  @Override
-  protected String truncateFragment(String ocrFragment) {
-    pageIter.setText(ocrFragment);
-    int start = pageIter.preceding(ocrFragment.indexOf(startHlTag));
-    int end = pageIter.following(ocrFragment.lastIndexOf(endHlTag));
-    ocrFragment = ocrFragment.substring(start, end);
-    limitIter.setText(ocrFragment);
-    start = limitIter.preceding(ocrFragment.indexOf(startHlTag));
-    end = limitIter.following(ocrFragment.lastIndexOf(endHlTag));
-    return ocrFragment.substring(start, end);
   }
 
   @Override
@@ -108,5 +97,15 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
             .collect(Collectors.toList()))
         .forEach(bs -> snip.addHighlightRegion(this.mergeBoxes(bs)));
     return snip;
+  }
+
+  @Override
+  protected BreakIterator getPageBreakIterator() {
+    return pageIter;
+  }
+
+  @Override
+  protected BreakIterator getLimitBreakIterator() {
+    return limitIter;
   }
 }

--- a/src/test/java/org/mdz/search/solrocr/solr/OcrFieldsTest.java
+++ b/src/test/java/org/mdz/search/solrocr/solr/OcrFieldsTest.java
@@ -68,16 +68,16 @@ public class OcrFieldsTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = xmlQ("q", "München");
     assertQ(req,
         "count(//lst[@name='ocrHighlighting']/lst[@name='31337']/lst[@name='external_ocr_text']/arr/lst)=3",
-            "//str[@name='text'][1]/text()='Bayerische Staatsbibliothek <em>München</em> Morgen-Ausgabe. Preſſe.'",
-            "//lst[@name='region'][1]/float[@name='ulx']/text()='0.3714'",
+            "//str[@name='text'][1]/text()='Bayerische Staatsbibliothek <em>München</em>'",
+            "//lst[@name='region'][1]/float[@name='ulx']/text()='0.4949'",
             "//lst[@name='region'][1]/float[@name='uly']/text()='0.0071'",
-            "//lst[@name='region'][1]/float[@name='lrx']/text()='0.8098'",
-            "//lst[@name='region'][1]/float[@name='lry']/text()='0.1104'",
+            "//lst[@name='region'][1]/float[@name='lrx']/text()='0.571'",
+            "//lst[@name='region'][1]/float[@name='lry']/text()='0.028499998'",
             "count(//arr[@name='highlights'])=3",
-            "//arr[@name='highlights'][1]/arr/lst/float[@name='ulx']/text()='0.3223'",
-            "//arr[@name='highlights'][1]/arr/lst/float[@name='uly']/text()='0.1481'",
-            "//arr[@name='highlights'][1]/arr/lst/float[@name='lrx']/text()='0.4171'",
-            "//arr[@name='highlights'][1]/arr/lst/float[@name='lry']/text()='0.2071'");
+            "//arr[@name='highlights'][1]/arr/lst/float[@name='ulx']/text()='0.2339'",
+            "//arr[@name='highlights'][1]/arr/lst/float[@name='uly']/text()='0.7149'",
+            "//arr[@name='highlights'][1]/arr/lst/float[@name='lrx']/text()='0.7805'",
+            "//arr[@name='highlights'][1]/arr/lst/int[@name='lry']/text()='1'");
   }
 
   @Test
@@ -222,8 +222,8 @@ public class OcrFieldsTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = xmlQ("q", "\"Bayerische Staatsbibliothek München\"", "hl.weightMatches", "true");
     assertQ(req,
             "count(//lst[@name='ocrHighlighting']/lst[@name='31337']/lst[@name='external_ocr_text']/arr/lst)=1",
-            "//str[@name='text']/text()='Herausgeber und <em>Bayerische Staatsbibliothek München</em>'",
-            "//arr[@name='highlights']/arr/lst[1]/float[@name='ulx']/text()='0.7853'",
+            "//str[@name='text']/text()='<em>Bayerische Staatsbibliothek München</em>'",
+            "//arr[@name='highlights']/arr/lst[1]/float[@name='ulx']/text()='0.1695'",
             "//arr[@name='highlights']/arr/lst[1]/int[@name='uly']/text()='0'");
   }
 

--- a/src/test/java/org/mdz/search/solrocr/solr/Utf8OcrFieldsTest.java
+++ b/src/test/java/org/mdz/search/solrocr/solr/Utf8OcrFieldsTest.java
@@ -68,17 +68,17 @@ public class Utf8OcrFieldsTest extends SolrTestCaseJ4 {
   public void testSingleTerm() throws Exception {
     SolrQueryRequest req = xmlQ("q", "München");
     assertQ(req,
-        "count(//lst[@name='ocrHighlighting']/lst[@name='31337']/lst[@name='ocr_text']/arr/lst)=3",
-        "//str[@name='text'][1]/text()='Bayerische Staatsbibliothek <em>München</em> Morgen-Ausgabe. Preſſe.'",
-        "//lst[@name='region'][1]/float[@name='ulx']/text()='0.3714'",
-        "//lst[@name='region'][1]/float[@name='uly']/text()='0.0071'",
-        "//lst[@name='region'][1]/float[@name='lrx']/text()='0.8098'",
-        "//lst[@name='region'][1]/float[@name='lry']/text()='0.1104'",
-        "count(//arr[@name='highlights'])=3",
-        "//arr[@name='highlights'][1]/arr/lst/float[@name='ulx']/text()='0.3223'",
-        "//arr[@name='highlights'][1]/arr/lst/float[@name='uly']/text()='0.1481'",
-        "//arr[@name='highlights'][1]/arr/lst/float[@name='lrx']/text()='0.4171'",
-        "//arr[@name='highlights'][1]/arr/lst/float[@name='lry']/text()='0.2071'");
+            "count(//lst[@name='ocrHighlighting']/lst[@name='31337']/lst[@name='ocr_text']/arr/lst)=3",
+            "//str[@name='text'][1]/text()='Bayerische Staatsbibliothek <em>München</em>'",
+            "//lst[@name='region'][1]/float[@name='ulx']/text()='0.4949'",
+            "//lst[@name='region'][1]/float[@name='uly']/text()='0.0071'",
+            "//lst[@name='region'][1]/float[@name='lrx']/text()='0.571'",
+            "//lst[@name='region'][1]/float[@name='lry']/text()='0.028499998'",
+            "count(//arr[@name='highlights'])=3",
+            "//arr[@name='highlights'][1]/arr/lst/float[@name='ulx']/text()='0.2339'",
+            "//arr[@name='highlights'][1]/arr/lst/float[@name='uly']/text()='0.7149'",
+            "//arr[@name='highlights'][1]/arr/lst/float[@name='lrx']/text()='0.7805'",
+            "//arr[@name='highlights'][1]/arr/lst/int[@name='lry']/text()='1'");
   }
 
   @Test


### PR DESCRIPTION
Also fixes improper truncation in MiniOCR as a nice side-effect.
The unit tests had to be changed for MiniOCR, since they had encoded the bad truncation in the assertions.