### PR TITLE
Add support for hl.absoluteHighlights option (implements #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ These parameters can be changed at query time:
   `block` or `page` and defaults to `page`.
 - `hl.ocr.pageId`: Only show passages from the page with this identifier. Useful if you want to implement a
   "Search on this page" feature (e.g. for the [IIIF Content Search API](https://iiif.io/api/search/1.0/)).
+- `hl.ocr.absoluteHighlights`: Return the coordinates of highlighted regions as absolute coordinates (i.e. relative to
+  the page, not the snippet region)
 
 
 ## The MiniOCR format

--- a/src/main/java/org/mdz/search/solrocr/formats/OcrFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/OcrFormat.java
@@ -30,5 +30,6 @@ public interface OcrFormat {
    * @param prehHighlightTag the tag to put in the snippet text before a highlighted region, e.g. &lt;em&gt;
    * @param postHighlightTag the tag to put in the snippet text after a highlighted region, e.g. &lt;/em&gt;
    */
-  OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag, String postHighlightTag);
+  OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag, String postHighlightTag,
+                                          boolean absoluteHighlights);
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/alto/AltoFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/alto/AltoFormat.java
@@ -33,7 +33,8 @@ public class AltoFormat implements OcrFormat {
 
   @Override
   public OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag,
-      String postHighlightTag) {
-    return new AltoPassageFormatter(breakTag, blockTagMapping.get(limitBlock), prehHighlightTag, postHighlightTag);
+                                                 String postHighlightTag, boolean absoluteHighlights) {
+    return new AltoPassageFormatter(breakTag, blockTagMapping.get(limitBlock), prehHighlightTag, postHighlightTag,
+                                    absoluteHighlights);
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
@@ -111,8 +111,6 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
         currentHl = null;
       }
     }
-    final int snipX = ulx;
-    final int snipY = uly;
     OcrBox snippetRegion = new OcrBox(null, ulx, uly, lrx, lry);
     String text = StringEscapeUtils.unescapeXml(
         extractText(ocrFragment).replaceAll("@@STARTHLTAG@@", startHlTag)

--- a/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.apache.commons.text.StringEscapeUtils;
 import org.mdz.search.solrocr.formats.OcrPassageFormatter;
 import org.mdz.search.solrocr.formats.OcrSnippet;
@@ -23,8 +22,9 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
   private final TagBreakIterator pageIter = new TagBreakIterator("Page");
   private final TagBreakIterator limitIter;
 
-  protected AltoPassageFormatter(String contextTag, String limitTag, String startHlTag, String endHlTag) {
-    super(startHlTag, endHlTag);
+  protected AltoPassageFormatter(String contextTag, String limitTag, String startHlTag, String endHlTag,
+                                 boolean absoluteHighlights) {
+    super(startHlTag, endHlTag, absoluteHighlights);
     this.limitIter = new TagBreakIterator(limitTag);
   }
 
@@ -118,12 +118,7 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
         extractText(ocrFragment).replaceAll("@@STARTHLTAG@@", startHlTag)
                                 .replaceAll("@@ENDHLTAG@@", endHlTag)).trim();
     OcrSnippet snip = new OcrSnippet(text,  pageId, snippetRegion);
-    hlBoxes.stream()
-        .map(bs -> bs.stream()
-            .map(b -> new OcrBox(b.text, b.ulx - snipX, b.uly - snipY,
-                                 b.lrx - snipX, b.lry - snipY))
-            .collect(Collectors.toList()))
-        .forEach(bs -> snip.addHighlightRegion(this.mergeBoxes(bs)));
+    this.addHighlightsToSnippet(hlBoxes, snip);
     return snip;
   }
 

--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrFormat.java
@@ -32,7 +32,8 @@ public class HocrFormat implements OcrFormat {
 
   @Override
   public OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag,
-                                                 String postHighlightTag) {
-    return new HocrPassageFormatter(breakClass, blockClassMapping.get(limitBlock), prehHighlightTag, postHighlightTag);
+                                                 String postHighlightTag, boolean absoluteHighlights) {
+    return new HocrPassageFormatter(breakClass, blockClassMapping.get(limitBlock), prehHighlightTag, postHighlightTag,
+                                    absoluteHighlights);
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.mdz.search.solrocr.formats.OcrPassageFormatter;
 import org.mdz.search.solrocr.formats.OcrSnippet;
 import org.mdz.search.solrocr.util.IterableCharSequence;
@@ -23,8 +22,9 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
   private final String startHlTag;
   private final String endHlTag;
 
-  public HocrPassageFormatter(String contextClass, String limitClass, String startHlTag, String endHlTag) {
-    super(startHlTag, endHlTag);
+  public HocrPassageFormatter(String contextClass, String limitClass, String startHlTag, String endHlTag,
+                              boolean absoluteHighlights) {
+    super(startHlTag, endHlTag, absoluteHighlights);
     this.pageIter = new HocrClassBreakIterator("ocr_page");
     this.limitIter = new HocrClassBreakIterator(limitClass);
     this.startHlTag = startHlTag;
@@ -90,12 +90,7 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
     int snipY = uly;
     OcrBox snippetRegion = new OcrBox(null, ulx, uly, lrx, lry);
     OcrSnippet snip = new OcrSnippet(getTextFromXml(ocrFragment), pageId, snippetRegion);
-    hlBoxes.stream()
-        .map(cs -> cs.stream()
-            .map(b -> new OcrBox(b.text, b.ulx - snipX, b.uly - snipY,
-                                 b.lrx - snipX, b.lry - snipY))
-            .collect(Collectors.toList()))
-        .forEach(bs -> snip.addHighlightRegion(this.mergeBoxes(bs)));
+    this.addHighlightsToSnippet(hlBoxes, snip);
     return snip;
   }
 

--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -86,8 +86,6 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
         currentHl = null;
       }
     }
-    int snipX = ulx;
-    int snipY = uly;
     OcrBox snippetRegion = new OcrBox(null, ulx, uly, lrx, lry);
     OcrSnippet snip = new OcrSnippet(getTextFromXml(ocrFragment), pageId, snippetRegion);
     this.addHighlightsToSnippet(hlBoxes, snip);

--- a/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrFormat.java
@@ -32,7 +32,9 @@ public class MiniOcrFormat implements OcrFormat {
   }
 
   @Override
-  public OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag, String postHighlightTag) {
-    return new MiniOcrPassageFormatter(breakTag, blockTagMapping.get(limitBlock), prehHighlightTag, postHighlightTag);
+  public OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag, String postHighlightTag,
+                                                 boolean absoluteHighlights) {
+    return new MiniOcrPassageFormatter(breakTag, blockTagMapping.get(limitBlock), prehHighlightTag, postHighlightTag,
+                                       absoluteHighlights);
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrPassageFormatter.java
@@ -21,8 +21,9 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
   private final TagBreakIterator pageIter = new TagBreakIterator("p");
   private final TagBreakIterator limitIter;
 
-  public MiniOcrPassageFormatter(String contextTag, String limitTag, String startHlTag, String endHlTag) {
-    super(startHlTag, endHlTag);
+  public MiniOcrPassageFormatter(String contextTag, String limitTag, String startHlTag, String endHlTag,
+                                 boolean absoluteHighlights) {
+    super(startHlTag, endHlTag, absoluteHighlights);
     this.limitIter = new TagBreakIterator(limitTag);
   }
 
@@ -79,8 +80,8 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
       }
     }
     OcrBox snippetRegion;
-    final float snipX = ulx;
-    final float snipY = uly;
+    final float xOffset = this.absoluteHighlights ? 0 : ulx;
+    final float yOffset = this.absoluteHighlights ? 0 : uly;
     final float snipWidth = lrx - ulx;
     final float snipHeight = lry - uly;
     if (lrx < 1) {
@@ -89,10 +90,10 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
       hlBoxes = hlBoxes.stream()
         .map(cs -> cs.stream()
             .map(b -> new OcrBox(b.text,
-                                 truncateFloat((b.ulx - snipX) / snipWidth),
-                                 truncateFloat((float) ((b.uly - snipY) / snipHeight)),
-                                 truncateFloat((b.lrx - snipX) / snipWidth),
-                                 truncateFloat((b.lry - snipY) / snipHeight)))
+                                 truncateFloat((b.ulx - xOffset) / snipWidth),
+                                 truncateFloat((float) ((b.uly - yOffset) / snipHeight)),
+                                 truncateFloat((b.lrx - xOffset) / snipWidth),
+                                 truncateFloat((b.lry - yOffset) / snipHeight)))
            .collect(Collectors.toList()))
         .map(this::mergeBoxes)
         .collect(Collectors.toList());
@@ -101,8 +102,8 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
       hlBoxes = hlBoxes.stream()
         .map(cs -> cs.stream()
             .map(b -> new OcrBox(b.text,
-                                 (b.ulx - snipX), (b.uly - snipY),
-                                 (b.lrx - snipX), (b.lry - snipY)))
+                                 (b.ulx - xOffset), (b.uly - yOffset),
+                                 (b.lrx - xOffset), (b.lry - yOffset)))
             .collect(Collectors.toList()))
         .map(this::mergeBoxes)
         .collect(Collectors.toList());

--- a/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrPassageFormatter.java
@@ -91,7 +91,7 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
         .map(cs -> cs.stream()
             .map(b -> new OcrBox(b.text,
                                  truncateFloat((b.ulx - xOffset) / snipWidth),
-                                 truncateFloat((float) ((b.uly - yOffset) / snipHeight)),
+                                 truncateFloat((b.uly - yOffset) / snipHeight),
                                  truncateFloat((b.lrx - xOffset) / snipWidth),
                                  truncateFloat((b.lry - yOffset) / snipHeight)))
            .collect(Collectors.toList()))

--- a/src/main/java/org/mdz/search/solrocr/solr/OcrHighlightParams.java
+++ b/src/main/java/org/mdz/search/solrocr/solr/OcrHighlightParams.java
@@ -8,4 +8,5 @@ public interface OcrHighlightParams extends HighlightParams {
   String LIMIT_BLOCK = "hl.ocr.limitBlock";
   String PAGE_ID = "hl.ocr.pageId";
   String SCORE_BOOST_EARLY = "hl.score.boostEarly";
+  String ABSOLUTE_HIGHLIGHTS = "hl.ocr.absoluteHighlights";
 }

--- a/src/main/java/org/mdz/search/solrocr/solr/SolrOcrHighlighter.java
+++ b/src/main/java/org/mdz/search/solrocr/solr/SolrOcrHighlighter.java
@@ -83,7 +83,8 @@ public class SolrOcrHighlighter extends UnifiedSolrHighlighter {
       OcrPassageFormatter ocrFormatter = ocrFormat.getPassageFormatter(
           OcrBlock.valueOf(params.get(OcrHighlightParams.LIMIT_BLOCK, "block").toUpperCase()),
           params.get(HighlightParams.TAG_PRE, "<em>"),
-          params.get(HighlightParams.TAG_POST, "</em>"));
+          params.get(HighlightParams.TAG_POST, "</em>"),
+          params.getBool(OcrHighlightParams.ABSOLUTE_HIGHLIGHTS, false));
       ocrSnippets = ocrHighlighter.highlightOcrFields(
           ocrFieldNames, query, docIDs, maxPassagesOcr, ocrBreakIterator, ocrFormatter,
           params.get(OcrHighlightParams.PAGE_ID, null));

--- a/src/test/java/org/mdz/search/solrocr/solr/HocrEscapedTest.java
+++ b/src/test/java/org/mdz/search/solrocr/solr/HocrEscapedTest.java
@@ -116,4 +116,12 @@ public class HocrEscapedTest extends SolrTestCaseJ4 {
         "//lst[@name='ocrHighlighting']//arr[@name='highlights']//str[@name='text']/text()='pirates hove their vessel that the other pirates'");
   }
 
+  @Test
+  public void testAbsoluteHighlightRegions() throws Exception {
+    SolrQueryRequest req = xmlQ("q", "Verführung", "hl.ocr.absoluteHighlights", "true");
+    assertQ(req,
+            "//lst[@name='region'][1]/int[@name='ulx']/text()=146",
+            "//arr[@name='highlights']/arr/lst[1]/int[@name='ulx']/text()=229");
+  }
+
 }


### PR DESCRIPTION
This PR adds a new query-time option `hl.absoluteHighlights` that will make the plugin return **absolute** coordinates for highlighted regions, i.e. coordinates that are relative to the containing page, not the containing snippet.