### PR TITLE
Refactor snippet parsing across formats to increase code reuse

### DIFF
--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -49,10 +49,10 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
     Matcher m = wordPat.matcher(ocrFragment);
     boolean inHighlight = false;
     while (m.find()) {
-      int x0 = Integer.valueOf(m.group("ulx"));
-      int y0 = Integer.valueOf(m.group("uly"));
-      int x1 = Integer.valueOf(m.group("lrx"));
-      int y1 = Integer.valueOf(m.group("lry"));
+      int x0 = Integer.parseInt(m.group("ulx"));
+      int y0 = Integer.parseInt(m.group("uly"));
+      int x1 = Integer.parseInt(m.group("lrx"));
+      int y1 = Integer.parseInt(m.group("lry"));
       String text = m.group("text");
       if (text.contains(startHlTag)) {
         inHighlight = true;

--- a/src/main/java/org/mdz/search/solrocr/util/OcrBox.java
+++ b/src/main/java/org/mdz/search/solrocr/util/OcrBox.java
@@ -6,14 +6,16 @@ public class OcrBox {
   public float uly;
   public float lrx;
   public float lry;
+  public boolean isHighlight;
 
 
-  public OcrBox(String text, float ulx, float uly, float lrx, float lry) {
+  public OcrBox(String text, float ulx, float uly, float lrx, float lry, boolean isHighlight) {
     this.text = text;
     this.ulx = ulx;
     this.uly = uly;
     this.lrx = lrx;
     this.lry = lry;
+    this.isHighlight = isHighlight;
   }
 
   @Override


### PR DESCRIPTION
Previously the three supported formats had a lot of very similar code to parse their respective formats and generate snippets and highlight spans.