### PR TITLE
hocr: Allow multiple implementations of generic block types (fixes #20)

### DIFF
--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrClassBreakIterator.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrClassBreakIterator.java
@@ -1,19 +1,25 @@
 package org.mdz.search.solrocr.formats.hocr;
 
+import com.google.common.collect.ImmutableSet;
 import java.text.BreakIterator;
 import java.text.CharacterIterator;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class HocrClassBreakIterator extends BreakIterator {
   private final static Pattern CLASS_PAT = Pattern.compile("class=['\"](?<class>ocr.+?)['\"]");
-  private final String breakClass;
+  private final Set<String> breakClasses;
 
   private CharacterIterator text;
   private int current;
 
   public HocrClassBreakIterator(String breakClass) {
-    this.breakClass = breakClass;
+    this.breakClasses = ImmutableSet.of(breakClass);
+  }
+
+  public HocrClassBreakIterator(Set<String> breakClasses) {
+    this.breakClasses = breakClasses;
   }
 
   @Override
@@ -43,7 +49,7 @@ public class HocrClassBreakIterator extends BreakIterator {
     String fullTag = "";
     String hocrClass = "";
     StringBuilder sb = null;
-    while(!hocrClass.equals(breakClass)) {
+    while(!breakClasses.contains(hocrClass)) {
       char c = this.text.current();
       if (c == '<') {
         sb = new StringBuilder();
@@ -80,7 +86,7 @@ public class HocrClassBreakIterator extends BreakIterator {
     String fullTag = "";
     String hocrClass = "";
     StringBuilder sb = null;
-    while(!hocrClass.equals(breakClass)) {
+    while(!breakClasses.contains(hocrClass)) {
       char c = this.text.current();
       if (c == '>') {
         sb = new StringBuilder();

--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrFormat.java
@@ -1,39 +1,41 @@
 package org.mdz.search.solrocr.formats.hocr;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.text.BreakIterator;
 import java.util.Map;
+import java.util.Set;
 import org.mdz.search.solrocr.formats.OcrBlock;
 import org.mdz.search.solrocr.formats.OcrFormat;
 import org.mdz.search.solrocr.formats.OcrPassageFormatter;
 import org.mdz.search.solrocr.util.ContextBreakIterator;
 
 public class HocrFormat implements OcrFormat {
-  private static final Map<OcrBlock, String> blockClassMapping = ImmutableMap.of(
-      OcrBlock.PAGE, "ocr_page",
-      OcrBlock.BLOCK, "ocr_carea",
-      OcrBlock.PARAGRAPH, "ocr_par",
-      OcrBlock.LINE, "ocr_line",
-      OcrBlock.WORD, "ocrx_word");
+  private static final Map<OcrBlock, Set<String>> blockClassMapping = ImmutableMap.of(
+      OcrBlock.PAGE, ImmutableSet.of("ocr_page"),
+      OcrBlock.BLOCK, ImmutableSet.of("ocr_carea", "ocrx_block"),
+      OcrBlock.PARAGRAPH, ImmutableSet.of("ocr_par"),
+      OcrBlock.LINE, ImmutableSet.of("ocr_line", "ocrx_line"),
+      OcrBlock.WORD, ImmutableSet.of("ocrx_word"));
 
-  private String breakClass = blockClassMapping.get(OcrBlock.LINE);
+  private Set<String> breakClasses = blockClassMapping.get(OcrBlock.LINE);
   private int contextSize = 2;
 
   @Override
   public void setBreakParameters(OcrBlock breakBlock, int contextSize) {
     this.contextSize = contextSize;
-    this.breakClass = blockClassMapping.get(breakBlock);
+    this.breakClasses = blockClassMapping.get(breakBlock);
   }
 
   @Override
   public BreakIterator getBreakIterator() {
-    return new ContextBreakIterator(new HocrClassBreakIterator(breakClass), contextSize);
+    return new ContextBreakIterator(new HocrClassBreakIterator(breakClasses), contextSize);
   }
 
   @Override
   public OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag,
                                                  String postHighlightTag, boolean absoluteHighlights) {
-    return new HocrPassageFormatter(breakClass, blockClassMapping.get(limitBlock), prehHighlightTag, postHighlightTag,
-                                    absoluteHighlights);
+    return new HocrPassageFormatter(
+        blockClassMapping.get(limitBlock), prehHighlightTag, postHighlightTag, absoluteHighlights);
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -3,6 +3,7 @@ package org.mdz.search.solrocr.formats.hocr;
 import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.mdz.search.solrocr.formats.OcrPassageFormatter;
@@ -21,11 +22,11 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
   private final String startHlTag;
   private final String endHlTag;
 
-  public HocrPassageFormatter(String contextClass, String limitClass, String startHlTag, String endHlTag,
+  public HocrPassageFormatter(Set<String> limitClasses, String startHlTag, String endHlTag,
                               boolean absoluteHighlights) {
     super(startHlTag, endHlTag, absoluteHighlights);
     this.pageIter = new HocrClassBreakIterator("ocr_page");
-    this.limitIter = new HocrClassBreakIterator(limitClass);
+    this.limitIter = new HocrClassBreakIterator(limitClasses);
     this.startHlTag = startHlTag;
     this.endHlTag = endHlTag;
   }


### PR DESCRIPTION
Previously `BLOCK` would only map to `ocr_carea` and `LINE` only to `ocr_line`. With this PR, `ocrx_block` and `ocrx_line` are now also acceptable values for these generic block types.