### PR TITLE
Refactor block-limitation logic to fix bugs and inconsistencies

### DIFF
--- a/src/main/java/org/mdz/search/solrocr/formats/OcrBlock.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/OcrBlock.java
@@ -1,5 +1,11 @@
 package org.mdz.search.solrocr.formats;
 
 public enum OcrBlock {
-  WORD, LINE, BLOCK, PARAGRAPH, SECTION, PAGE
+  /* Order matters: From top of the page layout hierarchy to bottom */
+  PAGE,
+  BLOCK,
+  SECTION,
+  PARAGRAPH,
+  LINE,
+  WORD;
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/OcrFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/OcrFormat.java
@@ -6,30 +6,19 @@ import java.text.BreakIterator;
  * Provides access to format-specific {@link BreakIterator} and {@link OcrPassageFormatter} instances.
  */
 public interface OcrFormat {
-
-  /** Set the block type to break the input on and the number of blocks that should form a passage
-   *
-   * This is decoupled from {@link #getBreakIterator()} since the {@link OcrPassageFormatter} instance is likely
-   * to reuse these parameters.
-   *
-   * FIXME: This is not really elegant, find a way to not depend on this
+  /** Get a BreakIterator that splits the content according to the break parameters
    *
    * @param breakBlock the type of {@link OcrBlock} that the input document is split on to build passages
+   * @param limitBlock the type of {@link OcrBlock} that a passage may not cross
    * @param contextSize the number of break blocks in a context that forms a highlighting passage
-   */
-  void setBreakParameters(OcrBlock breakBlock, int contextSize);
-
-  /** Get a BreakIterator that splits the content according to the break parameters */
-  BreakIterator getBreakIterator();
+   * */
+  BreakIterator getBreakIterator(OcrBlock breakBlock, OcrBlock limitBlock, int contextSize);
 
   /**
    * Get a PassageFormatter that builds OCR snippets from passages
    *
-   * @param limitBlock the type of {@link OcrBlock} that a passage should not go beyond. This is most likely going to
-   *                   be "PAGE" , "PARAGRAPH" or "BLOCK", since these often delimit unrelated units of text.
    * @param prehHighlightTag the tag to put in the snippet text before a highlighted region, e.g. &lt;em&gt;
    * @param postHighlightTag the tag to put in the snippet text after a highlighted region, e.g. &lt;/em&gt;
    */
-  OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag, String postHighlightTag,
-                                          boolean absoluteHighlights);
+  OcrPassageFormatter getPassageFormatter(String prehHighlightTag, String postHighlightTag, boolean absoluteHighlights);
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/OcrFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/OcrFormat.java
@@ -19,6 +19,8 @@ public interface OcrFormat {
    *
    * @param prehHighlightTag the tag to put in the snippet text before a highlighted region, e.g. &lt;em&gt;
    * @param postHighlightTag the tag to put in the snippet text after a highlighted region, e.g. &lt;/em&gt;
+   * @param absoluteHighlights whether the coordinates for highlights should be absolute, i.e. relative to the page
+   *                           and not the containing snippet
    */
   OcrPassageFormatter getPassageFormatter(String prehHighlightTag, String postHighlightTag, boolean absoluteHighlights);
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/alto/AltoFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/alto/AltoFormat.java
@@ -17,24 +17,16 @@ public class AltoFormat implements OcrFormat {
       OcrBlock.LINE, "TextLine",
       OcrBlock.WORD, "String");
 
-  private String breakTag = blockTagMapping.get(OcrBlock.LINE);
-  private int contextSize = 2;
-
   @Override
-  public void setBreakParameters(OcrBlock breakBlock, int contextSize) {
-    this.breakTag = blockTagMapping.get(breakBlock);
-    this.contextSize = contextSize;
+  public BreakIterator getBreakIterator(OcrBlock breakBlock, OcrBlock limitBlock, int contextSize) {
+    String breakTag = blockTagMapping.get(breakBlock);
+    String limitTag = blockTagMapping.get(limitBlock);
+    return new ContextBreakIterator(new TagBreakIterator(breakTag), new TagBreakIterator(limitTag), contextSize);
   }
 
   @Override
-  public BreakIterator getBreakIterator() {
-    return new ContextBreakIterator(new TagBreakIterator(breakTag), contextSize);
-  }
-
-  @Override
-  public OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag,
-                                                 String postHighlightTag, boolean absoluteHighlights) {
-    return new AltoPassageFormatter(breakTag, blockTagMapping.get(limitBlock), prehHighlightTag, postHighlightTag,
-                                    absoluteHighlights);
+  public OcrPassageFormatter getPassageFormatter(String prehHighlightTag, String postHighlightTag,
+                                                 boolean absoluteHighlights) {
+    return new AltoPassageFormatter(prehHighlightTag, postHighlightTag, absoluteHighlights);
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
@@ -1,6 +1,5 @@
 package org.mdz.search.solrocr.formats.alto;
 
-import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -22,12 +21,9 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
   private final static Pattern attribPat = Pattern.compile("(?<key>[A-Z]+?)=\"(?<val>.+?)\"");
 
   private final TagBreakIterator pageIter = new TagBreakIterator("Page");
-  private final TagBreakIterator limitIter;
 
-  protected AltoPassageFormatter(String contextTag, String limitTag, String startHlTag, String endHlTag,
-                                 boolean absoluteHighlights) {
+  protected AltoPassageFormatter(String startHlTag, String endHlTag, boolean absoluteHighlights) {
     super(startHlTag, endHlTag, absoluteHighlights);
-    this.limitIter = new TagBreakIterator(limitTag);
   }
 
   private Map<String, String> parseAttribs(String attribStr) {
@@ -109,15 +105,5 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
       }
     }
     return wordBoxes;
-  }
-
-  @Override
-  protected BreakIterator getPageBreakIterator() {
-    return pageIter;
-  }
-
-  @Override
-  protected BreakIterator getLimitBreakIterator() {
-    return limitIter;
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrFormat.java
@@ -18,24 +18,17 @@ public class HocrFormat implements OcrFormat {
       OcrBlock.LINE, ImmutableSet.of("ocr_line", "ocrx_line"),
       OcrBlock.WORD, ImmutableSet.of("ocrx_word"));
 
-  private Set<String> breakClasses = blockClassMapping.get(OcrBlock.LINE);
-  private int contextSize = 2;
-
   @Override
-  public void setBreakParameters(OcrBlock breakBlock, int contextSize) {
-    this.contextSize = contextSize;
-    this.breakClasses = blockClassMapping.get(breakBlock);
+  public BreakIterator getBreakIterator(OcrBlock breakBlock, OcrBlock limitBlock, int contextSize) {
+    Set<String> breakClasses = blockClassMapping.get(breakBlock);
+    Set<String> limitClasses = blockClassMapping.get(limitBlock);
+    return new ContextBreakIterator(new HocrClassBreakIterator(breakClasses), new HocrClassBreakIterator(limitClasses),
+                                    contextSize);
   }
 
   @Override
-  public BreakIterator getBreakIterator() {
-    return new ContextBreakIterator(new HocrClassBreakIterator(breakClasses), contextSize);
-  }
-
-  @Override
-  public OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag,
-                                                 String postHighlightTag, boolean absoluteHighlights) {
-    return new HocrPassageFormatter(
-        blockClassMapping.get(limitBlock), prehHighlightTag, postHighlightTag, absoluteHighlights);
+  public OcrPassageFormatter getPassageFormatter(String prehHighlightTag, String postHighlightTag,
+                                                 boolean absoluteHighlights) {
+    return new HocrPassageFormatter(prehHighlightTag, postHighlightTag, absoluteHighlights);
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -1,9 +1,7 @@
 package org.mdz.search.solrocr.formats.hocr;
 
-import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.mdz.search.solrocr.formats.OcrPassageFormatter;
@@ -18,15 +16,12 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
       "<div.+?class=['\"]ocr_page['\"].+?id=['\"](?<pageId>.+?)['\"]");
 
   private final HocrClassBreakIterator pageIter;
-  private final HocrClassBreakIterator limitIter;
   private final String startHlTag;
   private final String endHlTag;
 
-  public HocrPassageFormatter(Set<String> limitClasses, String startHlTag, String endHlTag,
-                              boolean absoluteHighlights) {
+  public HocrPassageFormatter(String startHlTag, String endHlTag, boolean absoluteHighlights) {
     super(startHlTag, endHlTag, absoluteHighlights);
     this.pageIter = new HocrClassBreakIterator("ocr_page");
-    this.limitIter = new HocrClassBreakIterator(limitClasses);
     this.startHlTag = startHlTag;
     this.endHlTag = endHlTag;
   }
@@ -69,15 +64,5 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
       }
     }
     return wordBoxes;
-  }
-
-  @Override
-  protected BreakIterator getPageBreakIterator() {
-    return pageIter;
-  }
-
-  @Override
-  protected BreakIterator getLimitBreakIterator() {
-    return limitIter;
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrFormat.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrFormat.java
@@ -17,24 +17,16 @@ public class MiniOcrFormat implements OcrFormat {
       OcrBlock.LINE, "l",
       OcrBlock.WORD, "w");
 
-  private String breakTag = blockTagMapping.get(OcrBlock.LINE);
-  private int contextSize = 2;
-
   @Override
-  public void setBreakParameters(OcrBlock breakBlock, int contextSize) {
-    this.contextSize = contextSize;
-    this.breakTag = blockTagMapping.get(breakBlock);
+  public BreakIterator getBreakIterator(OcrBlock breakBlock, OcrBlock limitBlock, int contextSize) {
+    String breakTag = blockTagMapping.get(breakBlock);
+    String limitTag = blockTagMapping.get(limitBlock);
+    return new ContextBreakIterator(new TagBreakIterator(breakTag), new TagBreakIterator(limitTag), contextSize);
   }
 
   @Override
-  public BreakIterator getBreakIterator() {
-    return new ContextBreakIterator(new TagBreakIterator(breakTag), contextSize);
-  }
-
-  @Override
-  public OcrPassageFormatter getPassageFormatter(OcrBlock limitBlock, String prehHighlightTag, String postHighlightTag,
+  public OcrPassageFormatter getPassageFormatter(String prehHighlightTag, String postHighlightTag,
                                                  boolean absoluteHighlights) {
-    return new MiniOcrPassageFormatter(breakTag, blockTagMapping.get(limitBlock), prehHighlightTag, postHighlightTag,
-                                       absoluteHighlights);
+    return new MiniOcrPassageFormatter(prehHighlightTag, postHighlightTag, absoluteHighlights);
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/mini/MiniOcrPassageFormatter.java
@@ -1,6 +1,5 @@
 package org.mdz.search.solrocr.formats.mini;
 
-import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -19,12 +18,9 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
   private final static Pattern pagePat = Pattern.compile("<p xml:id=\"(?<pageId>.+?)\">");
 
   private final TagBreakIterator pageIter = new TagBreakIterator("p");
-  private final TagBreakIterator limitIter;
 
-  public MiniOcrPassageFormatter(String contextTag, String limitTag, String startHlTag, String endHlTag,
-                                 boolean absoluteHighlights) {
+  public MiniOcrPassageFormatter(String startHlTag, String endHlTag, boolean absoluteHighlights) {
     super(startHlTag, endHlTag, absoluteHighlights);
-    this.limitIter = new TagBreakIterator(limitTag);
   }
 
   @Override
@@ -100,15 +96,5 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
   @Override
   public Object format(Passage[] passages, String content) {
     throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected BreakIterator getPageBreakIterator() {
-    return pageIter;
-  }
-
-  @Override
-  protected BreakIterator getLimitBreakIterator() {
-    return limitIter;
   }
 }

--- a/src/main/java/org/mdz/search/solrocr/lucene/OcrHighlighter.java
+++ b/src/main/java/org/mdz/search/solrocr/lucene/OcrHighlighter.java
@@ -207,6 +207,9 @@ public class OcrHighlighter extends UnifiedHighlighter {
     for (int d=0; d < docIds.length; d++) {
       OcrHighlightResult hl = new OcrHighlightResult();
       for (int f = 0; f < fields.length; f++) {
+        if (snippetCountsByField[f][d] <= 0) {
+          continue;
+        }
         hl.addSnippetsForField(fields[f], highlightDocsInByField[f][d]);
         hl.addSnippetCountForField(fields[f], snippetCountsByField[f][d]);
       }

--- a/src/main/java/org/mdz/search/solrocr/solr/SolrOcrHighlighter.java
+++ b/src/main/java/org/mdz/search/solrocr/solr/SolrOcrHighlighter.java
@@ -76,12 +76,11 @@ public class SolrOcrHighlighter extends UnifiedSolrHighlighter {
             .filter(f -> ocrHighlighter.getFlags(f).contains(HighlightFlag.WEIGHT_MATCHES))
             .forEach(field -> highlightFieldWarnings.put(field, NO_WEIGHT_MATCHES_SUPPORT_MSG));
       }
-      ocrFormat.setBreakParameters(
+      BreakIterator ocrBreakIterator = ocrFormat.getBreakIterator(
           OcrBlock.valueOf(params.get(OcrHighlightParams.CONTEXT_BLOCK, "line").toUpperCase()),
-          params.getInt(OcrHighlightParams.CONTEXT_SIZE, 2));
-      BreakIterator ocrBreakIterator = ocrFormat.getBreakIterator();
-      OcrPassageFormatter ocrFormatter = ocrFormat.getPassageFormatter(
           OcrBlock.valueOf(params.get(OcrHighlightParams.LIMIT_BLOCK, "block").toUpperCase()),
+          params.getInt(OcrHighlightParams.CONTEXT_SIZE, 2));
+      OcrPassageFormatter ocrFormatter = ocrFormat.getPassageFormatter(
           params.get(HighlightParams.TAG_PRE, "<em>"),
           params.get(HighlightParams.TAG_POST, "</em>"),
           params.getBool(OcrHighlightParams.ABSOLUTE_HIGHLIGHTS, false));

--- a/src/test/java/org/mdz/search/solrocr/solr/HocrEscapedTest.java
+++ b/src/test/java/org/mdz/search/solrocr/solr/HocrEscapedTest.java
@@ -124,4 +124,11 @@ public class HocrEscapedTest extends SolrTestCaseJ4 {
             "//arr[@name='highlights']/arr/lst[1]/int[@name='ulx']/text()=229");
   }
 
+  @Test
+  public void testLimitBlockHonored() throws Exception {
+    SolrQueryRequest req = xmlQ("q", "Japan", "hl.ocr.absoluteHighlights", "true");
+    assertQ(req,
+            "(//arr[@name='snippets']/lst/str[@name='text']/text())[3]='object too hastily, in addition to the facts already stated it ought to be remarked, that Kunnpfer describes the coast of<em>Japan</em>'");
+  }
+
 }

--- a/src/test/java/org/mdz/search/solrocr/solr/OcrFieldsTest.java
+++ b/src/test/java/org/mdz/search/solrocr/solr/OcrFieldsTest.java
@@ -133,7 +133,7 @@ public class OcrFieldsTest extends SolrTestCaseJ4 {
   public void testWildcardQueryWithWildcardOnly() throws Exception {
     SolrQueryRequest req = xmlQ("q", "*");
     assertQ(req,
-        "count(//lst[@name='ocrHighlighting']/lst[@name='31337']/lst[@name='external_ocr_text']/arr/lst)=10");
+        "count(//lst[@name='ocrHighlighting']/lst[@name='31337']/lst[@name='external_ocr_text']/arr/lst)=0");
   }
 
   @Test

--- a/src/test/java/org/mdz/search/solrocr/solr/Utf8OcrFieldsTest.java
+++ b/src/test/java/org/mdz/search/solrocr/solr/Utf8OcrFieldsTest.java
@@ -127,7 +127,7 @@ public class Utf8OcrFieldsTest extends SolrTestCaseJ4 {
   public void testWildcardQueryWithWildcardOnly() throws Exception {
     SolrQueryRequest req = xmlQ("q", "*");
     assertQ(req,
-        "count(//lst[@name='ocrHighlighting']/lst[@name='31337']/lst[@name='ocr_text']/arr/lst)=10");
+        "count(//lst[@name='ocrHighlighting']/lst[@name='31337']/lst[@name='ocr_text']/arr/lst)=0");
   }
 
   @Test

--- a/src/test/java/org/mdz/search/solrocr/util/ContextBreakIteratorTest.java
+++ b/src/test/java/org/mdz/search/solrocr/util/ContextBreakIteratorTest.java
@@ -4,14 +4,17 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.BreakIterator;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.charfilter.HTMLStripCharFilter;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mdz.search.solrocr.formats.hocr.HocrClassBreakIterator;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -32,7 +35,8 @@ class ContextBreakIteratorTest {
   @MethodSource("charSeq")
   void testContext(IterableCharSequence seq) throws IOException {
     BreakIterator baseIter = new TagBreakIterator("w");
-    ContextBreakIterator it = new ContextBreakIterator(baseIter, 5);
+    BreakIterator limitIter = new TagBreakIterator("b");
+    ContextBreakIterator it = new ContextBreakIterator(baseIter, limitIter, 5);
     it.setText(seq);
     int center;
     if (seq instanceof FileBytesCharIterator) {
@@ -47,5 +51,22 @@ class ContextBreakIteratorTest {
     assertThat(StringUtils.countMatches(snippet, "<w")).isEqualTo(2 * 5 + 1);
     assertThat(StringUtils.countMatches(snippet, "</w>")).isEqualTo(2 * 5 + 1);
     assertThat(stripTags(snippet)).isEqualTo("Sgr. 6 Pf, für die viergeſpaltene Petitzeile oder deren Raum berechnet,");
+  }
+
+  @Test
+  void testContextHonorsLimits() throws IOException {
+    IterableCharSequence seq = new FileBytesCharIterator(Paths.get("src/test/resources/data/hocr_escaped.html"),
+                                                         StandardCharsets.US_ASCII);
+    BreakIterator baseIter = new HocrClassBreakIterator("ocr_line");
+    BreakIterator limitIter = new HocrClassBreakIterator("ocrx_block");
+    ContextBreakIterator it = new ContextBreakIterator(baseIter, limitIter, 5);
+    it.setText(seq);
+    int start = it.preceding(5407013);
+    int end = it.following(5407025);
+    assertThat(start).isLessThan(end);
+    String snippet = seq.subSequence(start, end).toString();
+    assertThat(StringUtils.countMatches(snippet, "ocr_line")).isEqualTo(1 + 1 + 5);
+    assertThat(snippet).doesNotContain("ocr_page");
+    assertThat(snippet).containsOnlyOnce("ocrx_block");
   }
 }


### PR DESCRIPTION
Changes:
- No longer truncate fragments, the passages are now created in a way that prevents the crossing of the user-defined limits. The previous approach led to hard-to-track bugs, where we would either swallow some highlights or merge highlights from multiple pages
- No longer return any snippets for `*` queries
- Simplify internal APIs

