### PR TITLE
Fix ALTO regexp to correctly match TextBlock/Page/etc entities

### DIFF
--- a/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/org/mdz/search/solrocr/formats/alto/AltoPassageFormatter.java
@@ -68,7 +68,7 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
       String content = parseAttribs(m.group("attribs")).get("CONTENT");
       sb.replace(m.start(), m.end(), content);
     }
-    return StringEscapeUtils.unescapeXml(sb.toString().replaceAll("</?[A-Z]?.*?>?", ""))
+    return StringEscapeUtils.unescapeXml(sb.toString().replaceAll("</?[A-Z]?.*?>", ""))
         .trim()
         .replaceAll(START_HL, startHlTag)
         .replaceAll(END_HL, endHlTag);

--- a/src/test/java/org/mdz/search/solrocr/solr/AltoEscapedTest.java
+++ b/src/test/java/org/mdz/search/solrocr/solr/AltoEscapedTest.java
@@ -66,4 +66,10 @@ public class AltoEscapedTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = xmlQ("q", "ligesom");
     assertQ(req, "count(//arr[@name='highlights']/arr)=2");
   }
+
+  @Test
+  public void testEntityRemoval() throws Exception {
+    SolrQueryRequest req = xmlQ("q", "committee");
+    assertQ(req, "//str[@name='text'][1]/text()='Permanent <em>Committee</em>'");
+  }
 }

--- a/src/test/resources/data/alto_escaped.xml
+++ b/src/test/resources/data/alto_escaped.xml
@@ -1282,5 +1282,15 @@ ydpi:300
 </TextBlock>
 </PrintSpace>
 </Page>
+<Page WIDTH="2092" HEIGHT="3850" PHYSICAL_IMG_NR="6" ID="page_6">
+<TextBlock ID="block_12" HPOS="83" VPOS="3284" WIDTH="1703" HEIGHT="100">
+<TextLine ID="line_43" HPOS="182" VPOS="3284" WIDTH="1604" HEIGHT="49">
+<String ID="string_493" HPOS="706" VPOS="3285" WIDTH="222" HEIGHT="37" WC="0.72" CONTENT="Permanent"/>
+<SP WIDTH="31" VPOS="3285" HPOS="928"/>
+<String ID="string_494" HPOS="959" VPOS="3285" WIDTH="216" HEIGHT="36" WC="0.95" CONTENT="Committee"/>
+<SP WIDTH="30" VPOS="3285" HPOS="1175"/>
+</TextLine>
+</TextBlock>
+</Page>
 </Layout>
 </alto>


### PR DESCRIPTION
The ">?" at the end of the regexp in the getTextFromXml return block was causing inline entities to not be correctly matched/removed. Removing the quantifier fixes this.

Results with error:
![regexerr](https://user-images.githubusercontent.com/29146501/56903187-b4595180-6a93-11e9-82af-6dad5981f7a4.png)

With patch:
![regexfix](https://user-images.githubusercontent.com/29146501/56903185-b4595180-6a93-11e9-8f25-b736811c7157.png)

XML used for testing (snipped from larger file for testing. The whole file can be provided if required):
```xml
<Page WIDTH="2092" HEIGHT="3850" PHYSICAL_IMG_NR="6" ID="page_6"> <TextBlock ID="block_12" HPOS="83" VPOS="3284" WIDTH="1703" HEIGHT="100"><TextLine ID="line_43" HPOS="182" VPOS="3284" WIDTH="1604" HEIGHT="49"><String ID="string_493" HPOS="706" VPOS="3285" WIDTH="222" HEIGHT="37" WC="0.72" CONTENT="Permanent"/><SP WIDTH="31" VPOS="3285" HPOS="928"/><String ID="string_494" HPOS="959" VPOS="3285" WIDTH="216" HEIGHT="36" WC="0.95" CONTENT="Committee"/><SP WIDTH="30" VPOS="3285" HPOS="1175"/></TextLine></TextBlock></Page>
```
