### PR TITLE
Better error reporting

### DIFF
--- a/src/main/java/org/mdz/search/solrocr/lucene/fieldloader/PathFieldLoader.java
+++ b/src/main/java/org/mdz/search/solrocr/lucene/fieldloader/PathFieldLoader.java
@@ -139,10 +139,7 @@ public class PathFieldLoader implements ExternalFieldLoader, PluginInfoInitializ
         return new FileBytesCharIterator(fPath, this.charset);
       }
     } catch (NoSuchFileException e) {
-      // NOTE: We don't log these cases, since this is currently also called for documents that weren't indexed with
-      //       any value in this field
-      // FIXME: We should really warn/abort if no file is found
-      return null;
+      throw new IOException(String.format("Could not find file at resolved path '%s'.", fPath), e);
     }
   }
 

--- a/src/main/java/org/mdz/search/solrocr/util/FileBytesCharIterator.java
+++ b/src/main/java/org/mdz/search/solrocr/util/FileBytesCharIterator.java
@@ -218,6 +218,11 @@ public class FileBytesCharIterator implements IterableCharSequence {
   }
 
   @Override
+  public String getIdentifier() {
+    return this.filePath.toAbsolutePath().toString();
+  }
+
+  @Override
   public OffsetType getOffsetType() {
     return OffsetType.BYTES;
   }

--- a/src/main/java/org/mdz/search/solrocr/util/IterableCharSequence.java
+++ b/src/main/java/org/mdz/search/solrocr/util/IterableCharSequence.java
@@ -12,9 +12,13 @@ import java.util.stream.IntStream;
  * this plugin wraps the content is accessed via both interfaces.
  */
 public interface IterableCharSequence extends CharSequence, CharacterIterator {
+
+
   enum OffsetType {
     BYTES, CHARS
   }
+
+  String getIdentifier();
 
   OffsetType getOffsetType();
 
@@ -117,6 +121,11 @@ public interface IterableCharSequence extends CharSequence, CharacterIterator {
     @Override
     public String toString() {
       return this.s;
+    }
+
+    @Override
+    public String getIdentifier() {
+      return this.s.substring(0, 29) + "...";
     }
 
     @Override

--- a/src/main/java/org/mdz/search/solrocr/util/MultiFileBytesCharIterator.java
+++ b/src/main/java/org/mdz/search/solrocr/util/MultiFileBytesCharIterator.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 public class MultiFileBytesCharIterator implements IterableCharSequence {
   private final List<Path> paths;
@@ -60,6 +61,11 @@ public class MultiFileBytesCharIterator implements IterableCharSequence {
 
   private int adjustOffset(int offset) {
     return offset - offsetMap.floorKey(offset);
+  }
+
+  @Override
+  public String getIdentifier() {
+    return String.format("{%s}", this.paths.stream().map(Path::toString).collect(Collectors.joining(", ")));
   }
 
   @Override


### PR DESCRIPTION
- `IndexOutOfBoundsExceptions` are now logged as errors (i.e. they won't cause the request to fail) and contain more context to aid in debugging
- `FileNotFoundExceptions` now cause the request to fail (but include enough context to debug the issue).