### PR TITLE
Fix calculation of passages with matches spanning multiple lines

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrFieldHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrFieldHighlighter.java
@@ -134,7 +134,9 @@ public class OcrFieldHighlighter extends FieldHighlighter {
         }
         // advance breakIterator
         passage.setStartOffset(Math.max(this.breakIterator.preceding(start + 1), 0));
-        passage.setEndOffset(Math.min(this.breakIterator.following(start), contentLength));
+        passage.setEndOffset(Math.min(this.breakIterator.following(end), contentLength));
+      } else {
+        passage.setEndOffset(Math.min(this.breakIterator.following(end), contentLength));
       }
       // Add this term to the passage.
       BytesRef term = off.getTerm();// a reference; safe to refer to

--- a/src/main/java/de/digitalcollections/solrocr/util/OcrHighlightResult.java
+++ b/src/main/java/de/digitalcollections/solrocr/util/OcrHighlightResult.java
@@ -40,7 +40,7 @@ public class OcrHighlightResult {
       int snipCount = getSnippetCount(fieldName);
       OcrSnippet[] snips = getFieldSnippets(fieldName);
       NamedList[] outSnips = Arrays.stream(snips)
-          .map(OcrSnippet::toNamedList)
+          .map(snip -> snip == null ? null : snip.toNamedList())
           .toArray(NamedList[]::new);
       fieldOut.add("snippets", outSnips);
       fieldOut.add("numTotal", snipCount);

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiEscapedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiEscapedTest.java
@@ -96,6 +96,6 @@ public class AltoMultiEscapedTest extends SolrTestCaseJ4 {
         "count(//arr[@name='snippets']/lst)=1",
         "(//arr[@name='regions']/lst/str[@name='page'])[1]/text()='P2'",
         "(//arr[@name='regions']/lst/str[@name='page'])[2]/text()='P3'",
-        "//arr[@name='snippets']/lst/str[@name='text']/text()='Vcschllisse motivirt hat. wird gcwisi nirgends mchr gcwurdigt und tiaukbarer anerkannt, alS hier in unscrcm Landc; abcr auch <em>nirgendS H bas Bediirfnisi</em> nach ciucr cndlichen That des Bundcs dringender alS hier. Die bishcrige'");
+        "//arr[@name='snippets']/lst/str[@name='text']/text()='Vcschllisse motivirt hat. wird gcwisi nirgends mchr gcwurdigt und tiaukbarer anerkannt, alS hier in unscrcm Landc; abcr auch <em>nirgendS H bas Bediirfnisi</em> nach ciucr cndlichen That des Bundcs dringender alS hier. Die bishcrige Veschliïssc dcs Blindes, welche die Erfullung'");
   }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrEscapedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrEscapedTest.java
@@ -142,10 +142,22 @@ public class HocrEscapedTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = xmlQ("q", "\"max werner hochzeit\"~10", "hl.ocr.limitBlock", "none", "hl.weightMatches", "true");
     assertQ(
         req,
-        "//str[@name='text'][1]/text()='einer Verwandten ihres zukünftigen Mannes, die im Auslande ſtudiert und kürzlich promoviert habe. Tief im Winter, Mitte Januar, reiſte <em>Max Werner zur Hochzeit</em> ſeiner Schweſter in die ruſſiſche Provinz. Dort, auf dem Gut von deren Freunden, wo eine Un-'",
+        "//str[@name='text'][1]/text()='einer Verwandten ihres zukünftigen Mannes, die im Auslande ſtudiert und kürzlich promoviert habe. Tief im Winter, Mitte Januar, reiſte <em>Max Werner zur Hochzeit</em> ſeiner Schweſter in die ruſſiſche Provinz. Dort, auf dem Gut von deren Freunden, wo eine Un- menge fremder Gäſte untergebracht waren, ſah er mitten'",
         "(//arr[@name='highlights']/arr/lst/str[@name='page'])[1]='page_31'",
         "(//arr[@name='highlights']/arr/lst/str[@name='page'])[2]='page_32'",
         "count(//arr[@name='regions']/lst)=2");
+  }
+
+  @Test
+  public void testMergedRegionExceedsContext() throws Exception {
+    SolrQueryRequest req = xmlQ("q", "\"lord's prayer\"", "hl.weightMatches", "true");
+    assertQ(req,
+            "count(//arr[@name='regions']/lst)=1",
+            "//str[@name='text'][1]/text()=\"Witches are reported (amongst many other hellish observations, whereby "
+            + "they obh'ge them\u00ADselves to Satan) to say the <em>Lord's prayer</em> back\u00ADwards. "
+            + "Are there not many, who, though they do not. pronounce the syllables of the <em>Lord's "
+            + "prayer</em> retrograde (their discretion will not suf\u00ADfer them to be betrayed to such a "
+            + "nonsense sin), yet they transpose it in effect, desiring their\"");
   }
 
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrEscapedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrEscapedTest.java
@@ -258,7 +258,7 @@ public class MiniOcrEscapedTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = xmlQ("q", "\"london nachrichten\"~5", "hl.ocr.limitBlock", "none", "hl.weightMatches", "true");
     assertQ(
         req,
-        "//str[@name='text'][1]/text()='5proc. Metall. 69, 00. 1854er Looſe –. Bankactien 797, 00. Nordbahn –. National-Anlehen 74, 10. Credit-Actien 177, 80. St. Eiſenb.-Actien-Cert. 182, 10. Galizier 197, 00. <em>London 108, 90. ien-Nachrichten</em>. i er in ſº. . . 1 eyhfü „Fºº Är º Heinr P? P. ſ º. - Empfehlen º'",
+        "//str[@name='text'][1]/text()='5proc. Metall. 69, 00. 1854er Looſe –. Bankactien 797, 00. Nordbahn –. National-Anlehen 74, 10. Credit-Actien 177, 80. St. Eiſenb.-Actien-Cert. 182, 10. Galizier 197, 00. <em>London 108, 90. ien-Nachrichten</em>. i er in ſº. . . 1 eyhfü „Fºº Är º Heinr P? P. ſ º. - Empfehlen º Meyen ( - Leutloff mit -meraüren beenre-e-mehr-die-ergeben Ä-mein Gehrer u. Studirende!'",
         "(//arr[@name='highlights']/arr/lst/str[@name='page'])[1]='9'",
         "(//arr[@name='highlights']/arr/lst/str[@name='page'])[2]='10'",
         "(//arr[@name='regions']/lst/str[@name='page'])[1]='9'",


### PR DESCRIPTION
Previously a passage would be determined by the context of the first
match it contained (e.g. previous two lines + line with match + next two
lines). This caused breakage in cases where another match occurred on
the last line of the previous match's context.

We now expand the passage to the end of the last match's context.

Additionally, the end of a context is now determined based on the end of
the match, not the start. This will add one or multiple additional
context lines for matches that span multiple lines.