### PR TITLE
Fix hl.fl parameter handling

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -114,7 +114,7 @@ document that can be highlighted in your index.
 
 ## Querying
 At query time, no extra parameters besides `hl=true` and an inclusion of your OCR fields in the
-`hl.fields` parameter are required.
+`hl.fl` parameter are required.
 
 !!! note
     For a list of all available parameters, rever to the [Query Parameters documentation](queryparams.md)

--- a/src/main/java/de/digitalcollections/solrocr/solr/HighlightComponent.java
+++ b/src/main/java/de/digitalcollections/solrocr/solr/HighlightComponent.java
@@ -4,12 +4,9 @@ import de.digitalcollections.solrocr.formats.OcrFormat;
 import de.digitalcollections.solrocr.lucene.fieldloader.ExternalFieldLoader;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import org.apache.lucene.search.Query;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
-import org.apache.solr.common.params.HighlightParams;
-import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.PluginInfo;
@@ -88,16 +85,7 @@ public class HighlightComponent extends org.apache.solr.handler.component.Highli
         }
       }
 
-      ModifiableSolrParams ocrParams = new ModifiableSolrParams(params);
-      String[] hlFields = params.getParams(HighlightParams.FIELDS);
-      if (hlFields != null) {
-        ocrParams.set(
-            HighlightParams.FIELDS,
-            Arrays.stream(hlFields).filter(ocrFieldNames::contains).toArray(String[]::new));
-      }
-
       if( highlightQuery != null ) {
-        req.setParams(ocrParams);
         NamedList ocrHighlights = ocrHighlighter.doHighlighting(
             rb.getResults().docList,
             highlightQuery,

--- a/src/main/java/de/digitalcollections/solrocr/solr/SolrOcrHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/solr/SolrOcrHighlighter.java
@@ -11,8 +11,10 @@ import java.nio.charset.StandardCharsets;
 import java.text.BreakIterator;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.uhighlight.UnifiedHighlighter.HighlightFlag;
 import org.apache.solr.common.params.HighlightParams;
@@ -35,14 +37,14 @@ public class SolrOcrHighlighter extends UnifiedSolrHighlighter {
 
   private ExternalFieldLoader fieldLoader;
   private OcrFormat ocrFormat;
-  private List<String> ocrFieldNames;
+  private Set<String> ocrFieldNames;
 
 
   public SolrOcrHighlighter(ExternalFieldLoader fieldLoader, OcrFormat ocrFormat,
                             List<String> ocrFieldNames) {
     this.fieldLoader = fieldLoader;
     this.ocrFormat = ocrFormat;
-    this.ocrFieldNames = ocrFieldNames;
+    this.ocrFieldNames = new HashSet<>(ocrFieldNames);
   }
 
   @Override

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoEscapedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoEscapedTest.java
@@ -28,7 +28,7 @@ public class AltoEscapedTest extends SolrTestCaseJ4 {
   private static SolrQueryRequest xmlQ(String... extraArgs) throws Exception {
     Map<String, String> args = new HashMap<>(ImmutableMap.<String, String>builder()
         .put("hl", "true")
-        .put("hl.fields", "ocr_text")
+        .put("hl.fl", "ocr_text")
         .put("hl.usePhraseHighlighter", "true")
         .put("df", "ocr_text")
         .put("hl.ctxTag", "ocr_line")

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiEscapedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiEscapedTest.java
@@ -43,7 +43,7 @@ public class AltoMultiEscapedTest extends SolrTestCaseJ4 {
     Map<String, String> args = new HashMap<>(
         ImmutableMap.<String, String>builder()
            .put("hl", "true")
-           .put("hl.fields", "ocr_text")
+           .put("hl.fl", "ocr_text")
            .put("hl.weightMatches", "true")
            .put("hl.usePhraseHighlighter", "true")
            .put("df", "ocr_text")

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiUtf8Test.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiUtf8Test.java
@@ -44,7 +44,7 @@ public class AltoMultiUtf8Test extends SolrTestCaseJ4 {
     Map<String, String> args = new HashMap<>(
         ImmutableMap.<String, String>builder()
            .put("hl", "true")
-           .put("hl.fields", "ocr_text")
+           .put("hl.fl", "ocr_text")
            .put("hl.usePhraseHighlighter", "true")
            .put("df", "ocr_text")
            .put("hl.ctxTag", "ocr_line")

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoUtf8Test.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoUtf8Test.java
@@ -32,7 +32,7 @@ public class AltoUtf8Test extends SolrTestCaseJ4 {
   private static SolrQueryRequest xmlQ(String... extraArgs) throws Exception {
     Map<String, String> args = new HashMap<>(ImmutableMap.<String, String>builder()
         .put("hl", "true")
-        .put("hl.fields", "ocr_text")
+        .put("hl.fl", "ocr_text")
         .put("hl.usePhraseHighlighter", "true")
         .put("df", "ocr_text")
         .put("hl.ctxTag", "ocr_line")

--- a/src/test/java/de/digitalcollections/solrocr/solr/DistributedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/DistributedTest.java
@@ -50,7 +50,7 @@ public class DistributedTest extends BaseDistributedSearchTestCase {
     QueryResponse resp = query(
         "q", "svadag",
         "hl", "true",
-        "hl.fields", "ocr_text",
+        "hl.fl", "ocr_text",
         "hl.usePhraseHighlighter", "true",
         "df", "ocr_text",
         "hl.ctxTag", "ocr_line",

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrEscapedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrEscapedTest.java
@@ -35,7 +35,7 @@ public class HocrEscapedTest extends SolrTestCaseJ4 {
   private static SolrQueryRequest xmlQ(String... extraArgs) throws Exception {
     Map<String, String> args = new HashMap<>(ImmutableMap.<String, String>builder()
         .put("hl", "true")
-        .put("hl.fields", "ocr_text")
+        .put("hl.fl", "ocr_text")
         .put("hl.usePhraseHighlighter", "true")
         .put("df", "ocr_text")
         .put("hl.ctxTag", "ocr_line")

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrUtf8Test.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrUtf8Test.java
@@ -32,7 +32,7 @@ public class HocrUtf8Test extends SolrTestCaseJ4 {
   private static SolrQueryRequest xmlQ(String... extraArgs) throws Exception {
     Map<String, String> args = new HashMap<>(ImmutableMap.<String, String>builder()
         .put("hl", "true")
-        .put("hl.fields", "ocr_text")
+        .put("hl.fl", "ocr_text")
         .put("hl.usePhraseHighlighter", "true")
         .put("df", "ocr_text")
         .put("hl.ctxTag", "ocr_line")

--- a/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrEscapedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrEscapedTest.java
@@ -43,7 +43,7 @@ public class MiniOcrEscapedTest extends SolrTestCaseJ4 {
     Map<String, String> args = new HashMap<>(ImmutableMap.<String, String>builder()
         .put("defType", "edismax")
         .put("hl", "true")
-        .put("hl.fields", "external_ocr_text")
+        .put("hl.fl", "external_ocr_text")
         .put("hl.usePhraseHighlighter", "true")
         .put("df", "external_ocr_text")
         .put("hl.ctxTag", "l")
@@ -68,7 +68,7 @@ public class MiniOcrEscapedTest extends SolrTestCaseJ4 {
   public void testMixedHighlighting() throws Exception {
     SolrQueryRequest req = xmlQ("q", "commodo münchen",
                                 "qf", "some_text external_ocr_text", "df", "some_text",
-                                "hl.fields", "some_text,ocr_text", "hl.weightMatches", "true");
+                                "hl.fl", "some_text,external_ocr_text", "hl.weightMatches", "true");
     assertQ(req,
             "count(//lst[@name='highlighting']/lst[@name='1337']/arr[@name='some_text']/str)=1",
             ".//arr[@name='some_text']/str/text()=' aliquip ex ea <em>commodo</em> consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum'",
@@ -94,7 +94,7 @@ public class MiniOcrEscapedTest extends SolrTestCaseJ4 {
 
   @Test
   public void testStoredHighlighting() throws Exception {
-    SolrQueryRequest req = xmlQ("q", "München", "hl.fields", "stored_ocr_text", "df", "stored_ocr_text");
+    SolrQueryRequest req = xmlQ("q", "München", "hl.fl", "stored_ocr_text", "df", "stored_ocr_text");
     assertQ(req,
             "count(//lst[@name='ocrHighlighting']/lst[@name='41337']/lst[@name='stored_ocr_text']/arr/lst)=3");
   }

--- a/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrUtf8Test.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrUtf8Test.java
@@ -42,7 +42,7 @@ public class MiniOcrUtf8Test extends SolrTestCaseJ4 {
   protected static SolrQueryRequest xmlQ(String... extraArgs) throws Exception {
     Map<String, String> args = new HashMap<>(ImmutableMap.<String, String>builder()
         .put("hl", "true")
-        .put("hl.fields", "ocr_text")
+        .put("hl.fl", "ocr_text")
         .put("hl.usePhraseHighlighter", "true")
         .put("df", "ocr_text")
         .put("hl.ctxTag", "l")


### PR DESCRIPTION
Due to a bug, the `hl.fl` parameter **did not work at all** in previous versions, the only reason we didn't notice this is because all the tests and sample configurations used the `df` parameter, to which Solr falls back to if no `hl.fl` is defined.