### PR TITLE
Unescape text in snippet hits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>solr-ocrhighlighting</artifactId>
-  <version>0.2</version>
+  <version>0.3-SNAPSHOT</version>
 
   <name>Solr OCR Highlighting Plugin</name>
   <description>

--- a/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
@@ -128,7 +128,7 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
       int w = Integer.parseInt(attribs.get("WIDTH"));
       int h = Integer.parseInt(attribs.get("HEIGHT"));
       String subsType = attribs.get("SUBS_TYPE");
-      String text = attribs.get("CONTENT");
+      String text = StringEscapeUtils.unescapeXml(attribs.get("CONTENT"));
       if ("HypPart1".equals(subsType)) {
         text += "-";
       }

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 import de.digitalcollections.solrocr.formats.OcrPassageFormatter;
 import de.digitalcollections.solrocr.util.IterableCharSequence;
 import de.digitalcollections.solrocr.util.OcrBox;
+import org.apache.commons.text.StringEscapeUtils;
 
 public class HocrPassageFormatter extends OcrPassageFormatter {
   private final static Pattern wordPat = Pattern.compile(
@@ -64,7 +65,7 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
       int y0 = Integer.parseInt(m.group("uly"));
       int x1 = Integer.parseInt(m.group("lrx"));
       int y1 = Integer.parseInt(m.group("lry"));
-      String text = m.group("text");
+      String text = StringEscapeUtils.unescapeXml(m.group("text"));
       if (text.contains(startHlTag)) {
         inHighlight = true;
       }

--- a/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrPassageFormatter.java
@@ -6,6 +6,7 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.lucene.search.uhighlight.Passage;
 import de.digitalcollections.solrocr.formats.OcrPassageFormatter;
 import de.digitalcollections.solrocr.formats.OcrSnippet;
@@ -89,7 +90,7 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
       float y = Float.valueOf(m.group("y"));
       float width = Float.valueOf(m.group("w"));
       float height = Float.valueOf(m.group("h"));
-      String text = m.group("text");
+      String text = StringEscapeUtils.unescapeXml(m.group("text"));
       if (text.contains(startHlTag)) {
         inHighlight = true;
       }

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrEscapedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrEscapedTest.java
@@ -166,4 +166,10 @@ public class HocrEscapedTest extends SolrTestCaseJ4 {
     assertQ(req, "count(//arr[@name='regions']/lst)=1");
   }
 
+  @Test
+  public void testHighlightTextUnescaped() throws Exception {
+    SolrQueryRequest req = xmlQ("q", "\"alſo beſſer\"", "hl.weightMatches", "true");
+    assertQ(req, "//arr[@name='highlights']//str[@name='text']/text()='alſo beſſer,'");
+  }
+
 }


### PR DESCRIPTION
Previously, we did not unescape XML-encoded character entities in the `text` field of each snippet hit, that is, the text would be `&#x17f;alle du divan` instead of `ſalle du divan`.
This PR remedies this for all supported formats.