### PR TITLE
Add optimization for ASCII-only input documents

### DIFF
--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -13,18 +13,21 @@ the (again, potentially very large) contents themselves in the index.
 !!! note "Performance"
     When using external files for highlighting, the performance depends almost exclusively on
     how fast the underlying storage is able to perform random I/O. This is why **using flash storage
-    for the documents is highly recommended**. Another option to increase highlighting performance is
+    for the documents is highly recommended**.
+    
+    Another option to increase highlighting performance is
     to **switch from UTF8 to ASCII** (with XML-escaped Unicode codepoints) for the encoding of the OCR
     files. This requires less CPU during decoding, since we don't have to take multi-byte sequences into
-    account.
+    account. To signal to the plugin that a given source path is encoded in ASCII, include the `{ascii}`
+    string after the path, e.g. `/mnt/data/ocrdoc.xml{ascii}[31337:41337]`.
 
 How the source pointers are structured depends on how your actual OCR files on disk map to documents in the Solr
 index.
 
 !!! caution "Encoding"
-    The files pointed at by the source pointers **need to be UTF-8 encoded**. Other encodings will lead to
-    unexpected errors and weird behaviour, so make sure that the files are in the correct encoding before
-    you index them.
+    The files pointed at by the source pointers **need to be UTF-8 or ASCII encoded**. Other encodings will lead
+    to unexpected errors and weird behaviour, so make sure that the files are in the correct encoding before you
+    index them.
 
 ## One file per Solr document (`1:1`)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,13 +49,13 @@ In your core's `solrconfig.xml, you need to:
     search component you defined above. This example uses the standard /select handler.
 
     CAUTION: Make sure that the OCR highlight component is listed **before** the standard
-    highlighting component.
+    highlighting component, i.e. explicitely like in this example or with `first-components`
   -->
   <requestHandler name="/select" class="solr.SearchHandler">
       <arr name="components">
-      <str>query</str>
-      <str>ocrHighlight</str>
-      <str>highlight</str>
+          <str>query</str>
+          <str>ocrHighlight</str>
+          <str>highlight</str>
       </arr>
   </requestHandler>
 </config>

--- a/src/main/java/de/digitalcollections/solrocr/util/SourcePointer.java
+++ b/src/main/java/de/digitalcollections/solrocr/util/SourcePointer.java
@@ -20,8 +20,9 @@ public class SourcePointer {
   public static class FileSource {
     public Path path;
     public List<Region> regions;
+    public boolean isAscii;
 
-    public FileSource(Path path, List<Region> regions) throws IOException {
+    public FileSource(Path path, List<Region> regions, boolean isAscii) throws IOException {
       this.path = path;
       if (!path.toFile().exists()) {
         String msg = String.format("File at %s does not exist, skipping.", path.toString());
@@ -34,6 +35,7 @@ public class SourcePointer {
         throw new IOException(msg);
       }
       this.regions = regions;
+      this.isAscii = isAscii;
     }
   }
 
@@ -60,7 +62,9 @@ public class SourcePointer {
     }
   }
 
-  private static final Pattern POINTER_PAT = Pattern.compile("^(?<path>.+?)(?:\\[(?<regions>[0-9:,]+)])?$");
+  private static final Pattern POINTER_PAT = Pattern.compile(
+      "^(?<path>.+?)(?<isAscii>\\{ascii})?(?:\\[(?<regions>[0-9:,]+)])?$");
+
 
   public List<FileSource> sources;
 
@@ -89,7 +93,7 @@ public class SourcePointer {
                 .collect(Collectors.toList());
           }
           try {
-            return new FileSource(sourcePath, regions);
+            return new FileSource(sourcePath, regions, m.group("isAscii") != null);
           } catch (IOException e) {
             return null;
           }


### PR DESCRIPTION
Profiling revealed that a lot of time was spent on mapping the input `byte` offsets for the source pointer regions to target `char` offsets. There's no way of getting around this with UTF8-encoded source documents, but for ASCII-only source files we can skip the process.

To this end, a new option is added to the source pointer format: Users can now include the `{ascii}` string after the path and before any regions to indicate to the plugin that the source file at the location is encoded in ASCII and it is safe to skip the offset mapping.