### PR TITLE
hocr: Add support for retrieving page id from `x_source` property

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -21,7 +21,7 @@ query parameters](query.md#params) to control how snippets are generated.
 | Block     | hOCR class                  | notes                            |
 | --------- | --------------------------- | -------------------------------- |
 | Word      | `ocrx_word`                 | needs to have a `bbox` attribute with the coordinates on the page |
-| Page      | `ocr_page`                  | needs to have an `id` attribute with a page identifier or a `ppageno` entry in the `title` attribute |
+| Page      | `ocr_page`                  | needs to have an `id` attribute with a page identifier or a `ppageno` or `x_source` entry in the `title` attribute |
 | Block     | `ocr_carea`/`ocrx_block`    |                                  |
 | Section   | `ocr_chapter`/`ocr_section`/<br>`ocr_subsection`/`ocr_subsubsection` | |
 | Paragraph | `ocr_par`                   |                                  |


### PR DESCRIPTION
Previously we only supported getting the page identifier from the `id` HTML attribute or the `ppageno` hOCR property. This PR adds support for the [`x_source`](http://kba.cloud/hocr-spec/1.2/#x_source) hOCR property to support more use cases.