### PR TITLE
CI: Run legacy integration tests in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,19 @@
 include: "https://raw.githubusercontent.com/dbmdz/development/master/ci/.gitlab-ci-base.yml"
 
+services:
+  - docker:18.09.7-dind
+
+variables:
+  DOCKER_HOST: tcp://docker:2375/
+  SOLR_HOST: docker
+
+legacy_tests:
+  extends: .verify
+  stage: test
+  before_script:
+    - mvn package
+  script: ./integration-tests/run.sh
+
 publish_docs:
   stage: publish
   before_script:


### PR DESCRIPTION
This should ensure that we have no regressions in compatibility with legacy versions in the future.