### PR TITLE
Better error handling, stricter check of page identifiers and assorted bugfixes

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -18,7 +18,7 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
   private final static Pattern wordPat = Pattern.compile(
       "<span class=['\"]ocrx_word['\"].+?title=['\"].*?"
       + "bbox (?<ulx>\\d+) (?<uly>\\d+) (?<lrx>\\d+) (?<lry>\\d+);?.*?>(?<text>.+?)</span>");
-  private final static Pattern pageElemPat = Pattern.compile("<div.+?class=['\"]ocr_page['\"] ?(?<attribs>.+?)>");
+  private final static Pattern pageElemPat = Pattern.compile("<div.+?class=['\"]ocr_page['\"]\\s*(?<attribs>.+?)>");
   private final static Pattern pageIdPat = Pattern.compile(
       "(?:id=['\"](?<id>.+?)['\"]|x_source (?<source>.+?)['\";]|ppageno (?<pageno>\\d+))");
   private final static Pattern pageBboxPat = Pattern.compile("bbox 0 0 (?<width>\\d+) (?<height>\\d+)");

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -35,17 +35,19 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
   }
 
   private OcrPage parsePage(String pageAttribs, int pagePos) {
-    String fallbackId = String.format("_unknown_%d", pagePos);
+    RuntimeException noPageIdExc = new RuntimeException("Pages must have an identifier, check your source files!");
     if (pageAttribs == null) {
-      return new OcrPage(fallbackId, null);
+      throw noPageIdExc;
     }
     Matcher idMatch = pageIdPat.matcher(pageAttribs);
-    String pageId = fallbackId;
+    String pageId;
     if (idMatch.find()) {
       pageId = Stream.of("id", "source", "pageno")
           .map(idMatch::group)
           .filter(StringUtils::isNotEmpty)
-          .findFirst().orElse(pageId);
+          .findFirst().orElseThrow(() -> noPageIdExc);
+    } else {
+      throw noPageIdExc;
     }
     Dimension pageDims = null;
     Matcher boxMatch = pageBboxPat.matcher(pageAttribs);

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
@@ -346,8 +346,8 @@ public class OcrHighlighter extends UnifiedHighlighter {
   }
 
   private OcrFormat getFormat(IterableCharSequence content) throws IOException {
-    // Sample the first 2k characters to determine the format
-    String sampleChunk = content.subSequence(0, Math.min(2048, content.length())).toString();
+    // Sample the first 4k characters to determine the format
+    String sampleChunk = content.subSequence(0, Math.min(4096, content.length())).toString();
     return FORMATS.stream()
         .filter(fmt -> fmt.hasFormat(sampleChunk))
         .findFirst()

--- a/src/main/java/de/digitalcollections/solrocr/util/OcrPage.java
+++ b/src/main/java/de/digitalcollections/solrocr/util/OcrPage.java
@@ -1,6 +1,7 @@
 package de.digitalcollections.solrocr.util;
 
 import java.awt.Dimension;
+import java.util.Objects;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 
@@ -10,6 +11,7 @@ public class OcrPage {
   public final Dimension dimensions;
 
   public OcrPage(String id, Dimension dimensions) {
+    Objects.requireNonNull(id, "Pages need to have an identifier, check your source files!");
     this.id = id;
     this.dimensions = dimensions;
   }

--- a/src/main/java/de/digitalcollections/solrocr/util/SourcePointer.java
+++ b/src/main/java/de/digitalcollections/solrocr/util/SourcePointer.java
@@ -80,12 +80,12 @@ public class SourcePointer {
     if (!isPointer(pointer)) {
       throw new RuntimeException("Could not parse pointer: " + pointer);
     }
-    return new SourcePointer(Arrays.stream(pointer.split("\\+"))
+    List<FileSource> fileSources = Arrays.stream(pointer.split("\\+"))
         .map(ptr -> {
           Matcher m = POINTER_PAT.matcher(ptr);
           m.find();
           Path sourcePath = Paths.get(m.group("path"));
-          List<SourcePointer.Region> regions = ImmutableList.of();
+          List<Region> regions = ImmutableList.of();
           if (m.group("regions") != null) {
             regions = Arrays.stream(m.group("regions").split(","))
                 .map(SourcePointer::parseRegion)
@@ -97,7 +97,12 @@ public class SourcePointer {
           } catch (IOException e) {
             return null;
           }
-        }).filter(Objects::nonNull).collect(Collectors.toList()));
+        }).filter(Objects::nonNull).collect(Collectors.toList());
+    if (fileSources.isEmpty()) {
+      return null;
+    } else {
+      return new SourcePointer(fileSources);
+    }
   }
 
   private static SourcePointer.Region parseRegion(String r) {


### PR DESCRIPTION
**Error Handling**

Previously the plugin would crash the complete query in case highlighting failed. This PR changes this so only highlighting for the faulty field is skipped and the rest of the query can continue unimpeded. For the problematic field, a message with exception details is logged on the `ERROR` level so admins can analyze the error after the fact.

**Stricter Check of Page Identifiers**

Previously the code was conflicting in whether page identifiers were required or not (the docs said they were, while parts of the code implemented a fallback mechanism). This is now changed, a parsed page must **always** have an identifier (as specified in the format documentation) or the highlighting will fail.

**Assorted Bugfixes**

- Increased sample size for OCR format detection. 2k was too small for some hOCR files with large `ocr-system` headers, it is now 4k.
- Allow newlines in hOCR opening `ocr_page` elements