### PR TITLE
Fix cache warmer shutdown

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightComponent.java
+++ b/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightComponent.java
@@ -1,11 +1,13 @@
 package de.digitalcollections.solrocr.solr;
 
+import de.digitalcollections.solrocr.util.PageCacheWarmer;
 import java.io.IOException;
 import org.apache.lucene.search.Query;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.core.CloseHook;
 import org.apache.solr.core.PluginInfo;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.handler.component.ResponseBuilder;
@@ -29,6 +31,18 @@ public class OcrHighlightComponent extends org.apache.solr.handler.component.Hig
   public void inform(SolrCore core) {
     super.inform(core);
     this.ocrHighlighter = new SolrOcrHighlighter();
+
+    // Shut down the cache warming threads after closing of the core
+    core.addCloseHook(new CloseHook() {
+      @Override
+      public void preClose(SolrCore core) {
+      }
+
+      @Override
+      public void postClose(SolrCore core) {
+        PageCacheWarmer.shutdown();
+      }
+    });
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/solrocr/util/PageCacheWarmer.java
+++ b/src/main/java/de/digitalcollections/solrocr/util/PageCacheWarmer.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.solrocr.util;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import de.digitalcollections.solrocr.util.SourcePointer.FileSource;
 import de.digitalcollections.solrocr.util.SourcePointer.Region;
@@ -42,12 +41,10 @@ public class PageCacheWarmer {
   // Set of pending preload operations for file sources, used to allow the cancelling of preloading tasks
   private static final Set<FileSource> pendingPreloads = ConcurrentHashMap.newKeySet(MAX_PENDING_JOBS);
 
-  private static final ExecutorService service = MoreExecutors.getExitingExecutorService(
-      new ThreadPoolExecutor(
-          NUM_THREADS, NUM_THREADS, 60L, TimeUnit.SECONDS, new LinkedBlockingDeque<>(MAX_PENDING_JOBS),
-          new ThreadFactoryBuilder().setNameFormat("solr-ocrhighlighting-cache-warmer-%d").build(),
-          new ThreadPoolExecutor.DiscardOldestPolicy()),
-      0, TimeUnit.MILLISECONDS);
+  private static final ExecutorService service = new ThreadPoolExecutor(
+      NUM_THREADS, NUM_THREADS, 0, TimeUnit.MILLISECONDS, new LinkedBlockingDeque<>(MAX_PENDING_JOBS),
+      new ThreadFactoryBuilder().setNameFormat("solr-ocrhighlighting-cache-warmer-%d").build(),
+      new ThreadPoolExecutor.DiscardOldestPolicy());
 
 
   /**
@@ -98,5 +95,9 @@ public class PageCacheWarmer {
       return;
     }
     ptr.sources.forEach(pendingPreloads::remove);
+  }
+
+  public static void shutdown() {
+    service.shutdownNow();
   }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiTest.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.solrocr.solr;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.google.common.collect.ImmutableMap;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -9,19 +8,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.lucene.util.QuickPatchThreadsFilter;
-import org.apache.solr.SolrIgnoredThreadsFilter;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-@ThreadLeakFilters(defaultFilters = true, filters = {
-    SolrIgnoredThreadsFilter.class,
-    QuickPatchThreadsFilter.class,
-    CustomThreadsFilter.class
-})
 public class AltoMultiTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -1,25 +1,17 @@
 package de.digitalcollections.solrocr.solr;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.google.common.collect.ImmutableMap;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.apache.lucene.util.QuickPatchThreadsFilter;
-import org.apache.solr.SolrIgnoredThreadsFilter;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-@ThreadLeakFilters(defaultFilters = true, filters = {
-    SolrIgnoredThreadsFilter.class,
-    QuickPatchThreadsFilter.class,
-    CustomThreadsFilter.class
-})
 public class AltoTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/src/test/java/de/digitalcollections/solrocr/solr/DistributedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/DistributedTest.java
@@ -1,20 +1,12 @@
 package de.digitalcollections.solrocr.solr;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.apache.lucene.util.QuickPatchThreadsFilter;
 import org.apache.solr.BaseDistributedSearchTestCase;
-import org.apache.solr.SolrIgnoredThreadsFilter;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-@ThreadLeakFilters(defaultFilters = true, filters = {
-    SolrIgnoredThreadsFilter.class,
-    QuickPatchThreadsFilter.class,
-    CustomThreadsFilter.class
-})
 public class DistributedTest extends BaseDistributedSearchTestCase {
 
   @Override

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -1,25 +1,17 @@
 package de.digitalcollections.solrocr.solr;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.google.common.collect.ImmutableMap;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.apache.lucene.util.QuickPatchThreadsFilter;
-import org.apache.solr.SolrIgnoredThreadsFilter;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-@ThreadLeakFilters(defaultFilters = true, filters = {
-    SolrIgnoredThreadsFilter.class,
-    QuickPatchThreadsFilter.class,
-    CustomThreadsFilter.class
-})
 public class HocrTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrTest.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.solrocr.solr;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.google.common.collect.ImmutableMap;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -9,19 +8,12 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.apache.lucene.util.QuickPatchThreadsFilter;
-import org.apache.solr.SolrIgnoredThreadsFilter;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-@ThreadLeakFilters(defaultFilters = true, filters = {
-    SolrIgnoredThreadsFilter.class,
-    QuickPatchThreadsFilter.class,
-    CustomThreadsFilter.class
-})
 public class MiniOcrTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {


### PR DESCRIPTION
Adds a new `CloseHook` during plugin initialization to shut down the page cache warmer threads after closing the core. This should stop threads from hanging around and also allow us to get rid of the custom thread leak control checks in the unit tests. Also gets rid of a Guava dependency.