### PR TITLE
Add `hl.ocr.timeAllowed` parameter to limit highlighting time

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -154,3 +154,11 @@ Additionally, the plugin allows you to customize various OCR-specific parameters
     The default is `100`. The practical result is that only the first `n` matches in a document will be considered
     for highlighting, i.e. if a more relevant passage occurs at the end of the document, it is more likely to not be
     considered if the total number of matches in the document exceeds this number.
+
+`hl.ocr.timeAllowed`:
+:   Due to the fact that generating highlighting snippets from disk can take a very long time, depending on the
+    number of documents and snippets, you can limit the time OCR highlighting should take. The parameter takes the
+    maximum allowed time in **milliseconds**. If the timeout is exceeded during highlighting, the document currently
+    being highlighted and any other remaining documents will be skipped. The highlighting response will then only
+    include snippets from documents that were highlighted before the timeout. The presence of partial results will be
+    indicated by the `partialOcrHighlights` key in the `responseHeader`.

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
@@ -244,6 +244,7 @@ public class OcrHighlighter extends UnifiedHighlighter {
     int[][] snippetCountsByField = new int[fields.length][docIds.length];
     // Highlight in doc batches determined by loadFieldValues (consumes from docIdIter)
     DocIdSetIterator docIdIter = asDocIdSetIterator(docIds);
+    docLoop:
     for (int batchDocIdx = 0; batchDocIdx < docIds.length; ) {
       List<IterableCharSequence[]> fieldValsByDoc = loadOcrFieldValues(fields, docIdIter);
 
@@ -297,6 +298,8 @@ public class OcrHighlighter extends UnifiedHighlighter {
             log.warn("OCR Highlighting timed out while handling " + content.getPointer(), e);
             respHeader.put(PARTIAL_OCR_HIGHLIGHTS, Boolean.TRUE);
             resultByDocIn[docInIndex] = null;
+            // Stop highlighting
+            break docLoop;
           } catch (RuntimeException e) {
             // This catch-all prevents OCR highlighting from failing the complete query, instead users
             // get an error message in their Solr log.

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
@@ -68,6 +68,7 @@ import org.slf4j.LoggerFactory;
  * lazy-loading field values from external storage.
  */
 public class OcrHighlighter extends UnifiedHighlighter {
+
   private static final Logger log = LoggerFactory.getLogger(OcrHighlighter.class);
 
   private static final CharacterRunAutomaton[] ZERO_LEN_AUTOMATA_ARRAY_LEGACY = new CharacterRunAutomaton[0];
@@ -77,6 +78,7 @@ public class OcrHighlighter extends UnifiedHighlighter {
       new AltoFormat(),
       new MiniOcrFormat());
   private static final int DEFAULT_SNIPPET_LIMIT = 100;
+  public static final String PARTIAL_OCR_HIGHLIGHTS = "partialOcrHighlights";
 
   private static final boolean VERSION_IS_PRE81 = Version.LATEST.major < 8 || Version.LATEST.minor < 1;
   private static final boolean VERSION_IS_PRE82 = Version.LATEST.major < 8 || Version.LATEST.minor < 2;
@@ -293,7 +295,7 @@ public class OcrHighlighter extends UnifiedHighlighter {
                 params.get(OcrHighlightParams.PAGE_ID), snippetLimit);
           } catch (ExitingIterCharSeq.ExitingIterCharSeqException | ExitableDirectoryReader.ExitingReaderException e) {
             log.warn("OCR Highlighting timed out while handling " + content.getPointer(), e);
-            respHeader.put("partialOcrHighlights", Boolean.TRUE);
+            respHeader.put(PARTIAL_OCR_HIGHLIGHTS, Boolean.TRUE);
             resultByDocIn[docInIndex] = null;
           } catch (RuntimeException e) {
             // This catch-all prevents OCR highlighting from failing the complete query, instead users

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
@@ -59,7 +59,6 @@ import org.apache.lucene.util.Version;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.solr.common.params.HighlightParams;
 import org.apache.solr.common.params.SolrParams;
-import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.SolrQueryTimeoutImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -294,7 +293,7 @@ public class OcrHighlighter extends UnifiedHighlighter {
                 params.get(OcrHighlightParams.PAGE_ID), snippetLimit);
           } catch (ExitingIterCharSeq.ExitingIterCharSeqException | ExitableDirectoryReader.ExitingReaderException e) {
             log.warn("OCR Highlighting timed out while handling " + content.getPointer(), e);
-            respHeader.put(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY, Boolean.TRUE);
+            respHeader.put("partialOcrHighlights", Boolean.TRUE);
             resultByDocIn[docInIndex] = null;
           } catch (RuntimeException e) {
             // This catch-all prevents OCR highlighting from failing the complete query, instead users

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlightingTimeout.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlightingTimeout.java
@@ -1,4 +1,0 @@
-package de.digitalcollections.solrocr.lucene;
-
-public class OcrHighlightingTimeout {
-}

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlightingTimeout.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlightingTimeout.java
@@ -1,0 +1,4 @@
+package de.digitalcollections.solrocr.lucene;
+
+public class OcrHighlightingTimeout {
+}

--- a/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightComponent.java
+++ b/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightComponent.java
@@ -69,7 +69,7 @@ public class OcrHighlightComponent extends org.apache.solr.handler.component.Hig
         NamedList ocrHighlights = ocrHighlighter.doHighlighting(
             rb.getResults().docList,
             highlightQuery,
-            req, defaultHighlightFields);
+            req, defaultHighlightFields, rb.rsp.getResponseHeader().asShallowMap());
         if (ocrHighlights != null) {
           rb.rsp.add(highlightingResponseField(), ocrHighlights);
         }

--- a/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightComponent.java
+++ b/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightComponent.java
@@ -1,6 +1,7 @@
 package de.digitalcollections.solrocr.solr;
 
 import de.digitalcollections.solrocr.util.PageCacheWarmer;
+import de.digitalcollections.solrocr.lucene.OcrHighlighter;
 import java.io.IOException;
 import org.apache.lucene.search.Query;
 import org.apache.solr.common.SolrException;
@@ -103,9 +104,9 @@ public class OcrHighlightComponent extends org.apache.solr.handler.component.Hig
             continue;
           }
           NamedList<Object> rspHeader = (NamedList<Object>) srsp.getSolrResponse().getResponse().get("responseHeader");
-          Boolean partialHls = (Boolean) rspHeader.get("partialOcrHighlights");
+          Boolean partialHls = (Boolean) rspHeader.get(OcrHighlighter.PARTIAL_OCR_HIGHLIGHTS);
           if (partialHls != null && partialHls) {
-            rb.rsp.getResponseHeader().add("partialOcrHighlights", true);
+            rb.rsp.getResponseHeader().add(OcrHighlighter.PARTIAL_OCR_HIGHLIGHTS, true);
           }
         }
       }

--- a/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightParams.java
+++ b/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightParams.java
@@ -11,4 +11,5 @@ public interface OcrHighlightParams extends HighlightParams {
   String SCORE_BOOST_EARLY = "hl.score.boostEarly";
   String ABSOLUTE_HIGHLIGHTS = "hl.ocr.absoluteHighlights";
   String MAX_OCR_PASSAGES = "hl.ocr.maxPassages";
+  String TIME_ALLOWED = "hl.ocr.timeAllowed";
 }

--- a/src/main/java/de/digitalcollections/solrocr/util/ExitingIterCharSeq.java
+++ b/src/main/java/de/digitalcollections/solrocr/util/ExitingIterCharSeq.java
@@ -1,0 +1,143 @@
+package de.digitalcollections.solrocr.util;
+
+import java.nio.charset.Charset;
+import java.util.stream.IntStream;
+import org.apache.lucene.index.QueryTimeout;
+
+public class ExitingIterCharSeq implements IterableCharSequence {
+  public static class ExitingIterCharSeqException extends RuntimeException {
+    ExitingIterCharSeqException(String msg) {
+      super(msg);
+    }
+  }
+
+  private final static int CHARS_BETWEEN_CHECKS = 8192;
+
+  private final IterableCharSequence iter;
+  private final QueryTimeout timeout;
+  private int untilNextCheck = CHARS_BETWEEN_CHECKS;
+
+  public ExitingIterCharSeq(IterableCharSequence iter, QueryTimeout timeout) {
+    this.iter = iter;
+    this.timeout = timeout;
+  }
+
+  private void checkAndThrow() {
+    if (timeout.shouldExit()) {
+      throw new ExitingIterCharSeqException(String.format(
+          "The request took to long to highlight the OCR files (pointer: %s, timeout was: %s)", getPointer(), timeout));
+    } else if (Thread.interrupted()) {
+      throw new ExitingIterCharSeqException(String.format(
+          "Interrupted while reading the file for OCR (pointer: %s).", getPointer()));
+    }
+  }
+
+  @Override
+  public String getIdentifier() {
+    return iter.getIdentifier();
+  }
+
+  @Override
+  public OffsetType getOffsetType() {
+    return iter.getOffsetType();
+  }
+
+  @Override
+  public Charset getCharset() {
+    return iter.getCharset();
+  }
+
+  @Override
+  public SourcePointer getPointer() {
+    return iter.getPointer();
+  }
+
+  public static IterableCharSequence fromString(String string) {
+    return IterableCharSequence.fromString(string);
+  }
+
+  @Override
+  public int length() {
+    return iter.length();
+  }
+
+  @Override
+  public char charAt(int index) {
+    untilNextCheck--;
+    if (untilNextCheck == 0) {
+      checkAndThrow();
+      untilNextCheck = CHARS_BETWEEN_CHECKS;
+    }
+    return iter.charAt(index);
+  }
+
+  @Override
+  public CharSequence subSequence(int start, int end) {
+    return iter.subSequence(start, end);
+  }
+
+  @Override
+  public String toString() {
+    return iter.toString();
+  }
+
+  @Override
+  public IntStream chars() {
+    return iter.chars();
+  }
+
+  @Override
+  public IntStream codePoints() {
+    return iter.codePoints();
+  }
+
+  @Override
+  public char first() {
+    return iter.first();
+  }
+
+  @Override
+  public char last() {
+    return iter.last();
+  }
+
+  @Override
+  public char current() {
+    return iter.current();
+  }
+
+  @Override
+  public char next() {
+    return iter.next();
+  }
+
+  @Override
+  public char previous() {
+    return iter.previous();
+  }
+
+  @Override
+  public char setIndex(int position) {
+    return iter.setIndex(position);
+  }
+
+  @Override
+  public int getBeginIndex() {
+    return iter.getBeginIndex();
+  }
+
+  @Override
+  public int getEndIndex() {
+    return iter.getEndIndex();
+  }
+
+  @Override
+  public int getIndex() {
+    return iter.getIndex();
+  }
+
+  @Override
+  public Object clone() {
+    return new ExitingIterCharSeq(iter, timeout);
+  }
+}

--- a/src/main/java/de/digitalcollections/solrocr/util/HighlightTimeout.java
+++ b/src/main/java/de/digitalcollections/solrocr/util/HighlightTimeout.java
@@ -1,0 +1,47 @@
+package de.digitalcollections.solrocr.util;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.index.QueryTimeout;
+
+public class HighlightTimeout implements QueryTimeout {
+  public static ThreadLocal<Long> timeoutAt = new ThreadLocal<>();
+
+  private static HighlightTimeout instance = new HighlightTimeout();
+
+  public static HighlightTimeout getInstance() {
+    return instance;
+  }
+
+  private HighlightTimeout() { }
+
+  public static Long get() {
+    return timeoutAt.get();
+  }
+
+  public static void set(Long timeAllowed) {
+    timeoutAt.set(System.nanoTime() + TimeUnit.NANOSECONDS.convert(timeAllowed, TimeUnit.MILLISECONDS));
+  }
+
+  public static void reset() {
+    timeoutAt.remove();
+  }
+
+  @Override
+  public boolean shouldExit() {
+    Long timeoutAt = get();
+    if (timeoutAt == null) {
+      return false;
+    }
+    return timeoutAt - System.nanoTime() < 0L;
+  }
+
+  @Override
+  public boolean isTimeoutEnabled() {
+    return get() != null;
+  }
+
+  @Override
+  public String toString() {
+    return "timeoutAt: " + get() + " (System.nanoTime(): " + System.nanoTime() + ")";
+  }
+}

--- a/src/test/java/de/digitalcollections/solrocr/solr/DistributedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/DistributedTest.java
@@ -75,11 +75,9 @@ public class DistributedTest extends BaseDistributedSearchTestCase {
         "hl.ctxSize", "2",
         "hl.snippets", "10",
         "hl.ocr.timeAllowed", "-1",
-        "shards.tolerant", "true",
-        "fl", "id,score",
-        "sort", "score desc, id asc");
+        "fl", "id,score");
     assertEquals(1, resp.getResults().getNumFound());
-    assertEquals(true, resp.getHeader().getBooleanArg("partialResults"));
+    assertEquals(true, resp.getHeader().getBooleanArg("partialOcrHighlights"));
   }
 
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -173,4 +173,16 @@ public class HocrTest extends SolrTestCaseJ4 {
         "count(//arr[@name='regions']/lst)=2",
         "contains(//lst[@name='84']//arr[@name='snippets']/lst/str[@name='text']/text(), '<em>Vögelchen</em>')");
   }
+
+  @Test
+  public void testHighlightingTimeout() throws Exception {
+    // This test can only check for the worst case, since checking for partial results is unlikely to be stable across
+    // multiple environments due to timing issues.
+    SolrQueryRequest req = xmlQ("q", "Vögelchen", "hl.ocr.timeAllowed", "1");
+    assertQ(
+        req,
+        "//bool[@name='partialResults']='true'",
+        "count(//lst[@name='ocrHighlighting']/lst)=2",
+        "count(//arr[@name='snippets'])=0");
+  }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -181,7 +181,7 @@ public class HocrTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = xmlQ("q", "Vögelchen", "hl.ocr.timeAllowed", "1");
     assertQ(
         req,
-        "//bool[@name='partialResults']='true'",
+        "//bool[@name='partialOcrHighlights']='true'",
         "count(//lst[@name='ocrHighlighting']/lst)=2",
         "count(//arr[@name='snippets'])=0");
   }


### PR DESCRIPTION
The timeout will be checked during the most taxing part of the highlighting process, i.e. while reading the input OCR files from disk. If the timeout is encountered, highlighting for the current and any
further documents is cancelled and the highlighting terminated. Any snippets for documents that were handled before the timeout will be included in the response. The `responseHeader` will indicate the
partiality of the results with the `partialOcrHighlights` flag.