### PR TITLE
Fix bug in page cache pre-warming.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>solr-ocrhighlighting</artifactId>
-  <version>0.3.2-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
 
   <name>Solr OCR Highlighting Plugin</name>
   <description>


### PR DESCRIPTION
- Previously we assumed that all FileSources had `regions`. This is not true for files that are supposed to be read whole, so we use a fake region in this case now.
- Our previous reads from the file all were effectively NOPs, since we never cleared the underlying buffer. This is now fixed.