### PR TITLE
Close file channels after highlighting.

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
@@ -304,6 +304,15 @@ public class OcrHighlighter extends UnifiedHighlighter {
             // This catch-all prevents OCR highlighting from failing the complete query, instead users
             // get an error message in their Solr log.
             log.error("Could not highlight OCR content for document", e);
+          } finally {
+            if (content instanceof AutoCloseable) {
+              try {
+                ((AutoCloseable) content).close();
+              } catch (Exception e) {
+                log.warn(
+                    "Encountered error while closing content iterator for {}: {}", content.getPointer(), e.getMessage());
+              }
+            }
           }
           snippetCountsByField[fieldIdx][docInIndex] = fieldHighlighter.getNumMatches(docId);
         }


### PR DESCRIPTION
Previously we'd just let the channels be GCed without properly closing them. A previous PR (!90) already added an `AutoCloseable` implementation for `FileBytesCharIterator`. This PR adds it for
`MultiFileBytesCharIterator` as well and adds the actualy closing to the `OcrFieldHighlighter` class.