### PR TITLE
Adds support for ALTO coordinates expressed as floats.

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
@@ -42,7 +42,8 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
     Dimension dims = null;
     if (attribs.containsKey("WIDTH") && attribs.containsKey("HEIGHT")) {
       try {
-        dims = new Dimension(Integer.parseInt(attribs.get("WIDTH")), Integer.parseInt(attribs.get("HEIGHT")));
+        dims = new Dimension((int) Double.parseDouble(attribs.get("WIDTH")),
+                (int) Double.parseDouble(attribs.get("HEIGHT")));
       } catch (NumberFormatException e) {
         // NOP, we're only interested in integer dimensions
       }
@@ -138,10 +139,10 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
         pageId = pages.floorEntry(m.start()).getValue().id;
       }
       Map<String, String> attribs = parseAttribs(m.group("attribs"));
-      int x = Integer.parseInt(attribs.get("HPOS"));
-      int y = Integer.parseInt(attribs.get("VPOS"));
-      int w = Integer.parseInt(attribs.get("WIDTH"));
-      int h = Integer.parseInt(attribs.get("HEIGHT"));
+      int x = (int) Double.parseDouble(attribs.get("HPOS"));
+      int y = (int) Double.parseDouble(attribs.get("VPOS"));
+      int w = (int) Double.parseDouble(attribs.get("WIDTH"));
+      int h = (int) Double.parseDouble(attribs.get("HEIGHT"));
       String subsType = attribs.get("SUBS_TYPE");
       String text = StringEscapeUtils.unescapeXml(attribs.get("CONTENT"));
       if ("HypPart1".equals(subsType)) {

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -21,6 +21,8 @@ public class AltoTest extends SolrTestCaseJ4 {
     assertU(adoc("ocr_text", ocrPath.toString(), "id", "42"));
     ocrPath = Paths.get("src/test/resources/data/bnl_lunion_1865-04-15.xml");
     assertU(adoc("ocr_text", ocrPath.toString(), "id", "43"));
+    ocrPath = Paths.get("src/test/resources/data/alto_float.xml");
+    assertU(adoc("ocr_text", ocrPath.toString(), "id", "44"));
     assertU(commit());
   }
 
@@ -57,6 +59,15 @@ public class AltoTest extends SolrTestCaseJ4 {
         "//str[@name='text'][1]/text()='H.ieifics Menighed Kl. eg for Nicolai Mcniohed Kl. > > Slet. <) Sftensan« om-exler««««« boggeMenighederzNicvlaiMe- Mighed h«r »stenfang paa <em>Svadag</em> ferrkkvm»,cnde. ->) Sknf- «ewaal til Ssndagen holdes i H.geNesKirte sorNicolaiMemghch L?verda.en Kl.«, oz f»r H-geist-S Menighed Kk72. e) Bor-'",
         "//arr[@name='regions'][1]/lst/int[@name='ulx']/text()=436",
         "//arr[@name='highlights']/arr/lst[1]/int[@name='ulx']/text()=1504"
+    );
+  }
+
+  @Test
+  public void testAltoWithFloat() throws Exception {
+    SolrQueryRequest req = xmlQ("q", "mighty");
+    assertQ(req,
+            "count(//lst[@name='ocrHighlighting']/lst[@name='44']/lst[@name='ocr_text']/arr/lst)=1",
+            "//arr[@name='highlights']/arr/lst[1]/int[@name='ulx']/text()=524"
     );
   }
 

--- a/src/test/resources/data/alto_float.xml
+++ b/src/test/resources/data/alto_float.xml
@@ -1,0 +1,1236 @@
+<alto xmlns="http://schema.ccs-gmbh.com/ALTO">
+    <Description>
+        <MeasurementUnit>inch1200</MeasurementUnit>
+        <sourceImageInformation>
+            <fileName>/mnt/ra.iarchives.com/data01/jobq/root/projects/production/newspaper/Willamette_University/2013/Collegian/Phase_007/TWUA_1960-1962/ocr/Img0027a.tif</fileName>
+        </sourceImageInformation>
+        <OCRProcessing ID="OCR.0">
+            <ocrProcessingStep>
+                <processingStepSettings>abbyy9.version:9.0.0.7394-3Abbyy9.cache-check.image-CRC:b5cff916920d600208fc98ba25e29f6bLang:engabbyy9.option.ocr-auto-pictures:trueConf.SPead:1Dictionary Words:500Node Count:533Option Count:533abbyy9.option.analyze-manual-zones:falsePredicted Word Accuracy:100%Abbyy9.cache-check.base-page-CRC:b918039ec4d34ffe4f81acba41d90d00source-image:/mnt/ra.iarchives.com/data01/jobq/root/projects/production/newspaper/Willamette_University/2013/Collegian/Phase_007/TWUA_1960-1962/ocr/Img0027a.tifAbbyy9.cache-check.wrapper-version:1.3Inverted:falseEngine:Abbyy9Conf:1abbyy9.option.analyze-zones:trueCharacter Count:2687abbyy9.option.hyphenation:trueSuspicious Character Count:108Word Count:533width:2880height:3854xdpi:300ydpi:300</processingStepSettings>
+                <processingSoftware>
+                    <softwareCreator>iArchives</softwareCreator>
+                    <softwareName>iArchives OCR Framework</softwareName>
+                    <softwareVersion>Multiple</softwareVersion>
+                </processingSoftware>
+            </ocrProcessingStep>
+        </OCRProcessing>
+    </Description>
+    <Styles>
+        <TextStyle ID="TS_10.0_I" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="10.0" FONTSTYLE="italics"/>
+        <TextStyle ID="TS_10.0" FONTSIZE="10.0"/>
+        <TextStyle ID="TS_10.0_M" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="10.0" FONTSTYLE="smallcaps"/>
+        <TextStyle ID="TS_10.0_P" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="10.0" FONTSTYLE="superscript"/>
+    </Styles>
+    <Layout>
+        <Page ID="PAGE.4" HEIGHT="15416" WIDTH="11520" PHYSICAL_IMG_NR="48" PRINTED_IMG_NR="4" PROCESSING="OCR.0" PC="1.0">
+            <PrintSpace ID="PS.0" HEIGHT="15416.0" WIDTH="11520.0" HPOS="0.0" VPOS="0.0">
+                <TextBlock xmlns:ns1="http://www.w3.org/1999/xlink" ID="TB.Img0027a.1" HEIGHT="212" WIDTH="152" HPOS="152" VPOS="8472" ns1:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.1_0" HEIGHT="212.0" WIDTH="152.0" HPOS="152.0" VPOS="8472.0">
+                        <String ID="TB.Img0027a.1_0_0" STYLEREFS="TS_10.0_I" HEIGHT="212.0" WIDTH="152.0" HPOS="152.0" VPOS="8472.0" CONTENT="it" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns2="http://www.w3.org/1999/xlink" ID="TB.Img0027a.2" HEIGHT="536" WIDTH="936" HPOS="2212" VPOS="2580" ns2:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.2_0" HEIGHT="188.0" WIDTH="104.0" HPOS="3044.0" VPOS="2580.0">
+                        <String ID="TB.Img0027a.2_0_0" STYLEREFS="TS_10.0" HEIGHT="40.0" WIDTH="32.0" HPOS="3044.0" VPOS="2728.0" CONTENT="." WC="1.0"/>
+                        <SP WIDTH="44.0" HPOS="3076.0" VPOS="2580.0"/>
+                        <String ID="TB.Img0027a.2_0_1" STYLEREFS="TS_10.0" HEIGHT="32.0" WIDTH="28.0" HPOS="3120.0" VPOS="2580.0" CONTENT="'" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.2_1" HEIGHT="124.0" WIDTH="704.0" HPOS="2212.0" VPOS="2752.0">
+                        <String ID="TB.Img0027a.2_1_0" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="72.0" HPOS="2212.0" VPOS="2788.0" CONTENT="III" WC="1.0"/>
+                        <SP WIDTH="52.0" HPOS="2284.0" VPOS="2752.0"/>
+                        <String ID="TB.Img0027a.2_1_1" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="100.0" HPOS="2336.0" VPOS="2776.0" CONTENT="III" WC="1.0"/>
+                        <SP WIDTH="64.0" HPOS="2436.0" VPOS="2752.0"/>
+                        <String ID="TB.Img0027a.2_1_2" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="128.0" HPOS="2500.0" VPOS="2760.0" CONTENT="III" WC="1.0"/>
+                        <SP WIDTH="68.0" HPOS="2628.0" VPOS="2752.0"/>
+                        <String ID="TB.Img0027a.2_1_3" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="132.0" HPOS="2696.0" VPOS="2752.0" CONTENT="III" WC="1.0"/>
+                        <SP WIDTH="48.0" HPOS="2828.0" VPOS="2752.0"/>
+                        <String ID="TB.Img0027a.2_1_4" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="40.0" HPOS="2876.0" VPOS="2752.0" CONTENT="I" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.2_2" HEIGHT="176.0" WIDTH="748.0" HPOS="2332.0" VPOS="2800.0">
+                        <String ID="TB.Img0027a.2_2_0" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="100.0" HPOS="2332.0" VPOS="2860.0" CONTENT="III" WC="1.0"/>
+                        <SP WIDTH="64.0" HPOS="2432.0" VPOS="2800.0"/>
+                        <String ID="TB.Img0027a.2_2_1" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="128.0" HPOS="2496.0" VPOS="2856.0" CONTENT="III" WC="1.0"/>
+                        <SP WIDTH="68.0" HPOS="2624.0" VPOS="2800.0"/>
+                        <String ID="TB.Img0027a.2_2_2" STYLEREFS="TS_10.0" HEIGHT="104.0" WIDTH="132.0" HPOS="2692.0" VPOS="2848.0" CONTENT="III" WC="1.0"/>
+                        <SP WIDTH="52.0" HPOS="2824.0" VPOS="2800.0"/>
+                        <String ID="TB.Img0027a.2_2_3" STYLEREFS="TS_10.0" HEIGHT="156.0" WIDTH="40.0" HPOS="2876.0" VPOS="2800.0" CONTENT="I" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="2916.0" VPOS="2800.0"/>
+                        <String ID="TB.Img0027a.2_2_4" STYLEREFS="TS_10.0" HEIGHT="72.0" WIDTH="16.0" HPOS="3064.0" VPOS="2868.0" CONTENT=":" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.2_3" HEIGHT="204.0" WIDTH="744.0" HPOS="2328.0" VPOS="2912.0">
+                        <String ID="TB.Img0027a.2_3_0" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="100.0" HPOS="2328.0" VPOS="2980.0" CONTENT="III" WC="1.0"/>
+                        <SP WIDTH="64.0" HPOS="2428.0" VPOS="2912.0"/>
+                        <String ID="TB.Img0027a.2_3_1" STYLEREFS="TS_10.0" HEIGHT="104.0" WIDTH="128.0" HPOS="2492.0" VPOS="2976.0" CONTENT="HI" WC="1.0"/>
+                        <SP WIDTH="68.0" HPOS="2620.0" VPOS="2912.0"/>
+                        <String ID="TB.Img0027a.2_3_2" STYLEREFS="TS_10.0" HEIGHT="112.0" WIDTH="132.0" HPOS="2688.0" VPOS="2968.0" CONTENT="HI" WC="1.0"/>
+                        <SP WIDTH="48.0" HPOS="2820.0" VPOS="2912.0"/>
+                        <String ID="TB.Img0027a.2_3_3" STYLEREFS="TS_10.0_I" HEIGHT="204.0" WIDTH="100.0" HPOS="2868.0" VPOS="2912.0" CONTENT="I" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="2968.0" VPOS="2912.0"/>
+                        <String ID="TB.Img0027a.2_3_4" STYLEREFS="TS_10.0_I" HEIGHT="16.0" WIDTH="24.0" HPOS="3048.0" VPOS="3048.0" CONTENT="-" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns3="http://www.w3.org/1999/xlink" ID="TB.Img0027a.3" HEIGHT="4984" WIDTH="3144" HPOS="1176" VPOS="4272" ns3:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.3_0" HEIGHT="168.0" WIDTH="1836.0" HPOS="1216.0" VPOS="4272.0">
+                        <String ID="TB.Img0027a.3_0_0" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="456.0" HPOS="1216.0" VPOS="4272.0" CONTENT="Men's" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="1672.0" VPOS="4272.0"/>
+                        <String ID="TB.Img0027a.3_0_1" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="788.0" HPOS="1780.0" VPOS="4272.0" CONTENT="Dormitory" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="2568.0" VPOS="4272.0"/>
+                        <String ID="TB.Img0027a.3_0_2" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="376.0" HPOS="2676.0" VPOS="4276.0" CONTENT="Rises" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_1" HEIGHT="172.0" WIDTH="2920.0" HPOS="1400.0" VPOS="4532.0">
+                        <String ID="TB.Img0027a.3_1_0" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="220.0" HPOS="1400.0" VPOS="4540.0" CONTENT="It's" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="1620.0" VPOS="4532.0"/>
+                        <String ID="TB.Img0027a.3_1_1" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="524.0" HPOS="1732.0" VPOS="4532.0" CONTENT="mighty" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="2256.0" VPOS="4532.0"/>
+                        <String ID="TB.Img0027a.3_1_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="616.0" HPOS="2368.0" VPOS="4536.0" CONTENT="difficult" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="2984.0" VPOS="4532.0"/>
+                        <String ID="TB.Img0027a.3_1_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="3100.0" VPOS="4536.0" CONTENT="for" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="3316.0" VPOS="4532.0"/>
+                        <String ID="TB.Img0027a.3_1_4" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="240.0" HPOS="3420.0" VPOS="4592.0" CONTENT="one" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="3660.0" VPOS="4532.0"/>
+                        <String ID="TB.Img0027a.3_1_5" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="296.0" HPOS="3772.0" VPOS="4592.0" CONTENT="now" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="4068.0" VPOS="4532.0"/>
+                        <String ID="TB.Img0027a.3_1_6" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="132.0" HPOS="4188.0" VPOS="4580.0" CONTENT="to" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_2" HEIGHT="136.0" WIDTH="3108.0" HPOS="1212.0" VPOS="4724.0">
+                        <String ID="TB.Img0027a.3_2_0" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="612.0" HPOS="1212.0" VPOS="4724.0" CONTENT="visualize" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="1824.0" VPOS="4724.0"/>
+                        <String ID="TB.Img0027a.3_2_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="292.0" HPOS="1908.0" VPOS="4724.0" CONTENT="how" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="2200.0" VPOS="4724.0"/>
+                        <String ID="TB.Img0027a.3_2_2" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="212.0" HPOS="2292.0" VPOS="4728.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="2504.0" VPOS="4724.0"/>
+                        <String ID="TB.Img0027a.3_2_3" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="316.0" HPOS="2584.0" VPOS="4736.0" CONTENT="mire" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="2900.0" VPOS="4724.0"/>
+                        <String ID="TB.Img0027a.3_2_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="148.0" HPOS="2980.0" VPOS="4732.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="3128.0" VPOS="4724.0"/>
+                        <String ID="TB.Img0027a.3_2_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="3216.0" VPOS="4728.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="3432.0" VPOS="4724.0"/>
+                        <String ID="TB.Img0027a.3_2_6" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="812.0" HPOS="3508.0" VPOS="4728.0" CONTENT="Willamette" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_3" HEIGHT="172.0" WIDTH="3108.0" HPOS="1208.0" VPOS="4920.0">
+                        <String ID="TB.Img0027a.3_3_0" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="776.0" HPOS="1208.0" VPOS="4920.0" CONTENT="University" WC="1.0"/>
+                        <SP WIDTH="144.0" HPOS="1984.0" VPOS="4920.0"/>
+                        <String ID="TB.Img0027a.3_3_1" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="536.0" HPOS="2128.0" VPOS="4968.0" CONTENT="campus" WC="1.0"/>
+                        <SP WIDTH="144.0" HPOS="2664.0" VPOS="4920.0"/>
+                        <String ID="TB.Img0027a.3_3_2" STYLEREFS="TS_10.0" HEIGHT="72.0" WIDTH="276.0" HPOS="2808.0" VPOS="4976.0" CONTENT="area" WC="1.0"/>
+                        <SP WIDTH="136.0" HPOS="3084.0" VPOS="4920.0"/>
+                        <String ID="TB.Img0027a.3_3_3" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="276.0" HPOS="3220.0" VPOS="4928.0" CONTENT="just" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="3496.0" VPOS="4920.0"/>
+                        <String ID="TB.Img0027a.3_3_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="396.0" HPOS="3636.0" VPOS="4920.0" CONTENT="north" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="4032.0" VPOS="4920.0"/>
+                        <String ID="TB.Img0027a.3_3_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="144.0" HPOS="4172.0" VPOS="4920.0" CONTENT="of" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_4" HEIGHT="144.0" WIDTH="3104.0" HPOS="1208.0" VPOS="5100.0">
+                        <String ID="TB.Img0027a.3_4_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="216.0" HPOS="1208.0" VPOS="5100.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="1424.0" VPOS="5100.0"/>
+                        <String ID="TB.Img0027a.3_4_1" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="604.0" HPOS="1576.0" VPOS="5108.0" CONTENT="Twelfth" WC="1.0"/>
+                        <SP WIDTH="156.0" HPOS="2180.0" VPOS="5100.0"/>
+                        <String ID="TB.Img0027a.3_4_2" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="248.0" HPOS="2336.0" VPOS="5112.0" CONTENT="and" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="2584.0" VPOS="5100.0"/>
+                        <String ID="TB.Img0027a.3_4_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="420.0" HPOS="2736.0" VPOS="5112.0" CONTENT="Trade" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="3156.0" VPOS="5100.0"/>
+                        <String ID="TB.Img0027a.3_4_4" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="452.0" HPOS="3308.0" VPOS="5156.0" CONTENT="streets" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="3760.0" VPOS="5100.0"/>
+                        <String ID="TB.Img0027a.3_4_5" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="340.0" HPOS="3908.0" VPOS="5124.0" CONTENT="inter" SUBS_TYPE="HypPart1" SUBS_CONTENT="intersection" WC="1.0"/>
+                        <HYP WIDTH="48.0" HPOS="4264.0" VPOS="5200.0" CONTENT="-"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_5" HEIGHT="176.0" WIDTH="2520.0" HPOS="1796.0" VPOS="5296.0">
+                        <String ID="TB.Img0027a.3_5_0" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="492.0" HPOS="1208.0" VPOS="5304.0" CONTENT="section" SUBS_TYPE="HypPart2" SUBS_CONTENT="intersection" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="1700.0" VPOS="5296.0"/>
+                        <String ID="TB.Img0027a.3_5_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="264.0" HPOS="1796.0" VPOS="5296.0" CONTENT="will" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="2060.0" VPOS="5296.0"/>
+                        <String ID="TB.Img0027a.3_5_2" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="236.0" HPOS="2148.0" VPOS="5352.0" CONTENT="one" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="2384.0" VPOS="5296.0"/>
+                        <String ID="TB.Img0027a.3_5_3" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="244.0" HPOS="2480.0" VPOS="5300.0" CONTENT="day" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="2724.0" VPOS="5296.0"/>
+                        <String ID="TB.Img0027a.3_5_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="144.0" HPOS="2820.0" VPOS="5304.0" CONTENT="be" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="2964.0" VPOS="5296.0"/>
+                        <String ID="TB.Img0027a.3_5_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="884.0" HPOS="3060.0" VPOS="5304.0" CONTENT="transformed" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="3944.0" VPOS="5296.0"/>
+                        <String ID="TB.Img0027a.3_5_6" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="284.0" HPOS="4032.0" VPOS="5312.0" CONTENT="into" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_6" HEIGHT="184.0" WIDTH="3112.0" HPOS="1204.0" VPOS="5484.0">
+                        <String ID="TB.Img0027a.3_6_0" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="60.0" HPOS="1204.0" VPOS="5540.0" CONTENT="a" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="1264.0" VPOS="5484.0"/>
+                        <String ID="TB.Img0027a.3_6_1" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="804.0" HPOS="1352.0" VPOS="5484.0" CONTENT="beautifully" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="2156.0" VPOS="5484.0"/>
+                        <String ID="TB.Img0027a.3_6_2" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="772.0" HPOS="2244.0" VPOS="5488.0" CONTENT="landscaped" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="3016.0" VPOS="5484.0"/>
+                        <String ID="TB.Img0027a.3_6_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="344.0" HPOS="3108.0" VPOS="5492.0" CONTENT="lawn" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="3452.0" VPOS="5484.0"/>
+                        <String ID="TB.Img0027a.3_6_4" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="508.0" HPOS="3544.0" VPOS="5496.0" CONTENT="leading" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="4052.0" VPOS="5484.0"/>
+                        <String ID="TB.Img0027a.3_6_5" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="180.0" HPOS="4136.0" VPOS="5552.0" CONTENT="up" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_7" HEIGHT="136.0" WIDTH="3104.0" HPOS="1208.0" VPOS="5684.0">
+                        <String ID="TB.Img0027a.3_7_0" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="136.0" HPOS="1208.0" VPOS="5720.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="1344.0" VPOS="5684.0"/>
+                        <String ID="TB.Img0027a.3_7_1" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="152.0" HPOS="1496.0" VPOS="5732.0" CONTENT="an" WC="1.0"/>
+                        <SP WIDTH="160.0" HPOS="1648.0" VPOS="5684.0"/>
+                        <String ID="TB.Img0027a.3_7_2" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="708.0" HPOS="1808.0" VPOS="5692.0" CONTENT="attractive" WC="1.0"/>
+                        <SP WIDTH="156.0" HPOS="2516.0" VPOS="5684.0"/>
+                        <String ID="TB.Img0027a.3_7_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="836.0" HPOS="2672.0" VPOS="5684.0" CONTENT="brick-faced" WC="1.0"/>
+                        <SP WIDTH="160.0" HPOS="3508.0" VPOS="5684.0"/>
+                        <String ID="TB.Img0027a.3_7_4" STYLEREFS="TS_10.0" HEIGHT="112.0" WIDTH="644.0" HPOS="3668.0" VPOS="5708.0" CONTENT="240-man" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_8" HEIGHT="172.0" WIDTH="2840.0" HPOS="1200.0" VPOS="5868.0">
+                        <String ID="TB.Img0027a.3_8_0" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="776.0" HPOS="1200.0" VPOS="5868.0" CONTENT="dormitory." WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="1976.0" VPOS="5868.0"/>
+                        <String ID="TB.Img0027a.3_8_1" STYLEREFS="TS_10.0" HEIGHT="144.0" WIDTH="304.0" HPOS="2076.0" VPOS="5884.0" CONTENT="But," WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="2380.0" VPOS="5868.0"/>
+                        <String ID="TB.Img0027a.3_8_2" STYLEREFS="TS_10.0" HEIGHT="84.0" WIDTH="252.0" HPOS="2480.0" VPOS="5920.0" CONTENT="rest" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="2732.0" VPOS="5868.0"/>
+                        <String ID="TB.Img0027a.3_8_3" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="504.0" HPOS="2828.0" VPOS="5880.0" CONTENT="assured" WC="1.0"/>
+                        <SP WIDTH="200.0" HPOS="3332.0" VPOS="5868.0"/>
+                        <String ID="TB.Img0027a.3_8_4" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="104.0" HPOS="3532.0" VPOS="5884.0" CONTENT="it" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="3636.0" VPOS="5868.0"/>
+                        <String ID="TB.Img0027a.3_8_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="312.0" HPOS="3728.0" VPOS="5880.0" CONTENT="will." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_9" HEIGHT="176.0" WIDTH="2928.0" HPOS="1384.0" VPOS="6136.0">
+                        <String ID="TB.Img0027a.3_9_0" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="772.0" HPOS="1384.0" VPOS="6136.0" CONTENT="According" WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="2156.0" VPOS="6136.0"/>
+                        <String ID="TB.Img0027a.3_9_1" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="140.0" HPOS="2280.0" VPOS="6180.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="2420.0" VPOS="6136.0"/>
+                        <String ID="TB.Img0027a.3_9_2" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="544.0" HPOS="2536.0" VPOS="6144.0" CONTENT="Harvey" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="3080.0" VPOS="6136.0"/>
+                        <String ID="TB.Img0027a.3_9_3" STYLEREFS="TS_10.0" HEIGHT="148.0" WIDTH="480.0" HPOS="3200.0" VPOS="6148.0" CONTENT="Pruitt," WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="3680.0" VPOS="6136.0"/>
+                        <String ID="TB.Img0027a.3_9_4" STYLEREFS="TS_10.0" HEIGHT="160.0" WIDTH="504.0" HPOS="3808.0" VPOS="6152.0" CONTENT="project" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_10" HEIGHT="168.0" WIDTH="3104.0" HPOS="1204.0" VPOS="6328.0">
+                        <String ID="TB.Img0027a.3_10_0" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="616.0" HPOS="1204.0" VPOS="6376.0" CONTENT="manager" WC="1.0"/>
+                        <SP WIDTH="180.0" HPOS="1820.0" VPOS="6328.0"/>
+                        <String ID="TB.Img0027a.3_10_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="2000.0" VPOS="6328.0" CONTENT="for" WC="1.0"/>
+                        <SP WIDTH="168.0" HPOS="2216.0" VPOS="6328.0"/>
+                        <String ID="TB.Img0027a.3_10_2" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="828.0" HPOS="2384.0" VPOS="6372.0" CONTENT="contractors" WC="1.0"/>
+                        <SP WIDTH="188.0" HPOS="3212.0" VPOS="6328.0"/>
+                        <String ID="TB.Img0027a.3_10_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="476.0" HPOS="3400.0" VPOS="6336.0" CONTENT="Viesko" WC="1.0"/>
+                        <SP WIDTH="184.0" HPOS="3876.0" VPOS="6328.0"/>
+                        <String ID="TB.Img0027a.3_10_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="248.0" HPOS="4060.0" VPOS="6336.0" CONTENT="and" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_11" HEIGHT="160.0" WIDTH="3108.0" HPOS="1200.0" VPOS="6516.0">
+                        <String ID="TB.Img0027a.3_11_0" STYLEREFS="TS_10.0" HEIGHT="148.0" WIDTH="340.0" HPOS="1200.0" VPOS="6520.0" CONTENT="Post," WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="1540.0" VPOS="6516.0"/>
+                        <String ID="TB.Img0027a.3_11_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="212.0" HPOS="1688.0" VPOS="6516.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="136.0" HPOS="1900.0" VPOS="6516.0"/>
+                        <String ID="TB.Img0027a.3_11_2" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="284.0" HPOS="2036.0" VPOS="6572.0" CONTENT="new" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="2320.0" VPOS="6516.0"/>
+                        <String ID="TB.Img0027a.3_11_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="800.0" HPOS="2472.0" VPOS="6540.0" CONTENT="$1,036,000" WC="1.0"/>
+                        <SP WIDTH="144.0" HPOS="3272.0" VPOS="6516.0"/>
+                        <String ID="TB.Img0027a.3_11_4" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="664.0" HPOS="3416.0" VPOS="6568.0" CONTENT="structure" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="4080.0" VPOS="6516.0"/>
+                        <String ID="TB.Img0027a.3_11_5" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="96.0" HPOS="4212.0" VPOS="6536.0" CONTENT="is" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_12" HEIGHT="188.0" WIDTH="3108.0" HPOS="1196.0" VPOS="6704.0">
+                        <String ID="TB.Img0027a.3_12_0" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="128.0" HPOS="1196.0" VPOS="6748.0" CONTENT="at" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="1324.0" VPOS="6704.0"/>
+                        <String ID="TB.Img0027a.3_12_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="212.0" HPOS="1476.0" VPOS="6704.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="1688.0" VPOS="6704.0"/>
+                        <String ID="TB.Img0027a.3_12_2" STYLEREFS="TS_10.0" HEIGHT="104.0" WIDTH="64.0" HPOS="1836.0" VPOS="6732.0" CONTENT="2" WC="1.0"/>
+                        <SP WIDTH="44.0" HPOS="1900.0" VPOS="6704.0"/>
+                        <String ID="TB.Img0027a.3_12_3" STYLEREFS="TS_10.0" HEIGHT="108.0" WIDTH="44.0" HPOS="1944.0" VPOS="6732.0" CONTENT="5" WC="1.0"/>
+                        <SP WIDTH="160.0" HPOS="1988.0" VPOS="6704.0"/>
+                        <String ID="TB.Img0027a.3_12_4" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="220.0" HPOS="2148.0" VPOS="6764.0" CONTENT="per" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="2368.0" VPOS="6704.0"/>
+                        <String ID="TB.Img0027a.3_12_5" STYLEREFS="TS_10.0" HEIGHT="84.0" WIDTH="296.0" HPOS="2516.0" VPOS="6756.0" CONTENT="cent" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="2812.0" VPOS="6704.0"/>
+                        <String ID="TB.Img0027a.3_12_6" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="800.0" HPOS="2964.0" VPOS="6712.0" CONTENT="completion" WC="1.0"/>
+                        <SP WIDTH="144.0" HPOS="3764.0" VPOS="6704.0"/>
+                        <String ID="TB.Img0027a.3_12_7" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="396.0" HPOS="3908.0" VPOS="6760.0" CONTENT="stage," WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_13" HEIGHT="180.0" WIDTH="3112.0" HPOS="1192.0" VPOS="6896.0">
+                        <String ID="TB.Img0027a.3_13_0" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="332.0" HPOS="1192.0" VPOS="6896.0" CONTENT="with" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="1524.0" VPOS="6896.0"/>
+                        <String ID="TB.Img0027a.3_13_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="368.0" HPOS="1640.0" VPOS="6900.0" CONTENT="work" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="2008.0" VPOS="6896.0"/>
+                        <String ID="TB.Img0027a.3_13_2" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="580.0" HPOS="2128.0" VPOS="6912.0" CONTENT="running" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="2708.0" VPOS="6896.0"/>
+                        <String ID="TB.Img0027a.3_13_3" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="444.0" HPOS="2824.0" VPOS="6904.0" CONTENT="nearly" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="3268.0" VPOS="6896.0"/>
+                        <String ID="TB.Img0027a.3_13_4" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="168.0" HPOS="3384.0" VPOS="6960.0" CONTENT="on" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="3552.0" VPOS="6896.0"/>
+                        <String ID="TB.Img0027a.3_13_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="640.0" HPOS="3664.0" VPOS="6908.0" CONTENT="schedule." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_14" HEIGHT="184.0" WIDTH="3112.0" HPOS="1196.0" VPOS="7088.0">
+                        <String ID="TB.Img0027a.3_14_0" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="116.0" HPOS="1196.0" VPOS="7100.0" CONTENT="A" WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="1312.0" VPOS="7088.0"/>
+                        <String ID="TB.Img0027a.3_14_1" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="400.0" HPOS="1436.0" VPOS="7088.0" CONTENT="slight" WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="1836.0" VPOS="7088.0"/>
+                        <String ID="TB.Img0027a.3_14_2" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="368.0" HPOS="1960.0" VPOS="7088.0" CONTENT="delay" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="2328.0" VPOS="7088.0"/>
+                        <String ID="TB.Img0027a.3_14_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="2448.0" VPOS="7092.0" CONTENT="has" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="2664.0" VPOS="7088.0"/>
+                        <String ID="TB.Img0027a.3_14_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="312.0" HPOS="2792.0" VPOS="7096.0" CONTENT="been" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="3104.0" VPOS="7088.0"/>
+                        <String ID="TB.Img0027a.3_14_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="460.0" HPOS="3232.0" VPOS="7100.0" CONTENT="caused" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="3692.0" VPOS="7088.0"/>
+                        <String ID="TB.Img0027a.3_14_6" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="168.0" HPOS="3820.0" VPOS="7104.0" CONTENT="by" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="3988.0" VPOS="7088.0"/>
+                        <String ID="TB.Img0027a.3_14_7" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="132.0" HPOS="4108.0" VPOS="7112.0" CONTENT="in" SUBS_TYPE="HypPart1" SUBS_CONTENT="inclement" WC="1.0"/>
+                        <HYP WIDTH="48.0" HPOS="4260.0" VPOS="7184.0" CONTENT="-"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_15" HEIGHT="176.0" WIDTH="2388.0" HPOS="1916.0" VPOS="7284.0">
+                        <String ID="TB.Img0027a.3_15_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="568.0" HPOS="1192.0" VPOS="7276.0" CONTENT="clement" SUBS_TYPE="HypPart2" SUBS_CONTENT="inclement" WC="1.0"/>
+                        <SP WIDTH="156.0" HPOS="1760.0" VPOS="7284.0"/>
+                        <String ID="TB.Img0027a.3_15_1" STYLEREFS="TS_10.0" HEIGHT="156.0" WIDTH="608.0" HPOS="1916.0" VPOS="7284.0" CONTENT="weather," WC="1.0"/>
+                        <SP WIDTH="156.0" HPOS="2524.0" VPOS="7284.0"/>
+                        <String ID="TB.Img0027a.3_15_2" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="436.0" HPOS="2680.0" VPOS="7296.0" CONTENT="Pruitt" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="3116.0" VPOS="7284.0"/>
+                        <String ID="TB.Img0027a.3_15_3" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="644.0" HPOS="3268.0" VPOS="7292.0" CONTENT="reported," WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="3912.0" VPOS="7284.0"/>
+                        <String ID="TB.Img0027a.3_15_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="244.0" HPOS="4060.0" VPOS="7296.0" CONTENT="but" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_16" HEIGHT="172.0" WIDTH="3112.0" HPOS="1192.0" VPOS="7472.0">
+                        <String ID="TB.Img0027a.3_16_0" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="252.0" HPOS="1192.0" VPOS="7520.0" CONTENT="any" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="1444.0" VPOS="7472.0"/>
+                        <String ID="TB.Img0027a.3_16_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="304.0" HPOS="1556.0" VPOS="7512.0" CONTENT="type" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="1860.0" VPOS="7472.0"/>
+                        <String ID="TB.Img0027a.3_16_2" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="144.0" HPOS="1964.0" VPOS="7476.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="2108.0" VPOS="7472.0"/>
+                        <String ID="TB.Img0027a.3_16_3" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="60.0" HPOS="2216.0" VPOS="7528.0" CONTENT="a" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="2276.0" VPOS="7472.0"/>
+                        <String ID="TB.Img0027a.3_16_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="388.0" HPOS="2388.0" VPOS="7472.0" CONTENT="break" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="2776.0" VPOS="7472.0"/>
+                        <String ID="TB.Img0027a.3_16_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="360.0" HPOS="2880.0" VPOS="7476.0" CONTENT="from" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="3240.0" VPOS="7472.0"/>
+                        <String ID="TB.Img0027a.3_16_6" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="3348.0" VPOS="7480.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="3564.0" VPOS="7472.0"/>
+                        <String ID="TB.Img0027a.3_16_7" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="568.0" HPOS="3672.0" VPOS="7484.0" CONTENT="weather" SUBS_TYPE="HypPart1" SUBS_CONTENT="weatherman" WC="1.0"/>
+                        <HYP WIDTH="48.0" HPOS="4256.0" VPOS="7568.0" CONTENT="-"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_17" HEIGHT="148.0" WIDTH="2688.0" HPOS="1620.0" VPOS="7660.0">
+                        <String ID="TB.Img0027a.3_17_0" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="300.0" HPOS="1192.0" VPOS="7716.0" CONTENT="man" SUBS_TYPE="HypPart2" SUBS_CONTENT="weatherman" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="1492.0" VPOS="7660.0"/>
+                        <String ID="TB.Img0027a.3_17_1" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="264.0" HPOS="1620.0" VPOS="7664.0" CONTENT="will" WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="1884.0" VPOS="7660.0"/>
+                        <String ID="TB.Img0027a.3_17_2" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="188.0" HPOS="2008.0" VPOS="7720.0" CONTENT="sec" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="2196.0" VPOS="7660.0"/>
+                        <String ID="TB.Img0027a.3_17_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="216.0" HPOS="2324.0" VPOS="7660.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="2540.0" VPOS="7660.0"/>
+                        <String ID="TB.Img0027a.3_17_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="924.0" HPOS="2660.0" VPOS="7676.0" CONTENT="construction" WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="3584.0" VPOS="7660.0"/>
+                        <String ID="TB.Img0027a.3_17_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="600.0" HPOS="3708.0" VPOS="7672.0" CONTENT="schedule" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_18" HEIGHT="184.0" WIDTH="3112.0" HPOS="1192.0" VPOS="7852.0">
+                        <String ID="TB.Img0027a.3_18_0" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="328.0" HPOS="1192.0" VPOS="7852.0" CONTENT="back" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="1520.0" VPOS="7852.0"/>
+                        <String ID="TB.Img0027a.3_18_1" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="168.0" HPOS="1620.0" VPOS="7908.0" CONTENT="on" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="1788.0" VPOS="7852.0"/>
+                        <String ID="TB.Img0027a.3_18_2" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="316.0" HPOS="1888.0" VPOS="7864.0" CONTENT="time" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="2204.0" VPOS="7852.0"/>
+                        <String ID="TB.Img0027a.3_18_3" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="136.0" HPOS="2300.0" VPOS="7912.0" CONTENT="so" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="2436.0" VPOS="7852.0"/>
+                        <String ID="TB.Img0027a.3_18_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="292.0" HPOS="2532.0" VPOS="7856.0" CONTENT="that" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="2824.0" VPOS="7852.0"/>
+                        <String ID="TB.Img0027a.3_18_5" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="780.0" HPOS="2920.0" VPOS="7912.0" CONTENT="occupancy" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="3700.0" VPOS="7852.0"/>
+                        <String ID="TB.Img0027a.3_18_6" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="164.0" HPOS="3800.0" VPOS="7868.0" CONTENT="by" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="3964.0" VPOS="7852.0"/>
+                        <String ID="TB.Img0027a.3_18_7" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="236.0" HPOS="4068.0" VPOS="7868.0" CONTENT="fall" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_19" HEIGHT="136.0" WIDTH="1968.0" HPOS="1188.0" VPOS="8048.0">
+                        <String ID="TB.Img0027a.3_19_0" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="600.0" HPOS="1188.0" VPOS="8088.0" CONTENT="semester" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="1788.0" VPOS="8048.0"/>
+                        <String ID="TB.Img0027a.3_19_1" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="272.0" HPOS="1904.0" VPOS="8048.0" CONTENT="will" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="2176.0" VPOS="8048.0"/>
+                        <String ID="TB.Img0027a.3_19_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="144.0" HPOS="2304.0" VPOS="8048.0" CONTENT="be" WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="2448.0" VPOS="8048.0"/>
+                        <String ID="TB.Img0027a.3_19_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="584.0" HPOS="2572.0" VPOS="8048.0" CONTENT="realized." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_20" HEIGHT="176.0" WIDTH="2932.0" HPOS="1368.0" VPOS="8308.0">
+                        <String ID="TB.Img0027a.3_20_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="556.0" HPOS="1368.0" VPOS="8308.0" CONTENT="Ground" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="1924.0" VPOS="8308.0"/>
+                        <String ID="TB.Img0027a.3_20_1" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="260.0" HPOS="2020.0" VPOS="8364.0" CONTENT="was" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="2280.0" VPOS="8308.0"/>
+                        <String ID="TB.Img0027a.3_20_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="496.0" HPOS="2372.0" VPOS="8308.0" CONTENT="broken" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="2868.0" VPOS="8308.0"/>
+                        <String ID="TB.Img0027a.3_20_3" STYLEREFS="TS_10.0" HEIGHT="156.0" WIDTH="536.0" HPOS="2960.0" VPOS="8328.0" CONTENT="August" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="3496.0" VPOS="8308.0"/>
+                        <String ID="TB.Img0027a.3_20_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="208.0" HPOS="3596.0" VPOS="8336.0" CONTENT="23," WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="3804.0" VPOS="8308.0"/>
+                        <String ID="TB.Img0027a.3_20_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="376.0" HPOS="3924.0" VPOS="8340.0" CONTENT="1960," WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_21" HEIGHT="152.0" WIDTH="3120.0" HPOS="1180.0" VPOS="8492.0">
+                        <String ID="TB.Img0027a.3_21_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="380.0" HPOS="1180.0" VPOS="8492.0" CONTENT="when" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="1560.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.3_21_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="1652.0" VPOS="8496.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="1868.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.3_21_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="756.0" HPOS="1964.0" VPOS="8500.0" CONTENT="traditional" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="2720.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.3_21_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="388.0" HPOS="2816.0" VPOS="8504.0" CONTENT="silver" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="3204.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.3_21_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="444.0" HPOS="3288.0" VPOS="8508.0" CONTENT="shovel" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="3732.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.3_21_5" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="472.0" HPOS="3828.0" VPOS="8516.0" CONTENT="turned" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_22" HEIGHT="180.0" WIDTH="3112.0" HPOS="1184.0" VPOS="8684.0">
+                        <String ID="TB.Img0027a.3_22_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="1184.0" VPOS="8684.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="1400.0" VPOS="8684.0"/>
+                        <String ID="TB.Img0027a.3_22_1" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="264.0" HPOS="1520.0" VPOS="8692.0" CONTENT="sod." WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="1784.0" VPOS="8684.0"/>
+                        <String ID="TB.Img0027a.3_22_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="700.0" HPOS="1916.0" VPOS="8688.0" CONTENT="Architect" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="2616.0" VPOS="8684.0"/>
+                        <String ID="TB.Img0027a.3_22_3" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="92.0" HPOS="2748.0" VPOS="8700.0" CONTENT="is" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="2840.0" VPOS="8684.0"/>
+                        <String ID="TB.Img0027a.3_22_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="516.0" HPOS="2968.0" VPOS="8696.0" CONTENT="Salem's" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="3484.0" VPOS="8684.0"/>
+                        <String ID="TB.Img0027a.3_22_5" STYLEREFS="TS_10.0" HEIGHT="156.0" WIDTH="420.0" HPOS="3612.0" VPOS="8708.0" CONTENT="James" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="4032.0" VPOS="8684.0"/>
+                        <String ID="TB.Img0027a.3_22_6" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="136.0" HPOS="4160.0" VPOS="8712.0" CONTENT="L." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_23" HEIGHT="188.0" WIDTH="3120.0" HPOS="1180.0" VPOS="8880.0">
+                        <String ID="TB.Img0027a.3_23_0" STYLEREFS="TS_10.0" HEIGHT="160.0" WIDTH="464.0" HPOS="1180.0" VPOS="8884.0" CONTENT="Payne," WC="1.0"/>
+                        <SP WIDTH="72.0" HPOS="1644.0" VPOS="8880.0"/>
+                        <String ID="TB.Img0027a.3_23_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="304.0" HPOS="1716.0" VPOS="8880.0" CONTENT="who" WC="1.0"/>
+                        <SP WIDTH="64.0" HPOS="2020.0" VPOS="8880.0"/>
+                        <String ID="TB.Img0027a.3_23_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="2084.0" VPOS="8880.0" CONTENT="has" WC="1.0"/>
+                        <SP WIDTH="72.0" HPOS="2300.0" VPOS="8880.0"/>
+                        <String ID="TB.Img0027a.3_23_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="548.0" HPOS="2372.0" VPOS="8880.0" CONTENT="blended" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="2920.0" VPOS="8880.0"/>
+                        <String ID="TB.Img0027a.3_23_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="2996.0" VPOS="8888.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="72.0" HPOS="3212.0" VPOS="8880.0"/>
+                        <String ID="TB.Img0027a.3_23_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="1016.0" HPOS="3284.0" VPOS="8936.0" CONTENT="contemporary" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.3_24" HEIGHT="188.0" WIDTH="3120.0" HPOS="1176.0" VPOS="9068.0">
+                        <String ID="TB.Img0027a.3_24_0" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="440.0" HPOS="1176.0" VPOS="9068.0" CONTENT="design" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="1616.0" VPOS="9068.0"/>
+                        <String ID="TB.Img0027a.3_24_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="144.0" HPOS="1724.0" VPOS="9072.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="1868.0" VPOS="9068.0"/>
+                        <String ID="TB.Img0027a.3_24_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="212.0" HPOS="1976.0" VPOS="9072.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="2188.0" VPOS="9068.0"/>
+                        <String ID="TB.Img0027a.3_24_3" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="284.0" HPOS="2292.0" VPOS="9128.0" CONTENT="new" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="2576.0" VPOS="9068.0"/>
+                        <String ID="TB.Img0027a.3_24_4" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="600.0" HPOS="2688.0" VPOS="9076.0" CONTENT="building" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="3288.0" VPOS="9068.0"/>
+                        <String ID="TB.Img0027a.3_24_5" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="292.0" HPOS="3396.0" VPOS="9092.0" CONTENT="into" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="3688.0" VPOS="9068.0"/>
+                        <String ID="TB.Img0027a.3_24_6" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="512.0" HPOS="3784.0" VPOS="9132.0" CONTENT="present" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns4="http://www.w3.org/1999/xlink" ID="TB.Img0027a.4" HEIGHT="544" WIDTH="2984" HPOS="4576" VPOS="1568" ns4:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.4_0" HEIGHT="544.0" WIDTH="2984.0" HPOS="4576.0" VPOS="1568.0">
+                        <String ID="TB.Img0027a.4_0_0" STYLEREFS="TS_10.0_I" HEIGHT="520.0" WIDTH="1568.0" HPOS="4576.0" VPOS="1592.0" CONTENT="Jtom" WC="1.0"/>
+                        <SP WIDTH="424.0" HPOS="6144.0" VPOS="1568.0"/>
+                        <String ID="TB.Img0027a.4_0_1" STYLEREFS="TS_10.0_I" HEIGHT="520.0" WIDTH="992.0" HPOS="6568.0" VPOS="1568.0" CONTENT="the" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns5="http://www.w3.org/1999/xlink" ID="TB.Img0027a.5" HEIGHT="1056" WIDTH="832" HPOS="7168" VPOS="2464" ns5:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.5_0" HEIGHT="1056.0" WIDTH="832.0" HPOS="7168.0" VPOS="2464.0">
+                        <String ID="TB.Img0027a.5_0_0" STYLEREFS="TS_10.0_I" HEIGHT="1056.0" WIDTH="832.0" HPOS="7168.0" VPOS="2464.0" CONTENT="z" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns6="http://www.w3.org/1999/xlink" ID="TB.Img0027a.6" HEIGHT="5336" WIDTH="3096" HPOS="4536" VPOS="3960" ns6:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.6_0" HEIGHT="180.0" WIDTH="3064.0" HPOS="4568.0" VPOS="3960.0">
+                        <String ID="TB.Img0027a.6_0_0" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="528.0" HPOS="4568.0" VPOS="4020.0" CONTENT="campus" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="5096.0" VPOS="3960.0"/>
+                        <String ID="TB.Img0027a.6_0_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="912.0" HPOS="5244.0" VPOS="3964.0" CONTENT="architecture." WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="6156.0" VPOS="3960.0"/>
+                        <String ID="TB.Img0027a.6_0_2" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="120.0" HPOS="6304.0" VPOS="3976.0" CONTENT="A" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="6424.0" VPOS="3960.0"/>
+                        <String ID="TB.Img0027a.6_0_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="552.0" HPOS="6576.0" VPOS="3960.0" CONTENT="circular" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="7128.0" VPOS="3960.0"/>
+                        <String ID="TB.Img0027a.6_0_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="356.0" HPOS="7276.0" VPOS="3960.0" CONTENT="drive" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_1" HEIGHT="176.0" WIDTH="3068.0" HPOS="4564.0" VPOS="4156.0">
+                        <String ID="TB.Img0027a.6_1_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="248.0" HPOS="4564.0" VPOS="4160.0" CONTENT="and" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="4812.0" VPOS="4156.0"/>
+                        <String ID="TB.Img0027a.6_1_1" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="552.0" HPOS="4920.0" VPOS="4160.0" CONTENT="parking" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="5472.0" VPOS="4156.0"/>
+                        <String ID="TB.Img0027a.6_1_2" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="272.0" HPOS="5584.0" VPOS="4208.0" CONTENT="area" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="5856.0" VPOS="4156.0"/>
+                        <String ID="TB.Img0027a.6_1_3" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="196.0" HPOS="5972.0" VPOS="4208.0" CONTENT="are" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="6168.0" VPOS="4156.0"/>
+                        <String ID="TB.Img0027a.6_1_4" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="140.0" HPOS="6284.0" VPOS="4200.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="6424.0" VPOS="4156.0"/>
+                        <String ID="TB.Img0027a.6_1_5" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="144.0" HPOS="6532.0" VPOS="4160.0" CONTENT="be" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="6676.0" VPOS="4156.0"/>
+                        <String ID="TB.Img0027a.6_1_6" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="844.0" HPOS="6788.0" VPOS="4156.0" CONTENT="constructed" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_2" HEIGHT="176.0" WIDTH="3060.0" HPOS="4564.0" VPOS="4348.0">
+                        <String ID="TB.Img0027a.6_2_0" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="596.0" HPOS="4564.0" VPOS="4352.0" CONTENT="adjacent" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="5160.0" VPOS="4348.0"/>
+                        <String ID="TB.Img0027a.6_2_1" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="136.0" HPOS="5240.0" VPOS="4396.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="5376.0" VPOS="4348.0"/>
+                        <String ID="TB.Img0027a.6_2_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="216.0" HPOS="5452.0" VPOS="4348.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="5668.0" VPOS="4348.0"/>
+                        <String ID="TB.Img0027a.6_2_3" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="688.0" HPOS="5748.0" VPOS="4348.0" CONTENT="H-shaped" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="6436.0" VPOS="4348.0"/>
+                        <String ID="TB.Img0027a.6_2_4" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="408.0" HPOS="6516.0" VPOS="4348.0" CONTENT="living" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="6924.0" VPOS="4348.0"/>
+                        <String ID="TB.Img0027a.6_2_5" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="620.0" HPOS="7004.0" VPOS="4392.0" CONTENT="quarters." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_3" HEIGHT="176.0" WIDTH="2884.0" HPOS="4740.0" VPOS="4612.0">
+                        <String ID="TB.Img0027a.6_3_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="272.0" HPOS="4740.0" VPOS="4616.0" CONTENT="The" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="5012.0" VPOS="4612.0"/>
+                        <String ID="TB.Img0027a.6_3_1" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="592.0" HPOS="5112.0" VPOS="4612.0" CONTENT="building" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="5704.0" VPOS="4612.0"/>
+                        <String ID="TB.Img0027a.6_3_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="268.0" HPOS="5804.0" VPOS="4612.0" CONTENT="will" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="6072.0" VPOS="4612.0"/>
+                        <String ID="TB.Img0027a.6_3_3" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="528.0" HPOS="6172.0" VPOS="4624.0" CONTENT="contain" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="6700.0" VPOS="4612.0"/>
+                        <String ID="TB.Img0027a.6_3_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="272.0" HPOS="6800.0" VPOS="4612.0" CONTENT="five" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="7072.0" VPOS="4612.0"/>
+                        <String ID="TB.Img0027a.6_3_5" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="456.0" HPOS="7168.0" VPOS="4620.0" CONTENT="wings," WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_4" HEIGHT="180.0" WIDTH="3072.0" HPOS="4556.0" VPOS="4800.0">
+                        <String ID="TB.Img0027a.6_4_0" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="684.0" HPOS="4556.0" VPOS="4808.0" CONTENT="including" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="5240.0" VPOS="4800.0"/>
+                        <String ID="TB.Img0027a.6_4_1" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="268.0" HPOS="5348.0" VPOS="4852.0" CONTENT="two" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="5616.0" VPOS="4800.0"/>
+                        <String ID="TB.Img0027a.6_4_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="436.0" HPOS="5724.0" VPOS="4804.0" CONTENT="which" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="6160.0" VPOS="4800.0"/>
+                        <String ID="TB.Img0027a.6_4_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="268.0" HPOS="6264.0" VPOS="4804.0" CONTENT="will" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="6532.0" VPOS="4800.0"/>
+                        <String ID="TB.Img0027a.6_4_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="284.0" HPOS="6640.0" VPOS="4808.0" CONTENT="face" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="6924.0" VPOS="4800.0"/>
+                        <String ID="TB.Img0027a.6_4_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="600.0" HPOS="7028.0" VPOS="4800.0" CONTENT="Twelfth" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_5" HEIGHT="136.0" WIDTH="3072.0" HPOS="4556.0" VPOS="4996.0">
+                        <String ID="TB.Img0027a.6_5_0" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="388.0" HPOS="4556.0" VPOS="5044.0" CONTENT="street" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="4944.0" VPOS="4996.0"/>
+                        <String ID="TB.Img0027a.6_5_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="248.0" HPOS="5064.0" VPOS="5000.0" CONTENT="and" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="5312.0" VPOS="4996.0"/>
+                        <String ID="TB.Img0027a.6_5_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="392.0" HPOS="5424.0" VPOS="5000.0" CONTENT="house" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="5816.0" VPOS="4996.0"/>
+                        <String ID="TB.Img0027a.6_5_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="828.0" HPOS="5936.0" VPOS="4996.0" CONTENT="fraternities." WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="6764.0" VPOS="4996.0"/>
+                        <String ID="TB.Img0027a.6_5_4" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="120.0" HPOS="6888.0" VPOS="5012.0" CONTENT="A" WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="7008.0" VPOS="4996.0"/>
+                        <String ID="TB.Img0027a.6_5_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="496.0" HPOS="7132.0" VPOS="4996.0" CONTENT="central" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_6" HEIGHT="176.0" WIDTH="3064.0" HPOS="4560.0" VPOS="5188.0">
+                        <String ID="TB.Img0027a.6_6_0" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="352.0" HPOS="4560.0" VPOS="5200.0" CONTENT="wing" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="4912.0" VPOS="5188.0"/>
+                        <String ID="TB.Img0027a.6_6_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="268.0" HPOS="5044.0" VPOS="5192.0" CONTENT="will" WC="1.0"/>
+                        <SP WIDTH="136.0" HPOS="5312.0" VPOS="5188.0"/>
+                        <String ID="TB.Img0027a.6_6_2" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="144.0" HPOS="5448.0" VPOS="5196.0" CONTENT="be" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="5592.0" VPOS="5188.0"/>
+                        <String ID="TB.Img0027a.6_6_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="576.0" HPOS="5724.0" VPOS="5192.0" CONTENT="reserved" WC="1.0"/>
+                        <SP WIDTH="136.0" HPOS="6300.0" VPOS="5188.0"/>
+                        <String ID="TB.Img0027a.6_6_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="212.0" HPOS="6436.0" VPOS="5192.0" CONTENT="for" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="6648.0" VPOS="5188.0"/>
+                        <String ID="TB.Img0027a.6_6_5" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="404.0" HPOS="6776.0" VPOS="5244.0" CONTENT="upper" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="7180.0" VPOS="5188.0"/>
+                        <String ID="TB.Img0027a.6_6_6" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="312.0" HPOS="7312.0" VPOS="5188.0" CONTENT="class" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_7" HEIGHT="176.0" WIDTH="3068.0" HPOS="4556.0" VPOS="5384.0">
+                        <String ID="TB.Img0027a.6_7_0" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="336.0" HPOS="4556.0" VPOS="5440.0" CONTENT="men," WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="4892.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.6_7_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="332.0" HPOS="4988.0" VPOS="5384.0" CONTENT="with" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="5320.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.6_7_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="212.0" HPOS="5416.0" VPOS="5384.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="5628.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.6_7_3" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="716.0" HPOS="5724.0" VPOS="5392.0" CONTENT="remaining" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="6440.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.6_7_4" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="268.0" HPOS="6540.0" VPOS="5428.0" CONTENT="two" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="6808.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.6_7_5" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="412.0" HPOS="6904.0" VPOS="5392.0" CONTENT="wings" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="7316.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.6_7_6" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="216.0" HPOS="7408.0" VPOS="5384.0" CONTENT="for" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_8" HEIGHT="176.0" WIDTH="3072.0" HPOS="4556.0" VPOS="5576.0">
+                        <String ID="TB.Img0027a.6_8_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="692.0" HPOS="4556.0" VPOS="5576.0" CONTENT="freshmen." WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="5248.0" VPOS="5576.0"/>
+                        <String ID="TB.Img0027a.6_8_1" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="740.0" HPOS="5352.0" VPOS="5584.0" CONTENT="Fraternity" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="6092.0" VPOS="5576.0"/>
+                        <String ID="TB.Img0027a.6_8_2" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="556.0" HPOS="6188.0" VPOS="5576.0" CONTENT="sleeping" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="6744.0" VPOS="5576.0"/>
+                        <String ID="TB.Img0027a.6_8_3" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="416.0" HPOS="6844.0" VPOS="5632.0" CONTENT="rooms" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="7260.0" VPOS="5576.0"/>
+                        <String ID="TB.Img0027a.6_8_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="276.0" HPOS="7352.0" VPOS="5576.0" CONTENT="will" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_9" HEIGHT="176.0" WIDTH="3068.0" HPOS="4556.0" VPOS="5768.0">
+                        <String ID="TB.Img0027a.6_9_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="148.0" HPOS="4556.0" VPOS="5768.0" CONTENT="be" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="4704.0" VPOS="5768.0"/>
+                        <String ID="TB.Img0027a.6_9_1" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="132.0" HPOS="4788.0" VPOS="5776.0" CONTENT="in" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="4920.0" VPOS="5768.0"/>
+                        <String ID="TB.Img0027a.6_9_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="212.0" HPOS="5012.0" VPOS="5768.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="5224.0" VPOS="5768.0"/>
+                        <String ID="TB.Img0027a.6_9_3" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="460.0" HPOS="5312.0" VPOS="5780.0" CONTENT="wings," WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="5772.0" VPOS="5768.0"/>
+                        <String ID="TB.Img0027a.6_9_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="240.0" HPOS="5868.0" VPOS="5776.0" CONTENT="but" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="6108.0" VPOS="5768.0"/>
+                        <String ID="TB.Img0027a.6_9_5" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="720.0" HPOS="6204.0" VPOS="5772.0" CONTENT="dormitory" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="6924.0" VPOS="5768.0"/>
+                        <String ID="TB.Img0027a.6_9_6" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="608.0" HPOS="7016.0" VPOS="5772.0" CONTENT="residents" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_10" HEIGHT="180.0" WIDTH="3072.0" HPOS="4552.0" VPOS="5956.0">
+                        <String ID="TB.Img0027a.6_10_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="268.0" HPOS="4552.0" VPOS="5956.0" CONTENT="will" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="4820.0" VPOS="5956.0"/>
+                        <String ID="TB.Img0027a.6_10_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="324.0" HPOS="4928.0" VPOS="5960.0" CONTENT="have" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="5252.0" VPOS="5956.0"/>
+                        <String ID="TB.Img0027a.6_10_2" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="556.0" HPOS="5368.0" VPOS="5960.0" CONTENT="sleeping" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="5924.0" VPOS="5956.0"/>
+                        <String ID="TB.Img0027a.6_10_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="596.0" HPOS="6044.0" VPOS="5964.0" CONTENT="facilities" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="6640.0" VPOS="5956.0"/>
+                        <String ID="TB.Img0027a.6_10_4" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="620.0" HPOS="6756.0" VPOS="5968.0" CONTENT="provided" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="7376.0" VPOS="5956.0"/>
+                        <String ID="TB.Img0027a.6_10_5" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="136.0" HPOS="7488.0" VPOS="5976.0" CONTENT="in" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_11" HEIGHT="176.0" WIDTH="1692.0" HPOS="4556.0" VPOS="6148.0">
+                        <String ID="TB.Img0027a.6_11_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="328.0" HPOS="4556.0" VPOS="6148.0" CONTENT="their" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="4884.0" VPOS="6148.0"/>
+                        <String ID="TB.Img0027a.6_11_1" STYLEREFS="TS_10.0" HEIGHT="160.0" WIDTH="704.0" HPOS="4984.0" VPOS="6164.0" CONTENT="respective" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="5688.0" VPOS="6148.0"/>
+                        <String ID="TB.Img0027a.6_11_2" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="456.0" HPOS="5792.0" VPOS="6212.0" CONTENT="rooms." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_12" HEIGHT="140.0" WIDTH="2012.0" HPOS="4556.0" VPOS="6452.0">
+                        <String ID="TB.Img0027a.6_12_0" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="272.0" HPOS="4556.0" VPOS="6456.0" CONTENT="WU" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="4828.0" VPOS="6452.0"/>
+                        <String ID="TB.Img0027a.6_12_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="660.0" HPOS="4932.0" VPOS="6452.0" CONTENT="Students" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="5592.0" VPOS="6452.0"/>
+                        <String ID="TB.Img0027a.6_12_2" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="352.0" HPOS="5688.0" VPOS="6460.0" CONTENT="Give" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="6040.0" VPOS="6452.0"/>
+                        <String ID="TB.Img0027a.6_12_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="424.0" HPOS="6144.0" VPOS="6456.0" CONTENT="Blood" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_13" HEIGHT="164.0" WIDTH="2888.0" HPOS="4732.0" VPOS="6720.0">
+                        <String ID="TB.Img0027a.6_13_0" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="180.0" HPOS="4732.0" VPOS="6732.0" CONTENT="As" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="4912.0" VPOS="6720.0"/>
+                        <String ID="TB.Img0027a.6_13_1" STYLEREFS="TS_10.0" HEIGHT="156.0" WIDTH="404.0" HPOS="4996.0" VPOS="6720.0" CONTENT="usual," WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="5400.0" VPOS="6720.0"/>
+                        <String ID="TB.Img0027a.6_13_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="376.0" HPOS="5492.0" VPOS="6724.0" CONTENT="when" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="5868.0" VPOS="6720.0"/>
+                        <String ID="TB.Img0027a.6_13_3" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="60.0" HPOS="5956.0" VPOS="6780.0" CONTENT="a" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="6016.0" VPOS="6720.0"/>
+                        <String ID="TB.Img0027a.6_13_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="344.0" HPOS="6104.0" VPOS="6732.0" CONTENT="crisis" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="6448.0" VPOS="6720.0"/>
+                        <String ID="TB.Img0027a.6_13_5" STYLEREFS="TS_10.0" HEIGHT="148.0" WIDTH="396.0" HPOS="6536.0" VPOS="6736.0" CONTENT="arises," WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="6932.0" VPOS="6720.0"/>
+                        <String ID="TB.Img0027a.6_13_6" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="532.0" HPOS="7020.0" VPOS="6724.0" CONTENT="Willam" SUBS_TYPE="HypPart1" SUBS_CONTENT="Willamette" WC="1.0"/>
+                        <HYP WIDTH="48.0" HPOS="7572.0" VPOS="6820.0" CONTENT="-"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_14" HEIGHT="168.0" WIDTH="2684.0" HPOS="4940.0" VPOS="6920.0">
+                        <String ID="TB.Img0027a.6_14_0" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="264.0" HPOS="4548.0" VPOS="6956.0" CONTENT="ette" SUBS_TYPE="HypPart2" SUBS_CONTENT="Willamette" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="4812.0" VPOS="6920.0"/>
+                        <String ID="TB.Img0027a.6_14_1" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="768.0" HPOS="4940.0" VPOS="6920.0" CONTENT="University" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="5708.0" VPOS="6920.0"/>
+                        <String ID="TB.Img0027a.6_14_2" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="240.0" HPOS="5840.0" VPOS="6968.0" CONTENT="can" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="6080.0" VPOS="6920.0"/>
+                        <String ID="TB.Img0027a.6_14_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="144.0" HPOS="6212.0" VPOS="6920.0" CONTENT="be" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="6356.0" VPOS="6920.0"/>
+                        <String ID="TB.Img0027a.6_14_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="564.0" HPOS="6488.0" VPOS="6924.0" CONTENT="counted" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="7052.0" VPOS="6920.0"/>
+                        <String ID="TB.Img0027a.6_14_5" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="168.0" HPOS="7184.0" VPOS="6980.0" CONTENT="on" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="7352.0" VPOS="6920.0"/>
+                        <String ID="TB.Img0027a.6_14_6" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="140.0" HPOS="7484.0" VPOS="6968.0" CONTENT="to" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_15" HEIGHT="184.0" WIDTH="3068.0" HPOS="4552.0" VPOS="7108.0">
+                        <String ID="TB.Img0027a.6_15_0" STYLEREFS="TS_10.0" HEIGHT="84.0" WIDTH="360.0" HPOS="4552.0" VPOS="7152.0" CONTENT="come" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="4912.0" VPOS="7108.0"/>
+                        <String ID="TB.Img0027a.6_15_1" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="140.0" HPOS="5060.0" VPOS="7148.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="5200.0" VPOS="7108.0"/>
+                        <String ID="TB.Img0027a.6_15_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="5340.0" VPOS="7108.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="144.0" HPOS="5556.0" VPOS="7108.0"/>
+                        <String ID="TB.Img0027a.6_15_3" STYLEREFS="TS_10.0" HEIGHT="84.0" WIDTH="468.0" HPOS="5700.0" VPOS="7160.0" CONTENT="rescue." WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="6168.0" VPOS="7108.0"/>
+                        <String ID="TB.Img0027a.6_15_4" STYLEREFS="TS_10.0" HEIGHT="156.0" WIDTH="348.0" HPOS="6316.0" VPOS="7116.0" CONTENT="And," WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="6664.0" VPOS="7108.0"/>
+                        <String ID="TB.Img0027a.6_15_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="392.0" HPOS="6816.0" VPOS="7116.0" CONTENT="that's" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="7208.0" VPOS="7108.0"/>
+                        <String ID="TB.Img0027a.6_15_6" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="272.0" HPOS="7348.0" VPOS="7124.0" CONTENT="just" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_16" HEIGHT="188.0" WIDTH="3068.0" HPOS="4548.0" VPOS="7296.0">
+                        <String ID="TB.Img0027a.6_16_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="352.0" HPOS="4548.0" VPOS="7296.0" CONTENT="what" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="4900.0" VPOS="7296.0"/>
+                        <String ID="TB.Img0027a.6_16_1" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="308.0" HPOS="5016.0" VPOS="7304.0" CONTENT="WU" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="5324.0" VPOS="7296.0"/>
+                        <String ID="TB.Img0027a.6_16_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="592.0" HPOS="5432.0" VPOS="7300.0" CONTENT="students" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="6024.0" VPOS="7296.0"/>
+                        <String ID="TB.Img0027a.6_16_3" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="212.0" HPOS="6140.0" VPOS="7308.0" CONTENT="did" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="6352.0" VPOS="7296.0"/>
+                        <String ID="TB.Img0027a.6_16_4" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="472.0" HPOS="6464.0" VPOS="7308.0" CONTENT="during" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="6936.0" VPOS="7296.0"/>
+                        <String ID="TB.Img0027a.6_16_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="212.0" HPOS="7052.0" VPOS="7308.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="7264.0" VPOS="7296.0"/>
+                        <String ID="TB.Img0027a.6_16_6" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="240.0" HPOS="7376.0" VPOS="7312.0" CONTENT="last" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_17" HEIGHT="192.0" WIDTH="2880.0" HPOS="4548.0" VPOS="7488.0">
+                        <String ID="TB.Img0027a.6_17_0" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="276.0" HPOS="4548.0" VPOS="7492.0" CONTENT="Red" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="4824.0" VPOS="7488.0"/>
+                        <String ID="TB.Img0027a.6_17_1" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="376.0" HPOS="4916.0" VPOS="7500.0" CONTENT="Cross" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="5292.0" VPOS="7488.0"/>
+                        <String ID="TB.Img0027a.6_17_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="380.0" HPOS="5384.0" VPOS="7488.0" CONTENT="blood" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="5764.0" VPOS="7488.0"/>
+                        <String ID="TB.Img0027a.6_17_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="356.0" HPOS="5856.0" VPOS="7492.0" CONTENT="drive" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="6212.0" VPOS="7488.0"/>
+                        <String ID="TB.Img0027a.6_17_4" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="168.0" HPOS="6300.0" VPOS="7552.0" CONTENT="on" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="6468.0" VPOS="7488.0"/>
+                        <String ID="TB.Img0027a.6_17_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="212.0" HPOS="6556.0" VPOS="7500.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="6768.0" VPOS="7488.0"/>
+                        <String ID="TB.Img0027a.6_17_6" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="568.0" HPOS="6860.0" VPOS="7556.0" CONTENT="campus." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_18" HEIGHT="172.0" WIDTH="2892.0" HPOS="4728.0" VPOS="7752.0">
+                        <String ID="TB.Img0027a.6_18_0" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="356.0" HPOS="4728.0" VPOS="7752.0" CONTENT="Final" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="5084.0" VPOS="7752.0"/>
+                        <String ID="TB.Img0027a.6_18_1" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="324.0" HPOS="5184.0" VPOS="7752.0" CONTENT="tally" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="5508.0" VPOS="7752.0"/>
+                        <String ID="TB.Img0027a.6_18_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="516.0" HPOS="5600.0" VPOS="7752.0" CONTENT="showed" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="6116.0" VPOS="7752.0"/>
+                        <String ID="TB.Img0027a.6_18_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="284.0" HPOS="6216.0" VPOS="7760.0" CONTENT="that" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="6500.0" VPOS="7752.0"/>
+                        <String ID="TB.Img0027a.6_18_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="800.0" HPOS="6596.0" VPOS="7764.0" CONTENT="Willamette" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="7396.0" VPOS="7752.0"/>
+                        <String ID="TB.Img0027a.6_18_5" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="128.0" HPOS="7492.0" VPOS="7776.0" CONTENT="U" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_19" HEIGHT="192.0" WIDTH="3076.0" HPOS="4544.0" VPOS="7944.0">
+                        <String ID="TB.Img0027a.6_19_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="596.0" HPOS="4544.0" VPOS="7944.0" CONTENT="students" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="5140.0" VPOS="7944.0"/>
+                        <String ID="TB.Img0027a.6_19_1" STYLEREFS="TS_10.0" HEIGHT="84.0" WIDTH="180.0" HPOS="5236.0" VPOS="7992.0" CONTENT="set" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="5416.0" VPOS="7944.0"/>
+                        <String ID="TB.Img0027a.6_19_2" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="156.0" HPOS="5516.0" VPOS="8000.0" CONTENT="an" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="5672.0" VPOS="7944.0"/>
+                        <String ID="TB.Img0027a.6_19_3" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="556.0" HPOS="5768.0" VPOS="7944.0" CONTENT="all-time" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="6324.0" VPOS="7944.0"/>
+                        <String ID="TB.Img0027a.6_19_4" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="532.0" HPOS="6416.0" VPOS="8004.0" CONTENT="campus" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="6948.0" VPOS="7944.0"/>
+                        <String ID="TB.Img0027a.6_19_5" STYLEREFS="TS_10.0" HEIGHT="180.0" WIDTH="312.0" HPOS="7040.0" VPOS="7956.0" CONTENT="high" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="7352.0" VPOS="7944.0"/>
+                        <String ID="TB.Img0027a.6_19_6" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="176.0" HPOS="7444.0" VPOS="7964.0" CONTENT="by" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_20" HEIGHT="184.0" WIDTH="3068.0" HPOS="4548.0" VPOS="8132.0">
+                        <String ID="TB.Img0027a.6_20_0" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="632.0" HPOS="4548.0" VPOS="8132.0" CONTENT="donating" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="5180.0" VPOS="8132.0"/>
+                        <String ID="TB.Img0027a.6_20_1" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="340.0" HPOS="5284.0" VPOS="8192.0" CONTENT="some" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="5624.0" VPOS="8132.0"/>
+                        <String ID="TB.Img0027a.6_20_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="328.0" HPOS="5732.0" VPOS="8152.0" CONTENT="63'2" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="6060.0" VPOS="8132.0"/>
+                        <String ID="TB.Img0027a.6_20_3" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="488.0" HPOS="6180.0" VPOS="8144.0" CONTENT="gallons" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="6668.0" VPOS="8132.0"/>
+                        <String ID="TB.Img0027a.6_20_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="148.0" HPOS="6760.0" VPOS="8152.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="6908.0" VPOS="8132.0"/>
+                        <String ID="TB.Img0027a.6_20_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="212.0" HPOS="7012.0" VPOS="8152.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="7224.0" VPOS="8132.0"/>
+                        <String ID="TB.Img0027a.6_20_6" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="228.0" HPOS="7324.0" VPOS="8156.0" CONTENT="life" SUBS_TYPE="HypPart1" SUBS_CONTENT="life-saving" WC="1.0"/>
+                        <HYP WIDTH="48.0" HPOS="7568.0" VPOS="8244.0" CONTENT="-"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_21" HEIGHT="156.0" WIDTH="2524.0" HPOS="5092.0" VPOS="8328.0">
+                        <String ID="TB.Img0027a.6_21_0" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="452.0" HPOS="4544.0" VPOS="8336.0" CONTENT="saving" SUBS_TYPE="HypPart2" SUBS_CONTENT="life-saving" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="4996.0" VPOS="8328.0"/>
+                        <String ID="TB.Img0027a.6_21_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="344.0" HPOS="5092.0" VPOS="8328.0" CONTENT="fluid" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="5436.0" VPOS="8328.0"/>
+                        <String ID="TB.Img0027a.6_21_2" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="136.0" HPOS="5536.0" VPOS="8376.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="5672.0" VPOS="8328.0"/>
+                        <String ID="TB.Img0027a.6_21_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="212.0" HPOS="5764.0" VPOS="8332.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="5976.0" VPOS="8328.0"/>
+                        <String ID="TB.Img0027a.6_21_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="696.0" HPOS="6072.0" VPOS="8348.0" CONTENT="American" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="6768.0" VPOS="8328.0"/>
+                        <String ID="TB.Img0027a.6_21_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="276.0" HPOS="6864.0" VPOS="8348.0" CONTENT="Red" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="7140.0" VPOS="8328.0"/>
+                        <String ID="TB.Img0027a.6_21_6" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="380.0" HPOS="7236.0" VPOS="8360.0" CONTENT="Cross" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_22" HEIGHT="192.0" WIDTH="3072.0" HPOS="4540.0" VPOS="8520.0">
+                        <String ID="TB.Img0027a.6_22_0" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="568.0" HPOS="4540.0" VPOS="8520.0" CONTENT="regional" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="5108.0" VPOS="8520.0"/>
+                        <String ID="TB.Img0027a.6_22_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="380.0" HPOS="5220.0" VPOS="8520.0" CONTENT="blood" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="5600.0" VPOS="8520.0"/>
+                        <String ID="TB.Img0027a.6_22_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="380.0" HPOS="5720.0" VPOS="8528.0" CONTENT="bank." WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="6100.0" VPOS="8520.0"/>
+                        <String ID="TB.Img0027a.6_22_3" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="756.0" HPOS="6220.0" VPOS="8536.0" CONTENT="According" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="6976.0" VPOS="8520.0"/>
+                        <String ID="TB.Img0027a.6_22_4" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="140.0" HPOS="7092.0" VPOS="8584.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="7232.0" VPOS="8520.0"/>
+                        <String ID="TB.Img0027a.6_22_5" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="276.0" HPOS="7336.0" VPOS="8548.0" CONTENT="Red" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_23" HEIGHT="184.0" WIDTH="3076.0" HPOS="4540.0" VPOS="8712.0">
+                        <String ID="TB.Img0027a.6_23_0" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="380.0" HPOS="4540.0" VPOS="8720.0" CONTENT="Cross" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="4920.0" VPOS="8712.0"/>
+                        <String ID="TB.Img0027a.6_23_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="580.0" HPOS="5008.0" VPOS="8712.0" CONTENT="officials" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="5588.0" VPOS="8712.0"/>
+                        <String ID="TB.Img0027a.6_23_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="212.0" HPOS="5680.0" VPOS="8716.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="5892.0" VPOS="8712.0"/>
+                        <String ID="TB.Img0027a.6_23_3" STYLEREFS="TS_10.0" HEIGHT="104.0" WIDTH="64.0" HPOS="5992.0" VPOS="8744.0" CONTENT="2" WC="1.0"/>
+                        <SP WIDTH="40.0" HPOS="6056.0" VPOS="8712.0"/>
+                        <String ID="TB.Img0027a.6_23_4" STYLEREFS="TS_10.0" HEIGHT="160.0" WIDTH="520.0" HPOS="6096.0" VPOS="8736.0" CONTENT="54-pint" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="6616.0" VPOS="8712.0"/>
+                        <String ID="TB.Img0027a.6_23_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="904.0" HPOS="6712.0" VPOS="8736.0" CONTENT="contribution" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_24" HEIGHT="192.0" WIDTH="3076.0" HPOS="4536.0" VPOS="8908.0">
+                        <String ID="TB.Img0027a.6_24_0" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="260.0" HPOS="4536.0" VPOS="8952.0" CONTENT="was" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="4796.0" VPOS="8908.0"/>
+                        <String ID="TB.Img0027a.6_24_1" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="516.0" HPOS="4908.0" VPOS="8908.0" CONTENT="enough" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="5424.0" VPOS="8908.0"/>
+                        <String ID="TB.Img0027a.6_24_2" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="136.0" HPOS="5536.0" VPOS="8952.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="5672.0" VPOS="8908.0"/>
+                        <String ID="TB.Img0027a.6_24_3" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="468.0" HPOS="5784.0" VPOS="8908.0" CONTENT="supply" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="6252.0" VPOS="8908.0"/>
+                        <String ID="TB.Img0027a.6_24_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="216.0" HPOS="6368.0" VPOS="8916.0" CONTENT="for" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="6584.0" VPOS="8908.0"/>
+                        <String ID="TB.Img0027a.6_24_5" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="236.0" HPOS="6688.0" VPOS="8976.0" CONTENT="one" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="6924.0" VPOS="8908.0"/>
+                        <String ID="TB.Img0027a.6_24_6" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="244.0" HPOS="7040.0" VPOS="8928.0" CONTENT="day" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="7284.0" VPOS="8908.0"/>
+                        <String ID="TB.Img0027a.6_24_7" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="216.0" HPOS="7396.0" VPOS="8928.0" CONTENT="the" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.6_25" HEIGHT="204.0" WIDTH="3060.0" HPOS="4552.0" VPOS="9092.0">
+                        <String ID="TB.Img0027a.6_25_0" STYLEREFS="TS_10.0" HEIGHT="108.0" WIDTH="148.0" HPOS="4552.0" VPOS="9112.0" CONTENT="82" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="4700.0" VPOS="9092.0"/>
+                        <String ID="TB.Img0027a.6_25_1" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="616.0" HPOS="4848.0" VPOS="9092.0" CONTENT="hospitals" WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="5464.0" VPOS="9092.0"/>
+                        <String ID="TB.Img0027a.6_25_2" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="132.0" HPOS="5596.0" VPOS="9112.0" CONTENT="in" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="5728.0" VPOS="9092.0"/>
+                        <String ID="TB.Img0027a.6_25_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="732.0" HPOS="5868.0" VPOS="9108.0" CONTENT="Southwest" WC="1.0"/>
+                        <SP WIDTH="136.0" HPOS="6600.0" VPOS="9092.0"/>
+                        <String ID="TB.Img0027a.6_25_4" STYLEREFS="TS_10.0" HEIGHT="180.0" WIDTH="876.0" HPOS="6736.0" VPOS="9116.0" CONTENT="Washington" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns7="http://www.w3.org/1999/xlink" ID="TB.Img0027a.7" HEIGHT="752" WIDTH="2896" HPOS="8064" VPOS="2784" ns7:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.7_0" HEIGHT="752.0" WIDTH="2896.0" HPOS="8064.0" VPOS="2784.0">
+                        <String ID="TB.Img0027a.7_0_0" STYLEREFS="TS_10.0_I" HEIGHT="752.0" WIDTH="2896.0" HPOS="8064.0" VPOS="2784.0" CONTENT="ower" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns8="http://www.w3.org/1999/xlink" ID="TB.Img0027a.8" HEIGHT="5364" WIDTH="3168" HPOS="7844" VPOS="3956" ns8:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.8_0" HEIGHT="188.0" WIDTH="3132.0" HPOS="7876.0" VPOS="3956.0">
+                        <String ID="TB.Img0027a.8_0_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="252.0" HPOS="7876.0" VPOS="3956.0" CONTENT="and" WC="1.0"/>
+                        <SP WIDTH="180.0" HPOS="8128.0" VPOS="3956.0"/>
+                        <String ID="TB.Img0027a.8_0_1" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="540.0" HPOS="8308.0" VPOS="3964.0" CONTENT="Oregon" WC="1.0"/>
+                        <SP WIDTH="184.0" HPOS="8848.0" VPOS="3956.0"/>
+                        <String ID="TB.Img0027a.8_0_2" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="824.0" HPOS="9032.0" VPOS="3964.0" CONTENT="comprising" WC="1.0"/>
+                        <SP WIDTH="188.0" HPOS="9856.0" VPOS="3956.0"/>
+                        <String ID="TB.Img0027a.8_0_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="220.0" HPOS="10044.0" VPOS="3960.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="188.0" HPOS="10264.0" VPOS="3956.0"/>
+                        <String ID="TB.Img0027a.8_0_4" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="556.0" HPOS="10452.0" VPOS="3980.0" CONTENT="regional" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_1" HEIGHT="172.0" WIDTH="3136.0" HPOS="7876.0" VPOS="4152.0">
+                        <String ID="TB.Img0027a.8_1_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="388.0" HPOS="7876.0" VPOS="4152.0" CONTENT="bank." WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="8264.0" VPOS="4152.0"/>
+                        <String ID="TB.Img0027a.8_1_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="284.0" HPOS="8388.0" VPOS="4152.0" CONTENT="Red" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="8672.0" VPOS="4152.0"/>
+                        <String ID="TB.Img0027a.8_1_2" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="388.0" HPOS="8792.0" VPOS="4156.0" CONTENT="Cross" WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="9180.0" VPOS="4152.0"/>
+                        <String ID="TB.Img0027a.8_1_3" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="512.0" HPOS="9304.0" VPOS="4152.0" CONTENT="figures" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="9816.0" VPOS="4152.0"/>
+                        <String ID="TB.Img0027a.8_1_4" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="672.0" HPOS="9936.0" VPOS="4156.0" CONTENT="indicated" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="10608.0" VPOS="4152.0"/>
+                        <String ID="TB.Img0027a.8_1_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="284.0" HPOS="10728.0" VPOS="4168.0" CONTENT="that" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_2" HEIGHT="176.0" WIDTH="3128.0" HPOS="7884.0" VPOS="4344.0">
+                        <String ID="TB.Img0027a.8_2_0" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="52.0" HPOS="7884.0" VPOS="4364.0" CONTENT="3" WC="1.0"/>
+                        <SP WIDTH="44.0" HPOS="7936.0" VPOS="4344.0"/>
+                        <String ID="TB.Img0027a.8_2_1" STYLEREFS="TS_10.0" HEIGHT="112.0" WIDTH="48.0" HPOS="7980.0" VPOS="4368.0" CONTENT="5" WC="1.0"/>
+                        <SP WIDTH="156.0" HPOS="8028.0" VPOS="4344.0"/>
+                        <String ID="TB.Img0027a.8_2_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="608.0" HPOS="8184.0" VPOS="4344.0" CONTENT="students" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="8792.0" VPOS="4344.0"/>
+                        <String ID="TB.Img0027a.8_2_3" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="344.0" HPOS="8932.0" VPOS="4396.0" CONTENT="were" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="9276.0" VPOS="4344.0"/>
+                        <String ID="TB.Img0027a.8_2_4" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="584.0" HPOS="9416.0" VPOS="4352.0" CONTENT="rejected" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="10000.0" VPOS="4344.0"/>
+                        <String ID="TB.Img0027a.8_2_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="220.0" HPOS="10148.0" VPOS="4352.0" CONTENT="for" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="10368.0" VPOS="4344.0"/>
+                        <String ID="TB.Img0027a.8_2_6" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="504.0" HPOS="10508.0" VPOS="4368.0" CONTENT="various" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_3" HEIGHT="180.0" WIDTH="3136.0" HPOS="7868.0" VPOS="4536.0">
+                        <String ID="TB.Img0027a.8_3_0" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="504.0" HPOS="7868.0" VPOS="4596.0" CONTENT="reasons" WC="1.0"/>
+                        <SP WIDTH="164.0" HPOS="8372.0" VPOS="4536.0"/>
+                        <String ID="TB.Img0027a.8_3_1" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="364.0" HPOS="8536.0" VPOS="4536.0" CONTENT="from" WC="1.0"/>
+                        <SP WIDTH="168.0" HPOS="8900.0" VPOS="4536.0"/>
+                        <String ID="TB.Img0027a.8_3_2" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="492.0" HPOS="9068.0" VPOS="4592.0" CONTENT="among" WC="1.0"/>
+                        <SP WIDTH="176.0" HPOS="9560.0" VPOS="4536.0"/>
+                        <String ID="TB.Img0027a.8_3_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="224.0" HPOS="9736.0" VPOS="4540.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="172.0" HPOS="9960.0" VPOS="4536.0"/>
+                        <String ID="TB.Img0027a.8_3_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="460.0" HPOS="10132.0" VPOS="4552.0" CONTENT="record" WC="1.0"/>
+                        <SP WIDTH="168.0" HPOS="10592.0" VPOS="4536.0"/>
+                        <String ID="TB.Img0027a.8_3_5" STYLEREFS="TS_10.0" HEIGHT="108.0" WIDTH="64.0" HPOS="10760.0" VPOS="4580.0" CONTENT="2" WC="1.0"/>
+                        <SP WIDTH="40.0" HPOS="10824.0" VPOS="4536.0"/>
+                        <String ID="TB.Img0027a.8_3_6" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="140.0" HPOS="10864.0" VPOS="4580.0" CONTENT="89" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_4" HEIGHT="136.0" WIDTH="796.0" HPOS="7860.0" VPOS="4732.0">
+                        <String ID="TB.Img0027a.8_4_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="796.0" HPOS="7860.0" VPOS="4732.0" CONTENT="volunteers." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_5" HEIGHT="176.0" WIDTH="2960.0" HPOS="8048.0" VPOS="4996.0">
+                        <String ID="TB.Img0027a.8_5_0" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="544.0" HPOS="8048.0" VPOS="5008.0" CONTENT="Among" WC="1.0"/>
+                        <SP WIDTH="236.0" HPOS="8592.0" VPOS="4996.0"/>
+                        <String ID="TB.Img0027a.8_5_1" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="748.0" HPOS="8828.0" VPOS="4996.0" CONTENT="individual" WC="1.0"/>
+                        <SP WIDTH="240.0" HPOS="9576.0" VPOS="4996.0"/>
+                        <String ID="TB.Img0027a.8_5_2" STYLEREFS="TS_10.0" HEIGHT="160.0" WIDTH="524.0" HPOS="9816.0" VPOS="5004.0" CONTENT="donors," WC="1.0"/>
+                        <SP WIDTH="236.0" HPOS="10340.0" VPOS="4996.0"/>
+                        <String ID="TB.Img0027a.8_5_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="432.0" HPOS="10576.0" VPOS="5020.0" CONTENT="David" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_6" HEIGHT="160.0" WIDTH="3144.0" HPOS="7860.0" VPOS="5192.0">
+                        <String ID="TB.Img0027a.8_6_0" STYLEREFS="TS_10.0" HEIGHT="160.0" WIDTH="452.0" HPOS="7860.0" VPOS="5192.0" CONTENT="Patch," WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="8312.0" VPOS="5192.0"/>
+                        <String ID="TB.Img0027a.8_6_1" STYLEREFS="TS_10.0" HEIGHT="160.0" WIDTH="456.0" HPOS="8400.0" VPOS="5192.0" CONTENT="Salem," WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="8856.0" VPOS="5192.0"/>
+                        <String ID="TB.Img0027a.8_6_2" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="264.0" HPOS="8936.0" VPOS="5252.0" CONTENT="was" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="9200.0" VPOS="5192.0"/>
+                        <String ID="TB.Img0027a.8_6_3" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="596.0" HPOS="9276.0" VPOS="5192.0" CONTENT="honored" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="9872.0" VPOS="5192.0"/>
+                        <String ID="TB.Img0027a.8_6_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="344.0" HPOS="9948.0" VPOS="5200.0" CONTENT="with" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="10292.0" VPOS="5192.0"/>
+                        <String ID="TB.Img0027a.8_6_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="576.0" HPOS="10368.0" VPOS="5208.0" CONTENT="member" SUBS_TYPE="HypPart1" SUBS_CONTENT="membership" WC="1.0"/>
+                        <HYP WIDTH="44.0" HPOS="10960.0" VPOS="5300.0" CONTENT="-"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_7" HEIGHT="192.0" WIDTH="2752.0" HPOS="8252.0" VPOS="5384.0">
+                        <String ID="TB.Img0027a.8_7_0" STYLEREFS="TS_10.0" HEIGHT="180.0" WIDTH="280.0" HPOS="7864.0" VPOS="5384.0" CONTENT="ship" SUBS_TYPE="HypPart2" SUBS_CONTENT="membership" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="8144.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.8_7_1" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="136.0" HPOS="8252.0" VPOS="5400.0" CONTENT="in" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="8388.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.8_7_2" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="220.0" HPOS="8504.0" VPOS="5388.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="8724.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.8_7_3" STYLEREFS="TS_10.0" HEIGHT="180.0" WIDTH="448.0" HPOS="8840.0" VPOS="5384.0" CONTENT="gallon" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="9288.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.8_7_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="356.0" HPOS="9404.0" VPOS="5388.0" CONTENT="club." WC="1.0"/>
+                        <SP WIDTH="132.0" HPOS="9760.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.8_7_5" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="592.0" HPOS="9892.0" VPOS="5400.0" CONTENT="Campus" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="10484.0" VPOS="5384.0"/>
+                        <String ID="TB.Img0027a.8_7_6" STYLEREFS="TS_10.0" HEIGHT="180.0" WIDTH="404.0" HPOS="10600.0" VPOS="5396.0" CONTENT="living" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_8" HEIGHT="180.0" WIDTH="3148.0" HPOS="7860.0" VPOS="5592.0">
+                        <String ID="TB.Img0027a.8_8_0" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="916.0" HPOS="7860.0" VPOS="5592.0" CONTENT="organization" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="8776.0" VPOS="5592.0"/>
+                        <String ID="TB.Img0027a.8_8_1" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="892.0" HPOS="8924.0" VPOS="5596.0" CONTENT="competition" WC="1.0"/>
+                        <SP WIDTH="156.0" HPOS="9816.0" VPOS="5592.0"/>
+                        <String ID="TB.Img0027a.8_8_2" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="264.0" HPOS="9972.0" VPOS="5644.0" CONTENT="was" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="10236.0" VPOS="5592.0"/>
+                        <String ID="TB.Img0027a.8_8_3" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="308.0" HPOS="10384.0" VPOS="5648.0" CONTENT="won" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="10692.0" VPOS="5592.0"/>
+                        <String ID="TB.Img0027a.8_8_4" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="164.0" HPOS="10844.0" VPOS="5600.0" CONTENT="by" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_9" HEIGHT="188.0" WIDTH="3140.0" HPOS="7864.0" VPOS="5772.0">
+                        <String ID="TB.Img0027a.8_9_0" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="428.0" HPOS="7864.0" VPOS="5784.0" CONTENT="Sigma" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="8292.0" VPOS="5772.0"/>
+                        <String ID="TB.Img0027a.8_9_1" STYLEREFS="TS_10.0" HEIGHT="180.0" WIDTH="440.0" HPOS="8432.0" VPOS="5772.0" CONTENT="Alpha" WC="1.0"/>
+                        <SP WIDTH="144.0" HPOS="8872.0" VPOS="5772.0"/>
+                        <String ID="TB.Img0027a.8_9_2" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="544.0" HPOS="9016.0" VPOS="5780.0" CONTENT="Epsilon" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="9560.0" VPOS="5772.0"/>
+                        <String ID="TB.Img0027a.8_9_3" STYLEREFS="TS_10.0" HEIGHT="180.0" WIDTH="736.0" HPOS="9708.0" VPOS="5780.0" CONTENT="fraternity" WC="1.0"/>
+                        <SP WIDTH="144.0" HPOS="10444.0" VPOS="5772.0"/>
+                        <String ID="TB.Img0027a.8_9_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="416.0" HPOS="10588.0" VPOS="5788.0" CONTENT="whose" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_10" HEIGHT="176.0" WIDTH="3148.0" HPOS="7856.0" VPOS="5972.0">
+                        <String ID="TB.Img0027a.8_10_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="640.0" HPOS="7856.0" VPOS="5972.0" CONTENT="members" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="8496.0" VPOS="5972.0"/>
+                        <String ID="TB.Img0027a.8_10_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="576.0" HPOS="8584.0" VPOS="5976.0" CONTENT="donated" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="9160.0" VPOS="5972.0"/>
+                        <String ID="TB.Img0027a.8_10_2" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="144.0" HPOS="9260.0" VPOS="5996.0" CONTENT="53" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="9404.0" VPOS="5972.0"/>
+                        <String ID="TB.Img0027a.8_10_3" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="364.0" HPOS="9504.0" VPOS="5984.0" CONTENT="pints" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="9868.0" VPOS="5972.0"/>
+                        <String ID="TB.Img0027a.8_10_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="152.0" HPOS="9948.0" VPOS="5980.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="10100.0" VPOS="5972.0"/>
+                        <String ID="TB.Img0027a.8_10_5" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="432.0" HPOS="10188.0" VPOS="5976.0" CONTENT="blood," WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="10620.0" VPOS="5972.0"/>
+                        <String ID="TB.Img0027a.8_10_6" STYLEREFS="TS_10.0" HEIGHT="84.0" WIDTH="296.0" HPOS="10708.0" VPOS="6036.0" CONTENT="over" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_11" HEIGHT="148.0" WIDTH="3144.0" HPOS="7860.0" VPOS="6164.0">
+                        <String ID="TB.Img0027a.8_11_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="668.0" HPOS="7860.0" VPOS="6164.0" CONTENT="one-fifth" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="8528.0" VPOS="6164.0"/>
+                        <String ID="TB.Img0027a.8_11_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="152.0" HPOS="8632.0" VPOS="6168.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="8784.0" VPOS="6164.0"/>
+                        <String ID="TB.Img0027a.8_11_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="220.0" HPOS="8896.0" VPOS="6164.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="9116.0" VPOS="6164.0"/>
+                        <String ID="TB.Img0027a.8_11_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="384.0" HPOS="9232.0" VPOS="6168.0" CONTENT="total." WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="9616.0" VPOS="6164.0"/>
+                        <String ID="TB.Img0027a.8_11_4" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="144.0" HPOS="9732.0" VPOS="6180.0" CONTENT="Pi" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="9876.0" VPOS="6164.0"/>
+                        <String ID="TB.Img0027a.8_11_5" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="312.0" HPOS="9988.0" VPOS="6180.0" CONTENT="Beta" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="10300.0" VPOS="6164.0"/>
+                        <String ID="TB.Img0027a.8_11_6" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="228.0" HPOS="10416.0" VPOS="6176.0" CONTENT="Phi" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="10644.0" VPOS="6164.0"/>
+                        <String ID="TB.Img0027a.8_11_7" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="252.0" HPOS="10752.0" VPOS="6232.0" CONTENT="was" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_12" HEIGHT="180.0" WIDTH="3148.0" HPOS="7860.0" VPOS="6360.0">
+                        <String ID="TB.Img0027a.8_12_0" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="60.0" HPOS="7860.0" VPOS="6412.0" CONTENT="a" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="7920.0" VPOS="6360.0"/>
+                        <String ID="TB.Img0027a.8_12_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="708.0" HPOS="7996.0" VPOS="6360.0" CONTENT="one-tenth" WC="1.0"/>
+                        <SP WIDTH="72.0" HPOS="8704.0" VPOS="6360.0"/>
+                        <String ID="TB.Img0027a.8_12_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="800.0" HPOS="8776.0" VPOS="6404.0" CONTENT="percentage" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="9576.0" VPOS="6360.0"/>
+                        <String ID="TB.Img0027a.8_12_3" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="388.0" HPOS="9652.0" VPOS="6376.0" CONTENT="point" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="10040.0" VPOS="6360.0"/>
+                        <String ID="TB.Img0027a.8_12_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="516.0" HPOS="10120.0" VPOS="6376.0" CONTENT="winner" WC="1.0"/>
+                        <SP WIDTH="68.0" HPOS="10636.0" VPOS="6360.0"/>
+                        <String ID="TB.Img0027a.8_12_5" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="304.0" HPOS="10704.0" VPOS="6424.0" CONTENT="over" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_13" HEIGHT="176.0" WIDTH="3152.0" HPOS="7852.0" VPOS="6560.0">
+                        <String ID="TB.Img0027a.8_13_0" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="372.0" HPOS="7852.0" VPOS="6560.0" CONTENT="Lucy" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="8224.0" VPOS="6560.0"/>
+                        <String ID="TB.Img0027a.8_13_1" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="396.0" HPOS="8332.0" VPOS="6568.0" CONTENT="Anna" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="8728.0" VPOS="6560.0"/>
+                        <String ID="TB.Img0027a.8_13_2" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="240.0" HPOS="8844.0" VPOS="6564.0" CONTENT="Lee" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="9084.0" VPOS="6560.0"/>
+                        <String ID="TB.Img0027a.8_13_3" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="464.0" HPOS="9196.0" VPOS="6564.0" CONTENT="House" WC="1.0"/>
+                        <SP WIDTH="124.0" HPOS="9660.0" VPOS="6560.0"/>
+                        <String ID="TB.Img0027a.8_13_4" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="488.0" HPOS="9784.0" VPOS="6616.0" CONTENT="among" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="10272.0" VPOS="6560.0"/>
+                        <String ID="TB.Img0027a.8_13_5" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="620.0" HPOS="10384.0" VPOS="6572.0" CONTENT="women's" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_14" HEIGHT="180.0" WIDTH="3144.0" HPOS="7856.0" VPOS="6748.0">
+                        <String ID="TB.Img0027a.8_14_0" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="416.0" HPOS="7856.0" VPOS="6748.0" CONTENT="living" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="8272.0" VPOS="6748.0"/>
+                        <String ID="TB.Img0027a.8_14_1" STYLEREFS="TS_10.0" HEIGHT="160.0" WIDTH="1024.0" HPOS="8352.0" VPOS="6764.0" CONTENT="organizations." WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="9376.0" VPOS="6748.0"/>
+                        <String ID="TB.Img0027a.8_14_2" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="600.0" HPOS="9460.0" VPOS="6764.0" CONTENT="Campus" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="10060.0" VPOS="6748.0"/>
+                        <String ID="TB.Img0027a.8_14_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="368.0" HPOS="10140.0" VPOS="6760.0" CONTENT="drive" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="10508.0" VPOS="6748.0"/>
+                        <String ID="TB.Img0027a.8_14_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="348.0" HPOS="10588.0" VPOS="6756.0" CONTENT="chair" SUBS_TYPE="HypPart1" SUBS_CONTENT="chairman" WC="1.0"/>
+                        <HYP WIDTH="44.0" HPOS="10956.0" VPOS="6848.0" CONTENT="-"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_15" HEIGHT="136.0" WIDTH="1448.0" HPOS="8236.0" VPOS="6948.0">
+                        <String ID="TB.Img0027a.8_15_0" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="308.0" HPOS="7856.0" VPOS="6996.0" CONTENT="man" SUBS_TYPE="HypPart2" SUBS_CONTENT="chairman" WC="1.0"/>
+                        <SP WIDTH="72.0" HPOS="8164.0" VPOS="6948.0"/>
+                        <String ID="TB.Img0027a.8_15_1" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="260.0" HPOS="8236.0" VPOS="7000.0" CONTENT="was" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="8496.0" VPOS="6948.0"/>
+                        <String ID="TB.Img0027a.8_15_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="344.0" HPOS="8572.0" VPOS="6948.0" CONTENT="Tom" WC="1.0"/>
+                        <SP WIDTH="72.0" HPOS="8916.0" VPOS="6948.0"/>
+                        <String ID="TB.Img0027a.8_15_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="696.0" HPOS="8988.0" VPOS="6948.0" CONTENT="Dunham." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_16" HEIGHT="176.0" WIDTH="2220.0" HPOS="7868.0" VPOS="7244.0">
+                        <String ID="TB.Img0027a.8_16_0" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="544.0" HPOS="7868.0" VPOS="7244.0" CONTENT="Faculty" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="8412.0" VPOS="7244.0"/>
+                        <String ID="TB.Img0027a.8_16_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="744.0" HPOS="8528.0" VPOS="7248.0" CONTENT="Members" WC="1.0"/>
+                        <SP WIDTH="128.0" HPOS="9272.0" VPOS="7244.0"/>
+                        <String ID="TB.Img0027a.8_16_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="688.0" HPOS="9400.0" VPOS="7248.0" CONTENT="Honored" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_17" HEIGHT="144.0" WIDTH="2960.0" HPOS="8036.0" VPOS="7512.0">
+                        <String ID="TB.Img0027a.8_17_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="332.0" HPOS="8036.0" VPOS="7512.0" CONTENT="Two" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="8368.0" VPOS="7512.0"/>
+                        <String ID="TB.Img0027a.8_17_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="648.0" HPOS="8464.0" VPOS="7516.0" CONTENT="members" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="9112.0" VPOS="7512.0"/>
+                        <String ID="TB.Img0027a.8_17_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="152.0" HPOS="9212.0" VPOS="7516.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="9364.0" VPOS="7512.0"/>
+                        <String ID="TB.Img0027a.8_17_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="220.0" HPOS="9468.0" VPOS="7516.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="9688.0" VPOS="7512.0"/>
+                        <String ID="TB.Img0027a.8_17_4" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="832.0" HPOS="9784.0" VPOS="7516.0" CONTENT="Willamette" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="10616.0" VPOS="7512.0"/>
+                        <String ID="TB.Img0027a.8_17_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="212.0" HPOS="10716.0" VPOS="7520.0" CONTENT="fac" SUBS_TYPE="HypPart1" SUBS_CONTENT="faculty" WC="1.0"/>
+                        <HYP WIDTH="44.0" HPOS="10952.0" VPOS="7608.0" CONTENT="-"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_18" HEIGHT="180.0" WIDTH="2760.0" HPOS="8240.0" VPOS="7708.0">
+                        <String ID="TB.Img0027a.8_18_0" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="296.0" HPOS="7848.0" VPOS="7704.0" CONTENT="ulty" SUBS_TYPE="HypPart2" SUBS_CONTENT="faculty" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="8144.0" VPOS="7708.0"/>
+                        <String ID="TB.Img0027a.8_18_1" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="336.0" HPOS="8240.0" VPOS="7764.0" CONTENT="were" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="8576.0" VPOS="7708.0"/>
+                        <String ID="TB.Img0027a.8_18_2" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="488.0" HPOS="8672.0" VPOS="7764.0" CONTENT="among" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="9160.0" VPOS="7708.0"/>
+                        <String ID="TB.Img0027a.8_18_3" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="368.0" HPOS="9264.0" VPOS="7708.0" CONTENT="those" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="9632.0" VPOS="7708.0"/>
+                        <String ID="TB.Img0027a.8_18_4" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="596.0" HPOS="9724.0" VPOS="7712.0" CONTENT="honored" WC="1.0"/>
+                        <SP WIDTH="100.0" HPOS="10320.0" VPOS="7708.0"/>
+                        <String ID="TB.Img0027a.8_18_5" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="580.0" HPOS="10420.0" VPOS="7716.0" CONTENT="recently" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_19" HEIGHT="180.0" WIDTH="3148.0" HPOS="7852.0" VPOS="7900.0">
+                        <String ID="TB.Img0027a.8_19_0" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="176.0" HPOS="7852.0" VPOS="7900.0" CONTENT="by" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="8028.0" VPOS="7900.0"/>
+                        <String ID="TB.Img0027a.8_19_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="220.0" HPOS="8112.0" VPOS="7900.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="8332.0" VPOS="7900.0"/>
+                        <String ID="TB.Img0027a.8_19_2" STYLEREFS="TS_10.0_I" HEIGHT="176.0" WIDTH="528.0" HPOS="8412.0" VPOS="7904.0" CONTENT="Capital" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="8940.0" VPOS="7900.0"/>
+                        <String ID="TB.Img0027a.8_19_3" STYLEREFS="TS_10.0_I" HEIGHT="176.0" WIDTH="564.0" HPOS="9020.0" VPOS="7904.0" CONTENT="Journal" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="9584.0" VPOS="7900.0"/>
+                        <String ID="TB.Img0027a.8_19_4" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="128.0" HPOS="9668.0" VPOS="7964.0" CONTENT="as" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="9796.0" VPOS="7900.0"/>
+                        <String ID="TB.Img0027a.8_19_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="260.0" HPOS="9884.0" VPOS="7908.0" CONTENT="this" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="10144.0" VPOS="7900.0"/>
+                        <String ID="TB.Img0027a.8_19_6" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="384.0" HPOS="10236.0" VPOS="7920.0" CONTENT="area's" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="10620.0" VPOS="7900.0"/>
+                        <String ID="TB.Img0027a.8_19_7" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="296.0" HPOS="10704.0" VPOS="7964.0" CONTENT="men" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_20" HEIGHT="184.0" WIDTH="3160.0" HPOS="7844.0" VPOS="8092.0">
+                        <String ID="TB.Img0027a.8_20_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="152.0" HPOS="7844.0" VPOS="8092.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="7996.0" VPOS="8092.0"/>
+                        <String ID="TB.Img0027a.8_20_1" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="212.0" HPOS="8080.0" VPOS="8092.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="8292.0" VPOS="8092.0"/>
+                        <String ID="TB.Img0027a.8_20_2" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="340.0" HPOS="8368.0" VPOS="8152.0" CONTENT="year." WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="8708.0" VPOS="8092.0"/>
+                        <String ID="TB.Img0027a.8_20_3" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="736.0" HPOS="8792.0" VPOS="8108.0" CONTENT="Receiving" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="9528.0" VPOS="8092.0"/>
+                        <String ID="TB.Img0027a.8_20_4" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="676.0" HPOS="9612.0" VPOS="8100.0" CONTENT="accolades" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="10288.0" VPOS="8092.0"/>
+                        <String ID="TB.Img0027a.8_20_5" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="220.0" HPOS="10372.0" VPOS="8104.0" CONTENT="for" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="10592.0" VPOS="8092.0"/>
+                        <String ID="TB.Img0027a.8_20_6" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="332.0" HPOS="10672.0" VPOS="8104.0" CONTENT="their" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_21" HEIGHT="176.0" WIDTH="3148.0" HPOS="7848.0" VPOS="8292.0">
+                        <String ID="TB.Img0027a.8_21_0" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="984.0" HPOS="7848.0" VPOS="8292.0" CONTENT="contributions" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="8832.0" VPOS="8292.0"/>
+                        <String ID="TB.Img0027a.8_21_1" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="144.0" HPOS="8940.0" VPOS="8340.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="9084.0" VPOS="8292.0"/>
+                        <String ID="TB.Img0027a.8_21_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="220.0" HPOS="9188.0" VPOS="8292.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="9408.0" VPOS="8292.0"/>
+                        <String ID="TB.Img0027a.8_21_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="420.0" HPOS="9516.0" VPOS="8296.0" CONTENT="Salem" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="9936.0" VPOS="8292.0"/>
+                        <String ID="TB.Img0027a.8_21_4" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="948.0" HPOS="10048.0" VPOS="8304.0" CONTENT="community's" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_22" HEIGHT="172.0" WIDTH="3120.0" HPOS="7844.0" VPOS="8492.0">
+                        <String ID="TB.Img0027a.8_22_0" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="300.0" HPOS="7844.0" VPOS="8532.0" CONTENT="year" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="8144.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.8_22_1" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="336.0" HPOS="8220.0" VPOS="8540.0" CONTENT="were" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="8556.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.8_22_2" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="244.0" HPOS="8632.0" VPOS="8496.0" CONTENT="Dr." WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="8876.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.8_22_3" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="512.0" HPOS="8960.0" VPOS="8492.0" CONTENT="Robert" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="9472.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.8_22_4" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="664.0" HPOS="9556.0" VPOS="8492.0" CONTENT="Purbrick" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="10220.0" VPOS="8492.0"/>
+                        <String ID="TB.Img0027a.8_22_5" STYLEREFS="TS_10.0" HEIGHT="164.0" WIDTH="632.0" HPOS="10332.0" VPOS="8500.0" CONTENT="(science)" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_23" HEIGHT="188.0" WIDTH="2080.0" HPOS="7852.0" VPOS="8676.0">
+                        <String ID="TB.Img0027a.8_23_0" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="248.0" HPOS="7852.0" VPOS="8676.0" CONTENT="and" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="8100.0" VPOS="8676.0"/>
+                        <String ID="TB.Img0027a.8_23_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="280.0" HPOS="8212.0" VPOS="8680.0" CONTENT="Ted" WC="1.0"/>
+                        <SP WIDTH="112.0" HPOS="8492.0" VPOS="8676.0"/>
+                        <String ID="TB.Img0027a.8_23_2" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="540.0" HPOS="8604.0" VPOS="8680.0" CONTENT="Ogdahl" WC="1.0"/>
+                        <SP WIDTH="140.0" HPOS="9144.0" VPOS="8676.0"/>
+                        <String ID="TB.Img0027a.8_23_3" STYLEREFS="TS_10.0" HEIGHT="168.0" WIDTH="648.0" HPOS="9284.0" VPOS="8696.0" CONTENT="(sports)." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_24" HEIGHT="164.0" WIDTH="2968.0" HPOS="8028.0" VPOS="8948.0">
+                        <String ID="TB.Img0027a.8_24_0" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="240.0" HPOS="8028.0" VPOS="8948.0" CONTENT="Dr." WC="1.0"/>
+                        <SP WIDTH="168.0" HPOS="8268.0" VPOS="8948.0"/>
+                        <String ID="TB.Img0027a.8_24_1" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="508.0" HPOS="8436.0" VPOS="8948.0" CONTENT="Robert" WC="1.0"/>
+                        <SP WIDTH="172.0" HPOS="8944.0" VPOS="8948.0"/>
+                        <String ID="TB.Img0027a.8_24_2" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="136.0" HPOS="9116.0" VPOS="8956.0" CONTENT="L." WC="1.0"/>
+                        <SP WIDTH="184.0" HPOS="9252.0" VPOS="8948.0"/>
+                        <String ID="TB.Img0027a.8_24_3" STYLEREFS="TS_10.0" HEIGHT="160.0" WIDTH="708.0" HPOS="9436.0" VPOS="8952.0" CONTENT="Purbrick," WC="1.0"/>
+                        <SP WIDTH="176.0" HPOS="10144.0" VPOS="8948.0"/>
+                        <String ID="TB.Img0027a.8_24_4" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="312.0" HPOS="10320.0" VPOS="8948.0" CONTENT="who" WC="1.0"/>
+                        <SP WIDTH="148.0" HPOS="10632.0" VPOS="8948.0"/>
+                        <String ID="TB.Img0027a.8_24_5" STYLEREFS="TS_10.0" HEIGHT="132.0" WIDTH="216.0" HPOS="10780.0" VPOS="8948.0" CONTENT="has" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.8_25" HEIGHT="192.0" WIDTH="3144.0" HPOS="7848.0" VPOS="9128.0">
+                        <String ID="TB.Img0027a.8_25_0" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="480.0" HPOS="7848.0" VPOS="9128.0" CONTENT="headed" WC="1.0"/>
+                        <SP WIDTH="156.0" HPOS="8328.0" VPOS="9128.0"/>
+                        <String ID="TB.Img0027a.8_25_1" STYLEREFS="TS_10.0" HEIGHT="120.0" WIDTH="180.0" HPOS="8484.0" VPOS="9196.0" CONTENT="up" WC="1.0"/>
+                        <SP WIDTH="160.0" HPOS="8664.0" VPOS="9128.0"/>
+                        <String ID="TB.Img0027a.8_25_2" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="220.0" HPOS="8824.0" VPOS="9140.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="156.0" HPOS="9044.0" VPOS="9128.0"/>
+                        <String ID="TB.Img0027a.8_25_3" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="840.0" HPOS="9200.0" VPOS="9144.0" CONTENT="Willamette" WC="1.0"/>
+                        <SP WIDTH="152.0" HPOS="10040.0" VPOS="9128.0"/>
+                        <String ID="TB.Img0027a.8_25_4" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="136.0" HPOS="10192.0" VPOS="9152.0" CONTENT="U" WC="1.0"/>
+                        <SP WIDTH="156.0" HPOS="10328.0" VPOS="9128.0"/>
+                        <String ID="TB.Img0027a.8_25_5" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="508.0" HPOS="10484.0" VPOS="9144.0" CONTENT="physics" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns9="http://www.w3.org/1999/xlink" ID="TB.Img0027a.9" HEIGHT="3136" WIDTH="9012" HPOS="1776" VPOS="9576" ns9:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.9_0" HEIGHT="452.0" WIDTH="7748.0" HPOS="1776.0" VPOS="9576.0">
+                        <String ID="TB.Img0027a.9_0_0" STYLEREFS="TS_10.0" HEIGHT="176.0" WIDTH="52.0" HPOS="1776.0" VPOS="9792.0" CONTENT="1" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="1828.0" VPOS="9576.0"/>
+                        <String ID="TB.Img0027a.9_0_1" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="64.0" HPOS="1944.0" VPOS="9912.0" CONTENT=".(" WC="1.0"/>
+                        <SP WIDTH="144.0" HPOS="2008.0" VPOS="9576.0"/>
+                        <String ID="TB.Img0027a.9_0_2" STYLEREFS="TS_10.0" HEIGHT="172.0" WIDTH="48.0" HPOS="2152.0" VPOS="9848.0" CONTENT="j" WC="1.0"/>
+                        <SP WIDTH="264.0" HPOS="2200.0" VPOS="9576.0"/>
+                        <String ID="TB.Img0027a.9_0_3" STYLEREFS="TS_10.0" HEIGHT="368.0" WIDTH="96.0" HPOS="2464.0" VPOS="9604.0" CONTENT="J" WC="1.0"/>
+                        <SP WIDTH="584.0" HPOS="2560.0" VPOS="9576.0"/>
+                        <String ID="TB.Img0027a.9_0_4" STYLEREFS="TS_10.0" HEIGHT="204.0" WIDTH="28.0" HPOS="3144.0" VPOS="9772.0" CONTENT="I" WC="1.0"/>
+                        <SP WIDTH="1504.0" HPOS="3172.0" VPOS="9576.0"/>
+                        <String ID="TB.Img0027a.9_0_5" STYLEREFS="TS_10.0" HEIGHT="296.0" WIDTH="648.0" HPOS="4676.0" VPOS="9732.0" CONTENT="is" WC="1.0"/>
+                        <SP WIDTH="1684.0" HPOS="5324.0" VPOS="9576.0"/>
+                        <String ID="TB.Img0027a.9_0_6" STYLEREFS="TS_10.0_I" HEIGHT="44.0" WIDTH="20.0" HPOS="7008.0" VPOS="9744.0" CONTENT="'" WC="1.0"/>
+                        <SP WIDTH="1296.0" HPOS="7028.0" VPOS="9576.0"/>
+                        <String ID="TB.Img0027a.9_0_7" STYLEREFS="TS_10.0" HEIGHT="436.0" WIDTH="160.0" HPOS="8324.0" VPOS="9576.0" CONTENT="if" WC="1.0"/>
+                        <SP WIDTH="964.0" HPOS="8484.0" VPOS="9576.0"/>
+                        <String ID="TB.Img0027a.9_0_8" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="76.0" HPOS="9448.0" VPOS="9876.0" CONTENT="-!" WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.9_1" HEIGHT="376.0" WIDTH="4528.0" HPOS="6260.0" VPOS="12336.0">
+                        <String ID="TB.Img0027a.9_1_0" STYLEREFS="TS_10.0_I" HEIGHT="376.0" WIDTH="1916.0" HPOS="6260.0" VPOS="12336.0" CONTENT="rx:00y-y" WC="1.0"/>
+                        <SP WIDTH="116.0" HPOS="8176.0" VPOS="12336.0"/>
+                        <String ID="TB.Img0027a.9_1_1" STYLEREFS="TS_10.0_I" HEIGHT="44.0" WIDTH="36.0" HPOS="8292.0" VPOS="12468.0" CONTENT="'" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="8328.0" VPOS="12336.0"/>
+                        <String ID="TB.Img0027a.9_1_2" STYLEREFS="TS_10.0_I" HEIGHT="352.0" WIDTH="1276.0" HPOS="8408.0" VPOS="12336.0" CONTENT="MMiAfr" WC="1.0"/>
+                        <SP WIDTH="188.0" HPOS="9684.0" VPOS="12336.0"/>
+                        <String ID="TB.Img0027a.9_1_3" STYLEREFS="TS_10.0" HEIGHT="84.0" WIDTH="116.0" HPOS="9872.0" VPOS="12500.0" CONTENT="&#34;" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="9988.0" VPOS="12336.0"/>
+                        <String ID="TB.Img0027a.9_1_4" STYLEREFS="TS_10.0" HEIGHT="372.0" WIDTH="696.0" HPOS="10092.0" VPOS="12340.0" CONTENT="ifPH" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns10="http://www.w3.org/1999/xlink" ID="TB.Img0027a.10" HEIGHT="200" WIDTH="5416" HPOS="5520" VPOS="13544" ns10:type="simple" language="eng"/>
+                <TextBlock xmlns:ns11="http://www.w3.org/1999/xlink" ID="TB.Img0027a.11" HEIGHT="312" WIDTH="9248" HPOS="1428" VPOS="13752" ns11:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.11_0" HEIGHT="136.0" WIDTH="7336.0" HPOS="1576.0" VPOS="13752.0">
+                        <String ID="TB.Img0027a.11_0_0" STYLEREFS="TS_10.0" HEIGHT="68.0" WIDTH="344.0" HPOS="1576.0" VPOS="13752.0" CONTENT="mciNs" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="1920.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_1" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="1360.0" HPOS="2000.0" VPOS="13760.0" CONTENT="uuKvuiUKT-tt-snape" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="3360.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_2" STYLEREFS="TS_10.0" HEIGHT="104.0" WIDTH="380.0" HPOS="3444.0" VPOS="13760.0" CONTENT="design" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="3824.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_3" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="116.0" HPOS="3908.0" VPOS="13752.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="4024.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_4" STYLEREFS="TS_10.0" HEIGHT="92.0" WIDTH="640.0" HPOS="4104.0" VPOS="13760.0" CONTENT="Willamette" WC="1.0"/>
+                        <SP WIDTH="80.0" HPOS="4744.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_5" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="692.0" HPOS="4824.0" VPOS="13760.0" CONTENT="University's" WC="1.0"/>
+                        <SP WIDTH="76.0" HPOS="5516.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_6" STYLEREFS="TS_10.0" HEIGHT="68.0" WIDTH="244.0" HPOS="5592.0" VPOS="13804.0" CONTENT="new" WC="1.0"/>
+                        <SP WIDTH="72.0" HPOS="5836.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_7" STYLEREFS="TS_10.0" HEIGHT="104.0" WIDTH="496.0" HPOS="5908.0" VPOS="13780.0" CONTENT="240-man" WC="1.0"/>
+                        <SP WIDTH="108.0" HPOS="6404.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_8" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="116.0" HPOS="6512.0" VPOS="13788.0" CONTENT="$1" WC="1.0"/>
+                        <SP WIDTH="68.0" HPOS="6628.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_9" STYLEREFS="TS_10.0" HEIGHT="88.0" WIDTH="208.0" HPOS="6696.0" VPOS="13800.0" CONTENT="036" WC="1.0"/>
+                        <SP WIDTH="48.0" HPOS="6904.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_10" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="208.0" HPOS="6952.0" VPOS="13808.0" CONTENT="3(M" WC="1.0"/>
+                        <SP WIDTH="64.0" HPOS="7160.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_11" STYLEREFS="TS_10.0" HEIGHT="80.0" WIDTH="388.0" HPOS="7224.0" VPOS="13808.0" CONTENT=",J,m-." WC="1.0"/>
+                        <SP WIDTH="524.0" HPOS="7612.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_12" STYLEREFS="TS_10.0_M" HEIGHT="52.0" WIDTH="56.0" HPOS="8136.0" VPOS="13836.0" CONTENT="l" WC="1.0"/>
+                        <SP WIDTH="480.0" HPOS="8192.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_13" STYLEREFS="TS_10.0" HEIGHT="24.0" WIDTH="20.0" HPOS="8672.0" VPOS="13856.0" CONTENT="." WC="1.0"/>
+                        <SP WIDTH="200.0" HPOS="8692.0" VPOS="13752.0"/>
+                        <String ID="TB.Img0027a.11_0_14" STYLEREFS="TS_10.0" HEIGHT="32.0" WIDTH="20.0" HPOS="8892.0" VPOS="13856.0" CONTENT="." WC="1.0"/>
+                    </TextLine>
+                    <TextLine ID="TB.Img0027a.11_1" HEIGHT="224.0" WIDTH="9248.0" HPOS="1428.0" VPOS="13840.0">
+                        <String ID="TB.Img0027a.11_1_0" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="684.0" HPOS="1428.0" VPOS="13876.0" CONTENT="constructed" WC="1.0"/>
+                        <SP WIDTH="104.0" HPOS="2112.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_1" STYLEREFS="TS_10.0" HEIGHT="124.0" WIDTH="200.0" HPOS="2216.0" VPOS="13884.0" CONTENT="just" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="2416.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_2" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="316.0" HPOS="2508.0" VPOS="13884.0" CONTENT="south" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="2824.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_3" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="120.0" HPOS="2920.0" VPOS="13888.0" CONTENT="of" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="3040.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_4" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="180.0" HPOS="3128.0" VPOS="13888.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="3308.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_5" STYLEREFS="TS_10.0" HEIGHT="108.0" WIDTH="440.0" HPOS="3404.0" VPOS="13916.0" CONTENT="present" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="3844.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_6" STYLEREFS="TS_10.0" HEIGHT="96.0" WIDTH="372.0" HPOS="3940.0" VPOS="13904.0" CONTENT="Baxter" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="4312.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_7" STYLEREFS="TS_10.0" HEIGHT="104.0" WIDTH="224.0" HPOS="4408.0" VPOS="13904.0" CONTENT="Hall" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="4632.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_8" STYLEREFS="TS_10.0" HEIGHT="96.0" WIDTH="196.0" HPOS="4728.0" VPOS="13916.0" CONTENT="site" WC="1.0"/>
+                        <SP WIDTH="96.0" HPOS="4924.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_9" STYLEREFS="TS_10.0" HEIGHT="128.0" WIDTH="496.0" HPOS="5020.0" VPOS="13916.0" CONTENT="adjacent" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="5516.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_10" STYLEREFS="TS_10.0" HEIGHT="84.0" WIDTH="112.0" HPOS="5600.0" VPOS="13940.0" CONTENT="to" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="5712.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_11" STYLEREFS="TS_10.0" HEIGHT="104.0" WIDTH="448.0" HPOS="5804.0" VPOS="13932.0" CONTENT="Twelfth" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="6252.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_12" STYLEREFS="TS_10.0" HEIGHT="84.0" WIDTH="324.0" HPOS="6344.0" VPOS="13964.0" CONTENT="street" WC="1.0"/>
+                        <SP WIDTH="120.0" HPOS="6668.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_13" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="180.0" HPOS="6788.0" VPOS="13956.0" CONTENT="the" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="6968.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_14" STYLEREFS="TS_10.0" HEIGHT="224.0" WIDTH="556.0" HPOS="7056.0" VPOS="13840.0" CONTENT="structuT" WC="1.0"/>
+                        <SP WIDTH="40.0" HPOS="7612.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_15" STYLEREFS="TS_10.0" HEIGHT="204.0" WIDTH="412.0" HPOS="7652.0" VPOS="13860.0" CONTENT="Jll&#34;&#34;" WC="1.0"/>
+                        <SP WIDTH="1032.0" HPOS="8064.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_16" STYLEREFS="TS_10.0" HEIGHT="188.0" WIDTH="360.0" HPOS="9096.0" VPOS="13860.0" CONTENT="!bV-" WC="1.0"/>
+                        <SP WIDTH="72.0" HPOS="9456.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_17" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="752.0" HPOS="9528.0" VPOS="13860.0" CONTENT="Pho,9raPh-" WC="1.0"/>
+                        <SP WIDTH="72.0" HPOS="10280.0" VPOS="13840.0"/>
+                        <String ID="TB.Img0027a.11_1_18" STYLEREFS="TS_10.0_P" HEIGHT="116.0" WIDTH="324.0" HPOS="10352.0" VPOS="13868.0" CONTENT="Bemg" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns12="http://www.w3.org/1999/xlink" ID="TB.Img0027a.12" HEIGHT="152" WIDTH="3204" HPOS="6792" VPOS="14008" ns12:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.12_0" HEIGHT="152.0" WIDTH="3204.0" HPOS="6792.0" VPOS="14008.0">
+                        <String ID="TB.Img0027a.12_0_0" STYLEREFS="TS_10.0" HEIGHT="48.0" WIDTH="100.0" HPOS="6792.0" VPOS="14008.0" CONTENT=".n" WC="1.0"/>
+                        <SP WIDTH="164.0" HPOS="6892.0" VPOS="14008.0"/>
+                        <String ID="TB.Img0027a.12_0_1" STYLEREFS="TS_10.0" HEIGHT="68.0" WIDTH="512.0" HPOS="7056.0" VPOS="14008.0" CONTENT="srrucrure" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="7568.0" VPOS="14008.0"/>
+                        <String ID="TB.Img0027a.12_0_2" STYLEREFS="TS_10.0" HEIGHT="76.0" WIDTH="216.0" HPOS="7652.0" VPOS="14008.0" CONTENT="w,ll" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="7868.0" VPOS="14008.0"/>
+                        <String ID="TB.Img0027a.12_0_3" STYLEREFS="TS_10.0" HEIGHT="72.0" WIDTH="252.0" HPOS="7956.0" VPOS="14024.0" CONTENT="ease" WC="1.0"/>
+                        <SP WIDTH="88.0" HPOS="8208.0" VPOS="14008.0"/>
+                        <String ID="TB.Img0027a.12_0_4" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="444.0" HPOS="8296.0" VPOS="14040.0" CONTENT="campus" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="8740.0" VPOS="14008.0"/>
+                        <String ID="TB.Img0027a.12_0_5" STYLEREFS="TS_10.0" HEIGHT="140.0" WIDTH="472.0" HPOS="8824.0" VPOS="14012.0" CONTENT="housing" WC="1.0"/>
+                        <SP WIDTH="92.0" HPOS="9296.0" VPOS="14008.0"/>
+                        <String ID="TB.Img0027a.12_0_6" STYLEREFS="TS_10.0" HEIGHT="136.0" WIDTH="608.0" HPOS="9388.0" VPOS="14024.0" CONTENT="problems." WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+                <TextBlock xmlns:ns13="http://www.w3.org/1999/xlink" ID="TB.Img0027a.13" HEIGHT="120" WIDTH="1492" HPOS="9476" VPOS="14280" ns13:type="simple" language="eng">
+                    <TextLine ID="TB.Img0027a.13_0" HEIGHT="120.0" WIDTH="1492.0" HPOS="9476.0" VPOS="14280.0">
+                        <String ID="TB.Img0027a.13_0_0" STYLEREFS="TS_10.0" HEIGHT="100.0" WIDTH="792.0" HPOS="9476.0" VPOS="14300.0" CONTENT="WILLAMETTE" WC="1.0"/>
+                        <SP WIDTH="84.0" HPOS="10268.0" VPOS="14280.0"/>
+                        <String ID="TB.Img0027a.13_0_1" STYLEREFS="TS_10.0" HEIGHT="116.0" WIDTH="616.0" HPOS="10352.0" VPOS="14280.0" CONTENT="ALUMNUS" WC="1.0"/>
+                    </TextLine>
+                </TextBlock>
+            </PrintSpace>
+        </Page>
+    </Layout>
+</alto>


### PR DESCRIPTION
Relates to https://github.com/dbmdz/solr-ocrhighlighting/issues/93

This PR allows the retrieval of word coordinates that have been encoded with float values in ALTO files by converting these values to integers. The approach taken requires Java 7+ and has the same effect as Math.floor(). The conversion applies to all coordinates and may have a minor performance impact.

The PR also adds a test and a new resource file.


