### PR TITLE
Add text to regions, bugfixes, update demo

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   solr:
-    image: solr:8.4
+    image: solr:8.5
     ports:
       - "1044:1044"  # Debugging port
       - "8983:8983"  # Solr admin interface
@@ -10,10 +10,11 @@ services:
       - ./solr/core:/opt/core-config
       - index-data:/var/solr/data
       - ./data:/data
+      - ../target:/build
     environment:
       - ENABLE_REMOTE_JMX_OPTS=true
       - SOLR_HEAP=4g
-      - SOLR_ADDL_ARGS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044"
+      - ADDITIONAL_CMD_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:1044
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate

--- a/example/frontend/index.js
+++ b/example/frontend/index.js
@@ -28,14 +28,14 @@ var PARAMS = {
 };
 var BNL_10MM_TO_PIX_FACTOR = 300 / 254;
 var IMAGE_API_BASE = 'https://ocrhl.jbaiter.de/iiif/image/v2'
-//if (typeof window !== 'undefined') {
-//  var APP_BASE = `${window.location.protocol || 'http:'}//${window.location.host}`;
-//} else {
-//  var APP_BASE = 'http://localhost:8181';  // TODO: Read from environment?
-//}
-var APP_BASE = 'http://localhost:8181';
+if (typeof window !== 'undefined') {
+  var APP_BASE = `${window.location.protocol || 'http:'}//${window.location.host}`;
+} else {
+  var APP_BASE = 'http://localhost:8181';  // TODO: Read from environment?
+}
 
 
+// Largely a 1:1 port of https://github.com/ZeeCoder/use-resize-observer (MIT-licensed) to Preact
 function useResizeObserver({ ref, onResize }) {
   const defaultRef = useRef(null);
 

--- a/example/frontend/package-lock.json
+++ b/example/frontend/package-lock.json
@@ -10089,6 +10089,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",

--- a/example/frontend/package.json
+++ b/example/frontend/package.json
@@ -25,6 +25,7 @@
     "preact": "^10.4.0",
     "preact-cli": "^2.2.1",
     "preact-compat": "^3.19.0",
-    "preact-material-components": "^1.6.1"
+    "preact-material-components": "^1.6.1",
+    "resize-observer-polyfill": "^1.5.1"
   }
 }

--- a/example/frontend/style.css
+++ b/example/frontend/style.css
@@ -70,7 +70,8 @@ main p {
 	border-radius: 8px;
 }
 
-.region-display {
+.region-img-container {
+	display: inline-block;
 	position: relative;
 }
 

--- a/example/frontend/style.css
+++ b/example/frontend/style.css
@@ -61,7 +61,6 @@ main p {
 }
 
 .snippet-display {
-	position: relative;
 	box-shadow: 1px 2px 8px;
     border-radius: 8px;
 }
@@ -69,6 +68,10 @@ main p {
 .snippet-display img {
 	max-width: 100%;
 	border-radius: 8px;
+}
+
+.region-display {
+	position: relative;
 }
 
 .metadata {

--- a/example/solr/install-plugin.sh
+++ b/example/solr/install-plugin.sh
@@ -1,20 +1,25 @@
 #!/bin/bash
 set -e
 
-function extract_json() {
-    path="$1"
-    python -c "import json, sys; print json.load(sys.stdin)$path"
-}
-
 RELEASE_URL="https://api.github.com/repos/dbmdz/solr-ocrhighlighting/releases/latest"
 PLUGIN_LIB_DIR="/var/solr/data/plugins"
 
+wget -q https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O/tmp/jq
+chmod +x /tmp/jq
+
 mkdir -p "$PLUGIN_LIB_DIR"
 
-# Get the URL and filename for the latest release
-release_desc="$(curl -sS "$RELEASE_URL")"
-fname="$(echo "$release_desc" |extract_json "['assets'][0]['name']")"
-if [ ! -f "$PLUGIN_LIB_DIR"/"$fname" ]; then
-    url="$(echo "$release_desc" |extract_json "['assets'][0]['browser_download_url']")"
-    wget "$url" -P "$PLUGIN_LIB_DIR"
+if [ "$(ls /build |grep 'jar')" ]; then
+    # Copy the plugin from the build directory
+    echo "Installing plugin from build directory"
+    cp /build/solr-ocrhighlighting-*.jar "$PLUGIN_LIB_DIR"/
+else
+    # Get the URL and filename for the latest release
+    echo "Installing plugin from latest GitHub release"
+    release_desc="$(curl -sS "$RELEASE_URL")"
+    fname="$(echo "$release_desc" |/tmp/jq -r ".assets[0].name")"
+    if [ ! -f "$PLUGIN_LIB_DIR"/"$fname" ]; then
+        url="$(echo "$release_desc" |/tmp/jq -r ".assets[0].browser_download_url")"
+        wget -q "$url" -P "$PLUGIN_LIB_DIR"
+    fi
 fi

--- a/integration-tests/test.py
+++ b/integration-tests/test.py
@@ -17,7 +17,8 @@ HOCR_SNIPS = [
         "text": "rait par les bénéfices aux frais de l'expédition.Ce fut au mois de juin 1525 que partit <em>Francisco Pizarro de Panama</em> avec un navire et cent-vingt hommes.Nous le laisserons un instant pour revenir",
         "pages": [{"height": 2393, "id": "page_205", "width": 1476}],
         "regions": [
-            {"ulx": 170, "uly": 446, "lrx": 1124, "lry": 796, "pageIdx": 0}
+            {"ulx": 170, "uly": 446, "lrx": 1124, "lry": 796, "pageIdx": 0,
+             "text": "rait par les bénéfices aux frais de l'expédition. Ce fut au mois de juin 1525 que partit <em>Francisco Pizarro de Panama</em> avec un navire et cent-vingt hommes. Nous le laisserons un instant pour revenir" }
         ],
         "highlights": [
             [
@@ -44,7 +45,8 @@ ALTO_SNIPS = [
         "text": "— Ce n'est rien, faisait Lisbeth ; c'est la charrette de <em>Hans Bockel</em> qui passe, ou bien c'est la mère Dreyfus qui s'en va maintenant à la veillée chez les Brêmer.",
         "pages": [{"height": 4790, "id": "P2", "width": 3140}],
         "regions": [
-            {"ulx": 1621, "uly": 3710, "lrx": 2294, "lry": 3847, "pageIdx": 0}
+            {"ulx": 1621, "uly": 3710, "lrx": 2294, "lry": 3847, "pageIdx": 0,
+             "text": "— Ce n'est rien, faisait Lisbeth ; c'est la charrette de <em>Hans Bockel</em> qui passe, ou bien c'est la mère Dreyfus qui s'en va maintenant à la veillée chez les Brêmer." }
         ],
         "highlights": [
             [

--- a/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
@@ -156,20 +156,23 @@ public abstract class OcrPassageFormatter extends PassageFormatter {
     List<List<OcrBox>> byColumns = new ArrayList<>();
     List<OcrBox> currentCol = new ArrayList<>();
     OcrBox prevBox = null;
+    String pageId = null;
     for (OcrBox box : allBoxes) {
       // Stupid, haphazard heuristic for column detection: If the next box is at least the height of the current box
       // times five higher on the page, we're on a new column. Or if the page changes.
       // FIXME: This cleary needs some more thought put into it
-      boolean newColumn =
-          prevBox != null
-              && ((box.getUly() + prevBox.getHeight() * 5) < prevBox.getUly()
-                  || (!box.getPageId().equals(prevBox.getPageId())));
-      if (newColumn) {
+      boolean newColumn = prevBox != null && (box.getUly() + prevBox.getHeight() * 5) < prevBox.getUly();
+      boolean newPage = pageId != null && !box.getPageId().equals(pageId);
+      if (newColumn || newPage) {
         byColumns.add(currentCol);
         currentCol = new ArrayList<>();
       }
       currentCol.add(box);
-      prevBox = box;
+      // Skip very low-height boxes since they throw off the heuristic, we still track page changes, though!
+      if (box.getHeight() > 5) {
+        prevBox = box;
+      }
+      pageId = box.getPageId();
     }
     byColumns.add(currentCol);
 

--- a/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
@@ -144,6 +144,7 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
       int w = (int) Double.parseDouble(attribs.get("WIDTH"));
       int h = (int) Double.parseDouble(attribs.get("HEIGHT"));
       String subsType = attribs.get("SUBS_TYPE");
+
       String text = StringEscapeUtils.unescapeXml(attribs.get("CONTENT"));
       if ("HypPart1".equals(subsType)) {
         text += "-";
@@ -151,8 +152,8 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
       if (text.contains(START_HL) || attribs.getOrDefault("SUBS_CONTENT", "").contains(START_HL)) {
         inHighlight = true;
       }
-      wordBoxes.add(new OcrBox(text.replace(START_HL, "")
-                                   .replace(END_HL, ""),
+      wordBoxes.add(new OcrBox(text.replace(START_HL, startHlTag)
+                                   .replace(END_HL, endHlTag),
                                pageId,  x, y, x + w, y + h, inHighlight));
 
       if (inHighlight && subsType != null) {

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -101,8 +101,7 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
       if (text.contains(startHlTag)) {
         inHighlight = true;
       }
-      wordBoxes.add(new OcrBox(text.replace(startHlTag, "").replace(endHlTag, ""),
-                               pageId, x0, y0, x1, y1, inHighlight));
+      wordBoxes.add(new OcrBox(text, pageId, x0, y0, x1, y1, inHighlight));
       boolean endOfHl = (
           text.contains(endHlTag)
           || ocrFragment.substring(m.end(), Math.min(m.end() + endHlTag.length(), ocrFragment.length()))

--- a/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrPassageFormatter.java
@@ -93,6 +93,8 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
           box.setUly(truncateFloat((box.getUly() - yOffset) / snipHeight));
           box.setLry(truncateFloat((box.getLry() - yOffset) / snipHeight));
           box.setParentRegionIdx(snippet.getSnippetRegions().indexOf(region.get()));
+          // Remove the highlighting tags from the text
+          box.setText(box.getText().replaceAll(startHlTag, "").replaceAll(endHlTag, ""));
         });
     hlSpans.forEach(span -> snippet.addHighlightSpan(this.mergeBoxes(span)));
   }
@@ -115,8 +117,7 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
       if (text.contains(startHlTag)) {
         inHighlight = true;
       }
-      wordBoxes.add(new OcrBox(text.replace(startHlTag, "").replace(endHlTag, ""),
-                               pageId, x, y, x + width, y + height, inHighlight));
+      wordBoxes.add(new OcrBox(text, pageId, x, y, x + width, y + height, inHighlight));
       boolean endOfHl = (
           text.contains(endHlTag)
           || ocrFragment.substring(m.end(), Math.min(m.end() + endHlTag.length(), ocrFragment.length()))

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrFieldHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrFieldHighlighter.java
@@ -123,8 +123,12 @@ public class OcrFieldHighlighter extends FieldHighlighter {
         limitReached = true;
         continue;
       }
+      // advance breakIterator
+      int passageStart = Math.max(breakIter.preceding(start + 1), 0);
+      int passageEnd = Math.min(breakIter.following(end), contentLength);
+
       // See if this term should be part of a new passage.
-      if (start >= passage.getEndOffset()) {
+      if (passageStart >= passage.getEndOffset()) {
         if (passage.getStartOffset() >= 0) {
           numTotal++;
         }
@@ -133,12 +137,9 @@ public class OcrFieldHighlighter extends FieldHighlighter {
         if (start >= contentLength) {
           break;
         }
-        // advance breakIterator
-        passage.setStartOffset(Math.max(breakIter.preceding(start + 1), 0));
-        passage.setEndOffset(Math.min(breakIter.following(end), contentLength));
-      } else {
-        passage.setEndOffset(Math.min(breakIter.following(end), contentLength));
+        passage.setStartOffset(passageStart);
       }
+      passage.setEndOffset(passageEnd);
       // Add this term to the passage.
       BytesRef term = off.getTerm();// a reference; safe to refer to
       assert term != null;

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
@@ -40,6 +40,10 @@ public class ExternalUtf8ContentFilterFactory extends CharFilterFactory {
       // Read the input fully to obtain the source pointer
       String ptrStr = IOUtils.toString(input);
       SourcePointer pointer = SourcePointer.parse(ptrStr);
+      if (pointer == null) {
+        throw new RuntimeException(String.format(
+            "Could not parse source pointer from field, check the format (value was: '%s')!", ptrStr));
+      }
       pointer.sources.forEach(this::validateSource);
 
       // Regions contained in source pointers are defined by byte offsets.

--- a/src/main/java/de/digitalcollections/solrocr/model/OcrBox.java
+++ b/src/main/java/de/digitalcollections/solrocr/model/OcrBox.java
@@ -12,24 +12,25 @@ public class OcrBox implements Comparable<OcrBox> {
       .thenComparingDouble(OcrBox::getUly)
       .thenComparingDouble(OcrBox::getUlx);
 
-  private String pageId;
   private String text;
+  private String pageId;
   private float ulx;
   private float uly;
   private float lrx;
   private float lry;
-  private boolean isHighlight;
+  private boolean inHighlight;
   private Integer parentRegionIdx;
 
 
-  public OcrBox(String text, String pageId, float ulx, float uly, float lrx, float lry, boolean isHighlight) {
+  public OcrBox(String text, String pageId, float ulx, float uly, float lrx, float lry,
+                boolean inHighlight) {
     this.text = text;
     this.pageId = pageId;
     this.ulx = ulx;
     this.uly = uly;
     this.lrx = lrx;
     this.lry = lry;
-    this.isHighlight = isHighlight;
+    this.inHighlight = inHighlight;
   }
 
   private void addDimension(SimpleOrderedMap map, String name, float val) {
@@ -114,8 +115,8 @@ public class OcrBox implements Comparable<OcrBox> {
     return lry - uly;
   }
 
-  public boolean isHighlight() {
-    return isHighlight;
+  public boolean isInHighlight() {
+    return inHighlight;
   }
 
   public void setText(String text) {
@@ -142,8 +143,8 @@ public class OcrBox implements Comparable<OcrBox> {
     this.lry = lry;
   }
 
-  public void setHighlight(boolean highlight) {
-    isHighlight = highlight;
+  public void setInHighlight(boolean inHighlight) {
+    this.inHighlight = inHighlight;
   }
 
   public Integer getParentRegionIdx() {

--- a/src/main/java/de/digitalcollections/solrocr/model/OcrSnippet.java
+++ b/src/main/java/de/digitalcollections/solrocr/model/OcrSnippet.java
@@ -75,14 +75,15 @@ public class OcrSnippet {
     NamedList[] pageEntries = this.pages.stream()
         .map(OcrPage::toNamedList).toArray(NamedList[]::new);
     m.add("pages", pageEntries);
-    NamedList[] snips = this.snippetRegions.stream()
+    NamedList[] regions = this.snippetRegions.stream()
         .map(b -> b.toNamedList(pages)).toArray(NamedList[]::new);
-    m.add("regions", snips);
+    m.add("regions", regions);
     if (this.getHighlightSpans() != null) {
       List<NamedList[]> highlights = new ArrayList<>();
       for (OcrBox[] region : this.getHighlightSpans()) {
         NamedList[] regionBoxes = Arrays.stream(region)
-            .map(OcrBox::toNamedList).toArray(NamedList[]::new);
+            .map(OcrBox::toNamedList)
+            .toArray(NamedList[]::new);
         highlights.add(regionBoxes);
       }
       m.add("highlights", highlights);

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -133,13 +133,16 @@ public class AltoTest extends SolrTestCaseJ4 {
     // We had a bug that resulted in multiple regions here, this assert just tests for that
     assertQ(
         req,
-        "count(//arr[@name='regions']/lst)=1"
+        "count(//arr[@name='regions']/lst)=1",
+        "contains(//arr[@name='regions']/lst/str[@name='text']/text(), 'charrette de <em>Hans Bockel</em> qui passe,')"
     );
     // Phrase spanning multiple columns
     req = xmlQ("q", "\"moineau qui possède\"", "hl.weightMatches", "true");
     assertQ(
         req,
         "count(//arr[@name='regions']/lst)=2",
+        "contains(//arr[@name='regions']/lst[1]/str[@name='text']/text(), 'histoire du <em>moineau</em>')",
+        "contains(//arr[@name='regions']/lst[2]/str[@name='text'], '<em>qui possède</em> deux fois')",
         "count(//arr[@name='highlights']/arr)=1",
         "count(//arr[@name='highlights']/arr/lst)=2",
         "//arr[@name='highlights']/arr/lst[1]/int[@name='parentRegionIdx']/text()='0'",

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -211,4 +211,10 @@ public class HocrTest extends SolrTestCaseJ4 {
         "(//int[@name='parentRegionIdx'])[1]=0",
         "(//int[@name='parentRegionIdx'])[2]=1");
   }
+
+  @Test
+  public void testPassageContextMerge() {
+    SolrQueryRequest req = xmlQ("q", "haribo");
+    assertQ(req, "count(//arr[@name='snippets']/lst)=1");
+  }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -202,6 +202,12 @@ public class HocrTest extends SolrTestCaseJ4 {
         "count(//arr[@name='snippets']/lst)=1",
         "count(//arr[@name='snippets']/lst/arr[@name='regions']/lst)=2",
         "count(//arr[@name='snippets']/lst/arr[@name='highlights']/arr)=1",
+        "//arr[@name='regions']/lst[1]/str[@name='text']='Die General-Verwaltung der königlichen Eiſenbahnen "
+            + "beſteht aus einem Vorſtande, zwei Räthen, wovon einer der Komptabilität kundig ſeyn muß, einem "
+            + "Ober-Ingenieur, einem Maſchinenmeiſter, den erforderlichen <em>Kaffe</em>-,'",
+        "//arr[@name='regions']/lst[2]/str[@name='text']='<em>Rechnungs</em>-, Kanzlei-, Regiſtratur- und techniſchen "
+            + "Gehülfen-Perſonal Der Geſchäftsgang iſt bei der k. Eiſenbahn, ſoferne nicht für beſondere Fälle "
+            + "kollegiale Behandlung vorgeſchrieben iſt, bureaukratiſch, und der Vorſtand'",
         "(//int[@name='parentRegionIdx'])[1]=0",
         "(//int[@name='parentRegionIdx'])[2]=1");
   }


### PR DESCRIPTION
This PR got a bit out of hand since I was discovering  bugs left and right during testing of the initial "regions should carry their text" feature. But here we go:

1. Every region now carries the highlighted text it contains. This should allow for easy rendering of `alt` Attributes on region images without having to do clumsy text-processing of the complete snippet text.
2. The column splitting heuristic was tweaked to produce less false positives.
3. Subsequent passages with overlapping regions are now merged to form a bigger region. Previously this would result in snippets that contained some of the same lines as another snippet for the same document.
4. Better error messages during indexing. Previously users would just get a NPE message if a file was non-existant, now there's a hopefully helpful human-readable error message.
5. Add support for multi-column highlighting to the included example demo.

## Review Guide
The core set of changes is found here:

- [Adding the contained text to regions](https://github.com/dbmdz/solr-ocrhighlighting/pull/102/files?file-filters%5B%5D=.html&file-filters%5B%5D=.java#diff-a6949160109aea88a8f46c0caa50361eR223-R233)
- [Improved column splitting](https://github.com/dbmdz/solr-ocrhighlighting/pull/102/files?file-filters%5B%5D=.html&file-filters%5B%5D=.java#diff-a6949160109aea88a8f46c0caa50361eR159-R175)
- [Fixed passage merging](https://github.com/dbmdz/solr-ocrhighlighting/pull/102/files?file-filters%5B%5D=.html&file-filters%5B%5D=.java#diff-6271eb6a98da54dfdff00675ef892d21R126-R142)

The rest of the changeset is mostly downstream API users in the examples that had to be modified and tests.