### PR TITLE
Sort snippets by their descending score.

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrFieldHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrFieldHighlighter.java
@@ -7,6 +7,7 @@ import de.digitalcollections.solrocr.util.PageCacheWarmer;
 import java.io.IOException;
 import java.text.BreakIterator;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,7 +64,9 @@ public class OcrFieldHighlighter extends FieldHighlighter {
     }
 
     if (passages.length > 0) {
-      return formatter.format(passages, content);
+      OcrSnippet[] snippets = formatter.format(passages, content);
+      Arrays.sort(snippets, Collections.reverseOrder());
+      return snippets;
     } else {
       return null;
     }

--- a/src/main/java/de/digitalcollections/solrocr/model/OcrSnippet.java
+++ b/src/main/java/de/digitalcollections/solrocr/model/OcrSnippet.java
@@ -2,12 +2,14 @@ package de.digitalcollections.solrocr.model;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 
 /** A structured representation of a highlighted OCR snippet. */
-public class OcrSnippet {
+public class OcrSnippet implements Comparable<OcrSnippet> {
+  private static final Comparator<OcrSnippet> COMPARATOR = Comparator.comparing(OcrSnippet::getScore);
   private final String text;
   private final List<OcrPage> pages;
   private final List<OcrBox> snippetRegions;
@@ -89,5 +91,10 @@ public class OcrSnippet {
       m.add("highlights", highlights);
     }
     return m;
+  }
+
+  @Override
+  public int compareTo(OcrSnippet other) {
+    return COMPARATOR.compare(this, other);
   }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoMultiTest.java
@@ -70,13 +70,13 @@ public class AltoMultiTest extends SolrTestCaseJ4 {
         req,
         "count(//arr[@name='snippets']/lst)=3",
         "count(//arr[@name='pages'][1]/lst)=3",
-        "(//arr[@name='pages']/lst/str[@name='id'])[1]/text()='P1'",
-        "(//arr[@name='pages']/lst/int[@name='width'])[1]/text()='3170'",
-        "(//arr[@name='pages']/lst/int[@name='height'])[1]/text()='4890'",
+        "(//arr[@name='pages']/lst/str[@name='id'])[2]/text()='P1'",
+        "(//arr[@name='pages']/lst/int[@name='width'])[2]/text()='3170'",
+        "(//arr[@name='pages']/lst/int[@name='height'])[2]/text()='4890'",
         "(//int[@name='pageIdx'])[1]/text()='0'",
-        "(//arr[@name='snippets']/lst/str[@name='text'])[1]/text()='Embranchement de <em>Bettembourg</em> à Esch s/A.'",
-        "(//arr[@name='snippets']/lst/str[@name='text'])[2]/text()='Retour à Luxembourg pour les deux embranchements Départ de <em>Bettembourg</em>: 6h. 50 du soir. |'",
-        "(//arr[@name='snippets']/lst/str[@name='text'])[3]/text()='Embranchement de <em>Bettembourg</em> à Ottange.'");
+        "(//arr[@name='snippets']/lst/str[@name='text'])[2]/text()='Embranchement de <em>Bettembourg</em> à Esch s/A.'",
+        "(//arr[@name='snippets']/lst/str[@name='text'])[3]/text()='Retour à Luxembourg pour les deux embranchements Départ de <em>Bettembourg</em>: 6h. 50 du soir. |'",
+        "(//arr[@name='snippets']/lst/str[@name='text'])[1]/text()='Embranchement de <em>Bettembourg</em> à Ottange.'");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -124,7 +124,7 @@ public class HocrTest extends SolrTestCaseJ4 {
   public void testLimitBlockHonored() throws Exception {
     SolrQueryRequest req = xmlQ("q", "Japan", "hl.ocr.absoluteHighlights", "true");
     assertQ(req,
-            "(//arr[@name='snippets']/lst/str[@name='text']/text())[3]='object too hastily, in addition to the facts already stated it ought to be remarked, that Kunnpfer describes the coast of<em>Japan</em>'");
+            "(//arr[@name='snippets']/lst/str[@name='text']/text())[1]='object too hastily, in addition to the facts already stated it ought to be remarked, that Kunnpfer describes the coast of<em>Japan</em>'");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -217,4 +217,14 @@ public class HocrTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = xmlQ("q", "haribo");
     assertQ(req, "count(//arr[@name='snippets']/lst)=1");
   }
+
+  @Test
+  public void testPassageSorting() {
+    String firstSnip = "auf und ſchob <em>Fenia</em> ſo eilig er konnte hinein. Denn vom untern Sto>werk wurden "
+        + "Stimmen laut, und einer der Tatarenkellner geleitete fremde Herrſchaften hinauf.";
+    SolrQueryRequest req = xmlQ("q", "fenia", "hl.snippets", "1");
+    assertQ(req, String.format("//arr[@name='snippets']/lst[1]//str[@name='text']/text()='%s'", firstSnip));
+    req = xmlQ("q", "fenia", "hl.snippets", "100");
+    assertQ(req, String.format("//arr[@name='snippets']/lst[1]//str[@name='text']/text()='%s'", firstSnip));
+  }
 }


### PR DESCRIPTION
Previously snippets were not explicitly ordered, which resulted in different top-n snippets when changing the number of snippets returned. We now sort the snippets by their relevance score in descending order, i.e. the most relevant snippets will the the first in the list.