### PR TITLE
Dehyphenate region text for ALTO

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
@@ -222,9 +222,12 @@ public abstract class OcrPassageFormatter extends PassageFormatter {
     float snipLry = wordBoxes.stream().map(OcrBox::getLry).max(Float::compareTo).get();
     String pageId = wordBoxes.get(0).getPageId();
 
-    String regionText = wordBoxes.stream().map(OcrBox::getText).collect(Collectors.joining(" "));
+    String regionText = wordBoxes.stream()
+        .filter(box -> !box.isHyphenated() || box.getHyphenStart())
+        .map(box ->   box.isHyphenated() ? box.getDehyphenatedForm() : box.getText())
+        .collect(Collectors.joining(" "));
     OcrBox firstBox = wordBoxes.get(0);
-    OcrBox lastBox = wordBoxes.get(wordBoxes.size() -1);
+    OcrBox lastBox = wordBoxes.get(wordBoxes.size() - 1);
     if (firstBox.isInHighlight() && !firstBox.getText().contains(startHlTag)) {
       regionText = startHlTag + regionText;
     }

--- a/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
@@ -146,15 +146,22 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
       String subsType = attribs.get("SUBS_TYPE");
 
       String text = StringEscapeUtils.unescapeXml(attribs.get("CONTENT"));
-      if ("HypPart1".equals(subsType)) {
+      Boolean hyphenStart = subsType == null ? null : "HypPart1".equals(subsType);
+      if (hyphenStart != null && hyphenStart) {
         text += "-";
       }
       if (text.contains(START_HL) || attribs.getOrDefault("SUBS_CONTENT", "").contains(START_HL)) {
         inHighlight = true;
       }
-      wordBoxes.add(new OcrBox(text.replace(START_HL, startHlTag)
-                                   .replace(END_HL, endHlTag),
-                               pageId,  x, y, x + w, y + h, inHighlight));
+      OcrBox ocrBox = new OcrBox(text.replace(START_HL, startHlTag)
+          .replace(END_HL, endHlTag),
+          pageId, x, y, x + w, y + h, inHighlight);
+      if (hyphenStart != null) {
+        String dehyphenated =
+            attribs.get("SUBS_CONTENT").replace(START_HL, startHlTag).replace(END_HL, endHlTag);
+        ocrBox.setHyphenInfo(hyphenStart, dehyphenated);
+      }
+      wordBoxes.add(ocrBox);
 
       if (inHighlight && subsType != null) {
         if (subsType.equals("HypPart1") && attribs.get("SUBS_CONTENT").contains(END_HL)) {

--- a/src/main/java/de/digitalcollections/solrocr/model/OcrBox.java
+++ b/src/main/java/de/digitalcollections/solrocr/model/OcrBox.java
@@ -21,6 +21,8 @@ public class OcrBox implements Comparable<OcrBox> {
   private float lry;
   private boolean inHighlight;
   private Integer parentRegionIdx;
+  private String dehyphenatedForm;
+  private Boolean hyphenStart;
 
 
   public OcrBox(String text, String pageId, float ulx, float uly, float lrx, float lry,
@@ -120,6 +122,18 @@ public class OcrBox implements Comparable<OcrBox> {
     return inHighlight;
   }
 
+  public boolean isHyphenated() {
+    return hyphenStart != null;
+  }
+
+  public String getDehyphenatedForm() {
+    return dehyphenatedForm;
+  }
+
+  public Boolean getHyphenStart() {
+    return hyphenStart;
+  }
+
   public void setText(String text) {
     this.text = text;
   }
@@ -146,6 +160,11 @@ public class OcrBox implements Comparable<OcrBox> {
 
   public void setInHighlight(boolean inHighlight) {
     this.inHighlight = inHighlight;
+  }
+
+  public void setHyphenInfo(boolean hyphenStart, String dehyphenated) {
+    this.hyphenStart = hyphenStart;
+    this.dehyphenatedForm = dehyphenated;
   }
 
   public Integer getParentRegionIdx() {

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -151,4 +151,14 @@ public class AltoTest extends SolrTestCaseJ4 {
         "//arr[@name='highlights']/arr/lst[2]/str[@name='text']/text()='qui possède'"
     );
   }
+
+  @Test
+  public void testDehyphenation() {
+    SolrQueryRequest req = xmlQ("q", "ocr_text:\"au bureau en qualité\"");
+    assertQ(
+        req,
+        "count(//arr[@name='regions'])=1",
+        "contains(//arr[@name='snippets']/lst/str[@name='text'], '<em>qualité</em>')",
+        "contains(//arr[@name='regions']/lst/str[@name='text'], '<em>qualité</em>')");
+  }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -166,11 +166,11 @@ public class AltoTest extends SolrTestCaseJ4 {
   public void testAlignSpans() {
     String regionUnaligned = "Les seuls députés qui aient voté pour l'instruction primaire, gratuite et obligatoire, "
         + "combattue par M. de Parieu, vice-<em>président</em> du conseil d'Etat, sont MM. Belmont et Carnet, "
-        + "Chevandier de <em>Valdrôme</em>. Favre (Jules). Garnier-Pcgès, Glais-B.'zoin, Gué- rouit. Havin, Hôr"
+        + "Chevandier de <em>Valdrôme</em>. Favre (Jules). Garnier-Pcgès, Glais-B.'zoin, Guérouit. Havin, Hôr"
         + ".on, Magnin, Marie, Le";
     String regionAligned = "Les seuls députés qui aient voté pour l'instruction primaire, gratuite et obligatoire, "
         + "combattue par M. de Parieu, <em>vice-président</em> du conseil d'Etat, sont MM. Belmont et Carnet, "
-        + "Chevandier de <em>Valdrôme.</em> Favre (Jules). Garnier-Pcgès, Glais-B.'zoin, Gué- rouit. Havin, Hôr"
+        + "Chevandier de <em>Valdrôme.</em> Favre (Jules). Garnier-Pcgès, Glais-B.'zoin, Guérouit. Havin, Hôr"
         + ".on, Magnin, Marie, Le";
     SolrQueryRequest req = xmlQ("q", "ocr_text:(président OR Valdrôme)", "hl.ocr.pageId", "P3");
     assertQ(req, "(//arr[@name='regions']/lst/str[@name='text'])[1]/text()=\"" + regionUnaligned + "\"");


### PR DESCRIPTION
Previously only the whole snippet text would be dehyhenated, owing to the fact that we only considered the (potentially hyphenated)
surface-form for generating the region text. We now track if a word is hyphenated during parsing of ALTO documents.