### PR TITLE
Improve alignment between text and image spans (fixes #120)

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -145,6 +145,11 @@ Additionally, the plugin allows you to customize various OCR-specific parameters
 :   Set the block type that the passage context may not exceed. Valid values are `none` `word`, `line`,
     `paragraph`, `block` or `page`. This value defaults to `block`.
 
+`hl.ocr.alignSpans`
+:   Ensure that the spans in the highlighted text match the text of the highlighted image parts exactly.
+    By default (`false`), text spans will be more precise than image spans, since they can be defined at the
+    character-level, while image spans can only be as precise as the word boundaries in the OCR.
+
 `hl.ocr.pageId`:
 :   Only show passages from the page with this identifier. Useful in combination with a `fq` for a specific document
     if you want to implement a "Search on this page" feature (e.g. for the

--- a/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
@@ -99,6 +99,8 @@ public abstract class OcrPassageFormatter extends PassageFormatter {
     if (passage.getNumMatches() > 0) {
       List<PassageMatch> matches = mergeMatches(passage.getNumMatches(), passage.getMatchStarts(), passage.getMatchEnds());
       for (PassageMatch match : matches) {
+        // Can't just do match.start - passage.getStartOffset(), since both offsets are relative to **UTF-8 bytes**, but
+        // we need **UTF-16 codepoint** offsets in the code.
         String preMatchContent = content.subSequence(passage.getStartOffset(), match.start).toString();
         int matchStart = preMatchContent.length();
         if (alignSpans) {
@@ -106,6 +108,7 @@ public abstract class OcrPassageFormatter extends PassageFormatter {
         }
         sb.insert(extraChars + matchStart, startHlTag);
         extraChars += startHlTag.length();
+        // Again, can't just do match.end - passage.getStartOffset(), since we need char offsets (see above).
         int matchEnd = content.subSequence(passage.getStartOffset(), match.end).toString().length();
         String matchText = sb.substring(extraChars + matchStart, extraChars + matchEnd);
         if (matchText.trim().endsWith(">")) {

--- a/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
@@ -196,16 +196,23 @@ public abstract class OcrPassageFormatter extends PassageFormatter {
     List<OcrBox> currentSpan = null;
     for (OcrBox wordBox : allBoxes) {
       if (wordBox.isInHighlight()) {
-        if (currentSpan == null) {
+        boolean isInNewSpan = (
+            currentSpan == null
+            || currentSpan.isEmpty()
+            || !wordBox.getHighlightSpan().equals(currentSpan.get(0).getHighlightSpan()));
+        if (isInNewSpan) {
+          if (currentSpan != null && !currentSpan.isEmpty()) {
+            hlSpans.add(currentSpan);
+          }
           currentSpan = new ArrayList<>();
         }
         currentSpan.add(wordBox);
-      } else if (currentSpan != null) {
+      } else if (currentSpan != null && !currentSpan.isEmpty()) {
         hlSpans.add(currentSpan);
         currentSpan = null;
       }
     }
-    if (currentSpan != null) {
+    if (currentSpan != null && !currentSpan.isEmpty()) {
       hlSpans.add(currentSpan);
     }
 
@@ -246,7 +253,7 @@ public abstract class OcrPassageFormatter extends PassageFormatter {
       regionText = regionText + endHlTag;
     }
 
-    return new OcrBox(regionText, pageId, snipUlx, snipUly, snipLrx, snipLry, false);
+    return new OcrBox(regionText, pageId, snipUlx, snipUly, snipLrx, snipLry, null);
   }
 
   /** Parse word boxes from an OCR fragment. */

--- a/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/OcrPassageFormatter.java
@@ -122,11 +122,12 @@ public abstract class OcrPassageFormatter extends PassageFormatter {
             matchEnd -= (matchText.length() - idx);
           }
         }
-        if (alignSpans) {
-          String postMatchContent = sb.substring(matchEnd + extraChars, sb.length());
+        matchEnd = Math.min(matchEnd + extraChars, sb.length());
+        if (alignSpans && matchEnd != sb.length()) {
+          String postMatchContent = sb.substring(matchEnd, sb.length());
           matchEnd += postMatchContent.indexOf("</");
         }
-        sb.insert(Math.min(extraChars + matchEnd, sb.length()), endHlTag);
+        sb.insert(matchEnd, endHlTag);
         extraChars += endHlTag.length();
       }
     }

--- a/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoFormat.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoFormat.java
@@ -29,8 +29,8 @@ public class AltoFormat implements OcrFormat {
 
   @Override
   public OcrPassageFormatter getPassageFormatter(String prehHighlightTag, String postHighlightTag,
-                                                 boolean absoluteHighlights) {
-    return new AltoPassageFormatter(prehHighlightTag, postHighlightTag, absoluteHighlights);
+                                                 boolean absoluteHighlights, boolean alignSpans) {
+    return new AltoPassageFormatter(prehHighlightTag, postHighlightTag, absoluteHighlights, alignSpans);
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
@@ -24,6 +24,7 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
   private final static Pattern pagePat = Pattern.compile("<Page ?(?<attribs>.+?)/?>");
   private final static Pattern wordPat = Pattern.compile("<String ?(?<attribs>.+?)/?>");
   private final static Pattern attribPat = Pattern.compile("(?<key>[A-Z_]+?)=\"(?<val>.+?)\"");
+  private final static Pattern postContentPat = Pattern.compile("[\"']\\s*(\\w|/?>)");
 
   private final TagBreakIterator pageIter = new TagBreakIterator("Page");
 
@@ -153,9 +154,12 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
         }
         matchEnd = Math.min(matchEnd + extraChars, sb.length());
         if (alignSpans && matchEnd != sb.length()) {
-          String postMatchContent = content.subSequence(
-              passage.getStartOffset() + matchEnd, passage.getEndOffset()).toString();
-          matchEnd += (postMatchContent.indexOf('"'));
+          CharSequence postMatchContent = content.subSequence(
+              passage.getStartOffset() + matchEnd, passage.getEndOffset());
+          Matcher m = postContentPat.matcher(postMatchContent);
+          if (m.find()) {
+            matchEnd += m.start();
+          }
         }
         sb.insert(matchEnd, endHlTag);
         extraChars += endHlTag.length();

--- a/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoPassageFormatter.java
@@ -154,8 +154,7 @@ public class AltoPassageFormatter extends OcrPassageFormatter {
         }
         matchEnd = Math.min(matchEnd + extraChars, sb.length());
         if (alignSpans && matchEnd != sb.length()) {
-          CharSequence postMatchContent = content.subSequence(
-              passage.getStartOffset() + matchEnd, passage.getEndOffset());
+          String postMatchContent = sb.substring(matchEnd, sb.length());
           Matcher m = postContentPat.matcher(postMatchContent);
           if (m.find()) {
             matchEnd += m.start();

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrFormat.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrFormat.java
@@ -40,8 +40,8 @@ public class HocrFormat implements OcrFormat {
 
   @Override
   public OcrPassageFormatter getPassageFormatter(String prehHighlightTag, String postHighlightTag,
-                                                 boolean absoluteHighlights) {
-    return new HocrPassageFormatter(prehHighlightTag, postHighlightTag, absoluteHighlights);
+                                                 boolean absoluteHighlights, boolean alignSpans) {
+    return new HocrPassageFormatter(prehHighlightTag, postHighlightTag, absoluteHighlights, alignSpans);
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -8,6 +8,7 @@ import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -87,7 +88,7 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
   protected List<OcrBox> parseWords(String ocrFragment, TreeMap<Integer, OcrPage> pages, String startPage) {
     List<OcrBox> wordBoxes = new ArrayList<>();
     Matcher m = wordPat.matcher(ocrFragment);
-    boolean inHighlight = false;
+    UUID currentHighlight = null;
     while (m.find()) {
       String pageId = startPage;
       if (pages.floorKey(m.start()) != null) {
@@ -99,15 +100,15 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
       int y1 = Integer.parseInt(m.group("lry"));
       String text = StringEscapeUtils.unescapeXml(m.group("text"));
       if (text.contains(startHlTag)) {
-        inHighlight = true;
+        currentHighlight = UUID.randomUUID();
       }
-      wordBoxes.add(new OcrBox(text, pageId, x0, y0, x1, y1, inHighlight));
+      wordBoxes.add(new OcrBox(text, pageId, x0, y0, x1, y1, currentHighlight));
       boolean endOfHl = (
           text.contains(endHlTag)
           || ocrFragment.substring(m.end(), Math.min(m.end() + endHlTag.length(), ocrFragment.length()))
               .equals(endHlTag));
       if (endOfHl) {
-        inHighlight = false;
+        currentHighlight = null;
       }
     }
     return wordBoxes;

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrPassageFormatter.java
@@ -27,8 +27,8 @@ public class HocrPassageFormatter extends OcrPassageFormatter {
   private final String startHlTag;
   private final String endHlTag;
 
-  public HocrPassageFormatter(String startHlTag, String endHlTag, boolean absoluteHighlights) {
-    super(startHlTag, endHlTag, absoluteHighlights);
+  public HocrPassageFormatter(String startHlTag, String endHlTag, boolean absoluteHighlights, boolean alignSpans) {
+    super(startHlTag, endHlTag, absoluteHighlights, alignSpans);
     this.pageIter = new HocrClassBreakIterator("ocr_page");
     this.startHlTag = startHlTag;
     this.endHlTag = endHlTag;

--- a/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrFormat.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrFormat.java
@@ -33,8 +33,8 @@ public class MiniOcrFormat implements OcrFormat {
 
   @Override
   public OcrPassageFormatter getPassageFormatter(String prehHighlightTag, String postHighlightTag,
-                                                 boolean absoluteHighlights) {
-    return new MiniOcrPassageFormatter(prehHighlightTag, postHighlightTag, absoluteHighlights);
+                                                 boolean absoluteHighlights, boolean alignSpans) {
+    return new MiniOcrPassageFormatter(prehHighlightTag, postHighlightTag, absoluteHighlights, alignSpans);
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrPassageFormatter.java
@@ -26,8 +26,8 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
 
   private final TagBreakIterator pageIter = new TagBreakIterator("p");
 
-  public MiniOcrPassageFormatter(String startHlTag, String endHlTag, boolean absoluteHighlights) {
-    super(startHlTag, endHlTag, absoluteHighlights);
+  public MiniOcrPassageFormatter(String startHlTag, String endHlTag, boolean absoluteHighlights, boolean alignSpans) {
+    super(startHlTag, endHlTag, absoluteHighlights, alignSpans);
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/mini/MiniOcrPassageFormatter.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.text.StringEscapeUtils;
@@ -102,7 +103,7 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
   @Override
   protected List<OcrBox> parseWords(String ocrFragment, TreeMap<Integer, OcrPage> pages, String startPage) {
     List<OcrBox> wordBoxes = new ArrayList<>();
-    boolean inHighlight = false;
+    UUID currentHighlight = null;
     Matcher m = wordPat.matcher(ocrFragment);
     while (m.find()) {
       String pageId = startPage;
@@ -115,15 +116,15 @@ public class MiniOcrPassageFormatter extends OcrPassageFormatter {
       float height = Float.parseFloat(m.group("h"));
       String text = StringEscapeUtils.unescapeXml(m.group("text"));
       if (text.contains(startHlTag)) {
-        inHighlight = true;
+        currentHighlight = UUID.randomUUID();
       }
-      wordBoxes.add(new OcrBox(text, pageId, x, y, x + width, y + height, inHighlight));
+      wordBoxes.add(new OcrBox(text, pageId, x, y, x + width, y + height, currentHighlight));
       boolean endOfHl = (
           text.contains(endHlTag)
           || ocrFragment.substring(m.end(), Math.min(m.end() + endHlTag.length(), ocrFragment.length()))
               .equals(endHlTag));
       if (endOfHl) {
-        inHighlight = false;
+        currentHighlight = null;
       }
     }
     return wordBoxes;

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
@@ -286,7 +286,8 @@ public class OcrHighlighter extends UnifiedHighlighter {
           OcrPassageFormatter formatter = ocrFormat.getPassageFormatter(
               params.get(HighlightParams.TAG_PRE, "<em>"),
               params.get(HighlightParams.TAG_POST, "</em>"),
-              params.getBool(OcrHighlightParams.ABSOLUTE_HIGHLIGHTS, false));
+              params.getBool(OcrHighlightParams.ABSOLUTE_HIGHLIGHTS, false),
+              params.getBool(OcrHighlightParams.ALIGN_SPANS, false));
           int snippetLimit = Math.max(
               maxPassages[fieldIdx],
               params.getInt(OcrHighlightParams.MAX_OCR_PASSAGES, DEFAULT_SNIPPET_LIMIT));

--- a/src/main/java/de/digitalcollections/solrocr/model/OcrBox.java
+++ b/src/main/java/de/digitalcollections/solrocr/model/OcrBox.java
@@ -2,6 +2,7 @@ package de.digitalcollections.solrocr.model;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
@@ -19,19 +20,19 @@ public class OcrBox implements Comparable<OcrBox> {
   private float uly;
   private float lrx;
   private float lry;
-  private boolean inHighlight;
+  private UUID highlightSpan;
   private Integer parentRegionIdx;
 
 
   public OcrBox(String text, String pageId, float ulx, float uly, float lrx, float lry,
-                boolean inHighlight) {
+                UUID highlightSpan) {
     this.text = text;
     this.pageId = pageId;
     this.ulx = ulx;
     this.uly = uly;
     this.lrx = lrx;
     this.lry = lry;
-    this.inHighlight = inHighlight;
+    this.highlightSpan = highlightSpan;
   }
 
   private void addDimension(SimpleOrderedMap map, String name, float val) {
@@ -116,8 +117,12 @@ public class OcrBox implements Comparable<OcrBox> {
     return lry - uly;
   }
 
+  public UUID getHighlightSpan() {
+    return highlightSpan;
+  }
+
   public boolean isInHighlight() {
-    return inHighlight;
+    return highlightSpan != null;
   }
 
   public void setText(String text) {
@@ -144,8 +149,8 @@ public class OcrBox implements Comparable<OcrBox> {
     this.lry = lry;
   }
 
-  public void setInHighlight(boolean inHighlight) {
-    this.inHighlight = inHighlight;
+  public void setHighlightSpan(UUID highlightId) {
+    this.highlightSpan = highlightId;
   }
 
   public Integer getParentRegionIdx() {

--- a/src/main/java/de/digitalcollections/solrocr/model/OcrFormat.java
+++ b/src/main/java/de/digitalcollections/solrocr/model/OcrFormat.java
@@ -23,8 +23,12 @@ public interface OcrFormat {
    * @param postHighlightTag the tag to put in the snippet text after a highlighted region, e.g. &lt;/em&gt;
    * @param absoluteHighlights whether the coordinates for highlights should be absolute, i.e. relative to the page
    *                           and not the containing snippet
+   * @param alignSpans whether the spans in the text and image should match precisely. If false, the text spans will
+   *                   be more precise than the image "spans", since the latter are restricted to the granularity of
+   *                   the OCR document.
    */
-  OcrPassageFormatter getPassageFormatter(String prehHighlightTag, String postHighlightTag, boolean absoluteHighlights);
+  OcrPassageFormatter getPassageFormatter(
+      String prehHighlightTag, String postHighlightTag,  boolean absoluteHighlights, boolean alignSpans);
 
   Reader filter(Reader input);
 

--- a/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightParams.java
+++ b/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightParams.java
@@ -12,4 +12,5 @@ public interface OcrHighlightParams extends HighlightParams {
   String ABSOLUTE_HIGHLIGHTS = "hl.ocr.absoluteHighlights";
   String MAX_OCR_PASSAGES = "hl.ocr.maxPassages";
   String TIME_ALLOWED = "hl.ocr.timeAllowed";
+  String ALIGN_SPANS = "hl.ocr.alignSpans";
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -155,15 +155,17 @@ public class AltoTest extends SolrTestCaseJ4 {
   @Test
   public void testAlignSpans() {
     String regionUnaligned = "Les seuls députés qui aient voté pour l'instruction primaire, gratuite et obligatoire, "
-      + "combattue par M. de Parieu, vice-<em>président</em> du conseil d'Etat, sont MM. Belmont et Carnet,"
-      + " Chevandier de Valdrôme. Favre";
+        + "combattue par M. de Parieu, vice-<em>président</em> du conseil d'Etat, sont MM. Belmont et Carnet, "
+        + "Chevandier de <em>Valdrôme</em>. Favre (Jules). Garnier-Pcgès, Glais-B.'zoin, Gué- rouit. Havin, Hôr"
+        + ".on, Magnin, Marie, Le";
     String regionAligned = "Les seuls députés qui aient voté pour l'instruction primaire, gratuite et obligatoire, "
-        + "combattue par M. de Parieu, <em>vice-président</em> du conseil d'Etat, sont MM. Belmont et Carnet,"
-        + " Chevandier de Valdrôme. Favre";
-    SolrQueryRequest req = xmlQ("q", "ocr_text:président");
-    assertQ(req, "(//arr[@name='regions'])[3]/lst/str[@name='text']/text()=\"" + regionUnaligned + "\"");
-    req = xmlQ("q", "ocr_text:président", "hl.ocr.alignSpans", "true");
-    assertQ(req, "(//arr[@name='regions'])[3]/lst/str[@name='text']/text()=\"" + regionAligned + "\"");
+        + "combattue par M. de Parieu, <em>vice-président</em> du conseil d'Etat, sont MM. Belmont et Carnet, "
+        + "Chevandier de <em>Valdrôme.</em> Favre (Jules). Garnier-Pcgès, Glais-B.'zoin, Gué- rouit. Havin, Hôr"
+        + ".on, Magnin, Marie, Le";
+    SolrQueryRequest req = xmlQ("q", "ocr_text:(président OR Valdrôme)", "hl.ocr.pageId", "P3");
+    assertQ(req, "(//arr[@name='regions']/lst/str[@name='text'])[1]/text()=\"" + regionUnaligned + "\"");
+    req = xmlQ("q", "ocr_text:(président OR Valdrôme)", "hl.ocr.pageId", "P3", "hl.ocr.alignSpans", "true");
+    assertQ(req, "//arr[@name='regions']/lst/str[@name='text']/text()=\"" + regionAligned + "\"");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -165,4 +165,10 @@ public class AltoTest extends SolrTestCaseJ4 {
     req = xmlQ("q", "ocr_text:président", "hl.ocr.alignSpans", "true");
     assertQ(req, "(//arr[@name='regions'])[3]/lst/str[@name='text']/text()=\"" + regionAligned + "\"");
   }
+
+  @Test
+  public void testOverzealousMerging() {
+    SolrQueryRequest req = xmlQ("q", "ocr_text:\"au bureau en qualité\"");
+    assertQ(req, "count(//arr[@name='highlights']/arr)=4");
+  }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -151,4 +151,18 @@ public class AltoTest extends SolrTestCaseJ4 {
         "//arr[@name='highlights']/arr/lst[2]/str[@name='text']/text()='qui possède'"
     );
   }
+
+  @Test
+  public void testAlignSpans() {
+    String regionUnaligned = "Les seuls députés qui aient voté pour l'instruction primaire, gratuite et obligatoire, "
+      + "combattue par M. de Parieu, vice-<em>président</em> du conseil d'Etat, sont MM. Belmont et Carnet,"
+      + " Chevandier de Valdrôme. Favre";
+    String regionAligned = "Les seuls députés qui aient voté pour l'instruction primaire, gratuite et obligatoire, "
+        + "combattue par M. de Parieu, <em>vice-président</em> du conseil d'Etat, sont MM. Belmont et Carnet,"
+        + " Chevandier de Valdrôme. Favre";
+    SolrQueryRequest req = xmlQ("q", "ocr_text:président");
+    assertQ(req, "(//arr[@name='regions'])[3]/lst/str[@name='text']/text()=\"" + regionUnaligned + "\"");
+    req = xmlQ("q", "ocr_text:président", "hl.ocr.alignSpans", "true");
+    assertQ(req, "(//arr[@name='regions'])[3]/lst/str[@name='text']/text()=\"" + regionAligned + "\"");
+  }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -227,4 +227,20 @@ public class HocrTest extends SolrTestCaseJ4 {
     req = xmlQ("q", "fenia", "hl.snippets", "100");
     assertQ(req, String.format("//arr[@name='snippets']/lst[1]//str[@name='text']/text()='%s'", firstSnip));
   }
+
+  @Test
+  public void testAlignSpans() {
+    String unalignedText = "in die erſte Jugend, die nicht wiederkam. Lou <em>Andreas</em>-Salomet, Fenitſchka. 12";
+    String alignedText = "in die erſte Jugend, die nicht wiederkam. Lou <em>Andreas-Salomet,</em> Fenitſchka. 12";
+    SolrQueryRequest req = xmlQ("q", "Andreas", "hl.ocr.pageId", "page_181");
+    assertQ(
+        req,
+        "//arr[@name='snippets']/lst/str[@name='text']/text()='" + unalignedText + "'",
+        "//arr[@name='regions']/lst/str[@name='text']/text()='" + unalignedText + "'");
+    req = xmlQ("q", "Andreas", "hl.ocr.pageId", "page_181", "hl.ocr.alignSpans", "true");
+    assertQ(
+        req,
+        "//arr[@name='snippets']/lst/str[@name='text']/text()='" + alignedText + "'",
+        "//arr[@name='regions']/lst/str[@name='text']/text()='" + alignedText + "'");
+  }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -195,7 +195,7 @@ public class HocrTest extends SolrTestCaseJ4 {
 
   @Test
   public void testMultiColumnSnippet() {
-    SolrQueryRequest req = xmlQ("q", "\"kaffe rechnungs\"");
+    SolrQueryRequest req = xmlQ("q", "\"kaffe rechnungs\"", "hl.weightMatches", "true");
     assertQ(
         req,
         "count(//lst[@name='ocrHighlighting']//arr[@name='snippets'])=1",
@@ -204,7 +204,7 @@ public class HocrTest extends SolrTestCaseJ4 {
         "count(//arr[@name='snippets']/lst/arr[@name='highlights']/arr)=1",
         "//arr[@name='regions']/lst[1]/str[@name='text']='Die General-Verwaltung der königlichen Eiſenbahnen "
             + "beſteht aus einem Vorſtande, zwei Räthen, wovon einer der Komptabilität kundig ſeyn muß, einem "
-            + "Ober-Ingenieur, einem Maſchinenmeiſter, den erforderlichen <em>Kaffe</em>-,'",
+            + "Ober-Ingenieur, einem Maſchinenmeiſter, den erforderlichen <em>Kaffe-,</em>'",
         "//arr[@name='regions']/lst[2]/str[@name='text']='<em>Rechnungs</em>-, Kanzlei-, Regiſtratur- und techniſchen "
             + "Gehülfen-Perſonal Der Geſchäftsgang iſt bei der k. Eiſenbahn, ſoferne nicht für beſondere Fälle "
             + "kollegiale Behandlung vorgeſchrieben iſt, bureaukratiſch, und der Vorſtand'",


### PR DESCRIPTION
Previously, it was sometimes imposible to map the `<em>...</em>` spans in the text snippets to the highlight boxes. This was due to an overly aggressive merging strategy, that has now been fixed.

Additionally, this PR introduces a new parameter `hl.ocr.alignSpans` (that is disabled by default) that forces text spans to conform to word boundaries as set by the OCR. This has the effect of aligning text and image spans so they both contain the exact same text.