### PR TITLE
More fixes for bad markup, better error reporting

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/OcrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/OcrParser.java
@@ -1,6 +1,7 @@
 package de.digitalcollections.solrocr.formats;
 
 import com.ctc.wstx.api.WstxInputProperties;
+import com.ctc.wstx.exc.WstxLazyException;
 import com.ctc.wstx.stax.WstxInputFactory;
 import com.google.common.collect.ImmutableMap;
 import de.digitalcollections.solrocr.model.OcrBox;
@@ -125,7 +126,7 @@ public abstract class OcrParser implements Iterator<OcrBox>, Iterable<OcrBox> {
       do {
         this.nextWord = readNext(xmlReader, features);
       } while (hasNext() && this.nextWord == null);
-    } catch (XMLStreamException e) {
+    } catch (XMLStreamException| WstxLazyException e) {
       throw new RuntimeException(String.format(
           "Failed to parse the OCR markup, make sure your files are well-formed and your regions start/end on " +
           "complete tags! (Source was: %s)", this.input.getSource().orElse("[unknown]")), e);

--- a/src/main/java/de/digitalcollections/solrocr/formats/OcrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/OcrParser.java
@@ -89,7 +89,13 @@ public abstract class OcrParser implements Iterator<OcrBox>, Iterable<OcrBox> {
     // Register custom named entities used by hOCR
     xmlInputFactory.getConfig().setCustomInternalEntities(ENTITIES);
     this.xmlReader = (XMLStreamReader2) xmlInputFactory.createXMLStreamReader(this.input);
-    this.nextWord = this.readNext(this.xmlReader, this.features);
+    try {
+      this.nextWord = this.readNext(this.xmlReader, this.features);
+    } catch (XMLStreamException e) {
+      throw new RuntimeException(String.format(
+          "Failed to parse the OCR markup, make sure your files are well-formed and your regions start/end on " +
+          "complete tags! (Source was: %s)", this.input.getSource().orElse("[unknown]")), e);
+    }
   }
 
   @Override
@@ -117,9 +123,9 @@ public abstract class OcrParser implements Iterator<OcrBox>, Iterable<OcrBox> {
         this.nextWord = readNext(xmlReader, features);
       } while (hasNext() && this.nextWord == null);
     } catch (XMLStreamException e) {
-      throw new RuntimeException(
+      throw new RuntimeException(String.format(
           "Failed to parse the OCR markup, make sure your files are well-formed and your regions start/end on " +
-          "complete tags!",  e);
+          "complete tags! (Source was: %s)", this.input.getSource().orElse("[unknown]")), e);
     }
     return out;
   }

--- a/src/main/java/de/digitalcollections/solrocr/formats/OcrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/OcrParser.java
@@ -88,6 +88,9 @@ public abstract class OcrParser implements Iterator<OcrBox>, Iterable<OcrBox> {
     xmlInputFactory.getConfig().doSupportDTDs(false);
     // Register custom named entities used by hOCR
     xmlInputFactory.getConfig().setCustomInternalEntities(ENTITIES);
+    // Fallback for unknown undeclared entities: just output them verbatim
+    xmlInputFactory.getConfig().setUndeclaredEntityResolver(
+        (publicID, systemID, baseURI, namespace) -> String.format("&amp;%s;", namespace));
     this.xmlReader = (XMLStreamReader2) xmlInputFactory.createXMLStreamReader(this.input);
     try {
       this.nextWord = this.readNext(this.xmlReader, this.features);

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
@@ -41,6 +41,10 @@ public class HocrParser extends OcrParser {
         || !"ocrx_word".equals(xmlReader.getAttributeValue("", "class"))) {
       this.seekToNextWord(xmlReader, features.contains(ParsingFeature.PAGES));
     }
+    if (xmlReader.getEventType() != XMLStreamConstants.START_ELEMENT) {
+      // No words in this document, nothing to do
+      return null;
+    }
 
     OcrBox box = new OcrBox();
     Map<String, String> props = parseTitle(xmlReader.getAttributeValue("", "title"));

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
@@ -87,7 +87,7 @@ public class HocrParser extends OcrParser {
         hyphenEnd.setHyphenInfo(false, dehyphenated);
       } else {
         // No hyphen end, add hyphen character if needed and strip hyphenation info
-        if (!box.getText().endsWith("-")) {
+        if (box.getText() != null && !box.getText().endsWith("-")) {
           box.setText(box.getText() + "-");
         }
         box.setHyphenInfo(null, null);

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrPassageFormatter.java
@@ -321,7 +321,7 @@ public class OcrPassageFormatter extends PassageFormatter {
       parsingFeatures.add(OcrParser.ParsingFeature.PAGES);
     }
     OcrParser parser = format.getParser(
-        new SanitizingXmlFilter(new StringReader(ocrFragment)),
+        new SanitizingXmlFilter(new StringReader(ocrFragment), true),
         parsingFeatures.toArray(new OcrParser.ParsingFeature[0]));
     boolean onStartPage = true;
     for (OcrBox box : parser) {

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrPassageFormatter.java
@@ -345,7 +345,7 @@ public class OcrPassageFormatter extends PassageFormatter {
           if (!this.absoluteHighlights) {
             float xOffset = region.get().getUlx();
             float yOffset = region.get().getUly();
-            if (box.getUlx() < 1 || box.getUly() < 1) {
+            if ((box.getUlx() > 0 && box.getUlx() < 1) || (box.getUly() > 0 && box.getUly() < 1)) {
               // Relative coordinates, need to do some more calculations
               float snipWidth = region.get().getLrx() - xOffset;
               float snipHeight = region.get().getLry() - yOffset;

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilter.java
@@ -1,15 +1,18 @@
 package de.digitalcollections.solrocr.lucene.filters;
 
 import de.digitalcollections.solrocr.model.SourcePointer;
+import de.digitalcollections.solrocr.util.SourceAwareReader;
 import de.digitalcollections.solrocr.util.Utf8;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import org.apache.lucene.analysis.charfilter.BaseCharFilter;
 
-public class ExternalUtf8ContentFilter extends BaseCharFilter {
+public class ExternalUtf8ContentFilter extends BaseCharFilter implements SourceAwareReader {
+
   /**
    * The cumulative offset difference between the input (bytes) and the output (chars)
    * at the current position.
@@ -28,12 +31,19 @@ public class ExternalUtf8ContentFilter extends BaseCharFilter {
    */
   private int currentOutOffset;
 
+  /**
+   * Source pointer of this reader, used for debugging and error reporting.
+   */
+  private final String pointer;
+
   private boolean nextIsOffset = false;
   private final Queue<SourcePointer.Region> remainingRegions;
   private SourcePointer.Region currentRegion;
 
-  public ExternalUtf8ContentFilter(Reader input, List<SourcePointer.Region> regions) throws IOException {
+  public ExternalUtf8ContentFilter(Reader input, List<SourcePointer.Region> regions, String pointer)
+      throws IOException {
     super(input);
+    this.pointer = pointer;
     this.currentOutOffset = 0;
     this.currentInOffset = 0;
     this.cumulative = 0;
@@ -105,5 +115,10 @@ public class ExternalUtf8ContentFilter extends BaseCharFilter {
         nextIsOffset = true;
       }
     }
+  }
+
+  @Override
+  public Optional<String> getSource() {
+    return Optional.of(this.pointer);
   }
 }

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilter.java
@@ -14,10 +14,12 @@ import org.apache.lucene.analysis.charfilter.BaseCharFilter;
 public class ExternalUtf8ContentFilter extends BaseCharFilter implements SourceAwareReader {
 
   /**
-   * The cumulative offset difference between the input (bytes) and the output (chars)
-   * at the current position.
+   * The cumulative offset difference between the input (bytes) and the output (chars) at the
+   * current position.
    *
+   * <pre>
    * current actual byte offset in input = currentOutOffset + cumulative
+   * </pre>
    */
   private int cumulative;
 
@@ -57,8 +59,8 @@ public class ExternalUtf8ContentFilter extends BaseCharFilter implements SourceA
   }
 
   /**
-   * Read <tt>len</tt> <tt>char</tt>s into <tt>cbuf</tt>, starting from character index <tt>off</tt> relative to
-   * the beginning of <tt>cbuf</tt> and return the number of <tt>char</tt>s read.
+   * Read <tt>len</tt> <tt>char</tt>s into <tt>cbuf</tt>, starting from character index <tt>off</tt>
+   * relative to the beginning of <tt>cbuf</tt> and return the number of <tt>char</tt>s read.
    **/
   @Override
   public int read(char[] cbuf, int off, int len) throws IOException {
@@ -101,7 +103,7 @@ public class ExternalUtf8ContentFilter extends BaseCharFilter implements SourceA
   }
 
   private void correctOffsets(char[] cbuf, int off, int len) {
-    for (int i=off; i < off + len; i++) {
+    for (int i = off; i < off + len; i++) {
       if (nextIsOffset) {
         this.addOffCorrectMap(currentOutOffset, cumulative);
         nextIsOffset = false;

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
@@ -66,7 +66,7 @@ public class ExternalUtf8ContentFilterFactory extends CharFilterFactory {
       List<SourcePointer.Region> charRegions = pointer.sources.stream()
           .flatMap(s -> s.regions.stream())
           .collect(Collectors.toList());
-      return new ExternalUtf8ContentFilter(new BufferedReader(r), charRegions);
+      return new ExternalUtf8ContentFilter(new BufferedReader(r), charRegions, ptrStr);
     } catch (IOException e) {
       throw new RuntimeException("Error while reading external content: " + e.toString(), e);
     }

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilterFactory.java
@@ -21,6 +21,7 @@ public class OcrCharFilterFactory extends CharFilterFactory {
   private static final int CTX_BUF_SIZE = 16384;
 
   private final boolean expandAlternatives;
+  private final boolean fixMarkup;
 
   private static final ImmutableSet<OcrFormat> FORMATS = ImmutableSet.of(
       new HocrFormat(),
@@ -30,12 +31,13 @@ public class OcrCharFilterFactory extends CharFilterFactory {
   public OcrCharFilterFactory(Map<String, String> args) {
     super(args);
     this.expandAlternatives = "true".equals(args.get("expandAlternatives"));
+    this.fixMarkup = "true".equals(args.get("fixMarkup"));
   }
 
   @Override
   public Reader create(Reader input) {
     PeekingReader peeker = new PeekingReader(
-       new SanitizingXmlFilter(input), BEGIN_BUF_SIZE, CTX_BUF_SIZE);
+       new SanitizingXmlFilter(input, fixMarkup), BEGIN_BUF_SIZE, CTX_BUF_SIZE);
     OcrFormat fmt = FORMATS.stream()
         .filter(f -> f.hasFormat(peeker.peekBeginning()))
         .findFirst()

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -137,7 +137,7 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
 
       // Check if we're dealing with a legal tag, in some early Google Books hOCR unescaped
       // `<` and `>` characters sometimes lead to spans that look like elements but aren't actually
-      boolean illegalTag = false;
+      boolean illegalTag = tagLen == 0;
       for (int i = 0; i < tagLen; i++) {
         if (!Character.isLetter(cbuf[startTag + i])) {
           illegalTag = true;

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -134,6 +134,22 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
         endTag = cbuf[endElem - 1] == '/' ? endElem - 1 : endElem;
       }
       int tagLen = endTag - startTag;
+
+      // Check if we're dealing with a legal tag, in some early Google Books hOCR unescaped
+      // `<` and `>` characters sometimes lead to spans that look like elements but aren't actually
+      boolean illegalTag = false;
+      for (int i = 0; i < tagLen; i++) {
+        if (!Character.isLetter(cbuf[startTag + i])) {
+          illegalTag = true;
+          break;
+        }
+      }
+      if (illegalTag) {
+        cbuf[startElem] = '_';
+        cbuf[endElem] = '_';
+        continue;
+      }
+
       if (cbuf[startElem + 1] == '/') {
         char[] checkTag = elementStack.peek();
         if (checkTag == null || !tagEquals(cbuf, startTag, tagLen, checkTag)) {

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -1,10 +1,12 @@
 package de.digitalcollections.solrocr.lucene.filters;
 
 import com.google.common.collect.ImmutableSet;
+import de.digitalcollections.solrocr.util.SourceAwareReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
@@ -18,7 +20,8 @@ import org.apache.lucene.analysis.charfilter.BaseCharFilter;
  *  a problem since we used a RegEx-based parsing approach, but with the new StAX-based approach we have to make sure
  *  that the XML we feed to the parser is well-formed.
  */
-public class SanitizingXmlFilter extends BaseCharFilter {
+public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareReader {
+
   private static final Set<String> STRIP_TAGS = ImmutableSet.of("br");
   private final Deque<char[]> elementStack = new ArrayDeque<>();
   private char[] carryOver = null;
@@ -198,5 +201,14 @@ public class SanitizingXmlFilter extends BaseCharFilter {
       }
     }
     return -1;
+  }
+
+  @Override
+  public Optional<String> getSource() {
+    if (this.input instanceof SourceAwareReader) {
+      return ((SourceAwareReader) this.input).getSource();
+    } else {
+      return Optional.empty();
+    }
   }
 }

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -110,12 +110,28 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
         break;
       }
       idx = endElem + 1;
-      if (cbuf[startElem + 1] == '?' && cbuf[endElem - 1] != '?') {
+      if (cbuf[startElem + 1] == '?'  && (endElem - startElem < 3 || cbuf[endElem - 1] != '?')) {
         // Illegal processing instruction, fix by stripping the question mark
         cbuf[startElem + 1] = '_';
       }
+
+      if (cbuf[startElem + 1] == '!') {
+        boolean illegal = (
+            // Comment?
+            (cbuf[startElem + 2] == '-' && cbuf[startElem + 3] != '-')
+            // Doctype?
+            || ((cbuf[startElem + 2] == 'D' || cbuf[startElem + 2] == 'd') && (endElem - startElem) < 12)
+            // CDATA?
+            || (cbuf[startElem + 2] == '[' && (endElem - startElem) < 10));
+        if (illegal) {
+          cbuf[startElem] = '_';
+          cbuf[endElem] = '-';
+          continue;
+        }
+      }
+
       if (cbuf[startElem + 1] == '?' || (cbuf[startElem + 1] == '!'
-          && cbuf[startElem + 2] == '-')) {
+          && cbuf[startElem + 2] == '-') && cbuf[startElem + 3] == '-') {
         // XML Declaration or comment, nothing to do
         continue;
       }

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -81,7 +81,7 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
           break;
         }
         int entityEnd = multiIndexOf(cbuf, match + 1, '<', ';');
-        if (entityEnd < 0 || cbuf[entityEnd] == '<') {
+        if (entityEnd < 0 || entityEnd == match + 1 || cbuf[entityEnd] == '<') {
           // Illegal entity declaration (doesn't end before next element opening), mask
           cbuf[match] = '_';
         }

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -110,14 +110,19 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
         break;
       }
       idx = endElem + 1;
-      if (cbuf[startElem + 1] == '?' || (cbuf[startElem + 1] == '!' && cbuf[startElem + 2] == '-')) {
+      if (cbuf[startElem + 1] == '?' && cbuf[endElem - 1] != '?') {
+        // Illegal processing instruction, fix by stripping the question mark
+        cbuf[startElem + 1] = '_';
+      }
+      if (cbuf[startElem + 1] == '?' || (cbuf[startElem + 1] == '!'
+          && cbuf[startElem + 2] == '-')) {
         // XML Declaration or comment, nothing to do
         continue;
       }
 
-
       // Strip out duplicate doctype declarations, these break the multidoc parsing mode in Woodstox
-      if (cbuf[startElem  + 1] == '!' && (cbuf[startElem + 2] == 'D' || cbuf[startElem + 2] == 'd')) {
+      if (cbuf[startElem + 1] == '!' && (cbuf[startElem + 2] == 'D'
+          || cbuf[startElem + 2] == 'd')) {
         if (hasDocType) {
           for (int i = startElem; i <= endElem; i++) {
             cbuf[i] = ' ';

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -40,7 +40,7 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
     if (tagLen != checkTag.length) {
       return false;
     }
-    for (int i=0; i < tagLen; i++) {
+    for (int i = 0; i < tagLen; i++) {
       if (markupBuf[startTag + i] != checkTag[i]) {
         return false;
       }

--- a/src/main/java/de/digitalcollections/solrocr/reader/PeekingReader.java
+++ b/src/main/java/de/digitalcollections/solrocr/reader/PeekingReader.java
@@ -1,12 +1,14 @@
 package de.digitalcollections.solrocr.reader;
 
+import de.digitalcollections.solrocr.util.SourceAwareReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Optional;
 import org.apache.lucene.analysis.charfilter.BaseCharFilter;
 
 /** Reader class that supports "peeking forward" into the beginning of the stream and "peeking backward" into a fixed
  * window of previously read data. */
-public class PeekingReader extends BaseCharFilter {
+public class PeekingReader extends BaseCharFilter implements SourceAwareReader {
   /** Buffer to hold the beginning of the input reader. */
   private final char[] peekStart;
 
@@ -132,5 +134,14 @@ public class PeekingReader extends BaseCharFilter {
   /** Get the maximum supported size of the back context. */
   public int getMaxBackContextSize() {
     return this.backContext.length;
+  }
+
+  @Override
+  public Optional<String> getSource() {
+    if (this.input instanceof SourceAwareReader) {
+      return ((SourceAwareReader) this.input).getSource();
+    } else {
+      return Optional.empty();
+    }
   }
 }

--- a/src/main/java/de/digitalcollections/solrocr/util/SourceAwareReader.java
+++ b/src/main/java/de/digitalcollections/solrocr/util/SourceAwareReader.java
@@ -1,2 +1,38 @@
-package de.digitalcollections.solrocr.util;public interface SourceAwareReader {
+package de.digitalcollections.solrocr.util;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Optional;
+
+public interface SourceAwareReader {
+  default Optional<String> getSource() {
+    return Optional.empty();
+  }
+
+  class Wrapper extends Reader implements SourceAwareReader {
+    private final Reader input;
+
+    public Wrapper(Reader input) {
+      this.input = input;
+    }
+
+    @Override
+    public Optional<String> getSource() {
+      if (this.input instanceof SourceAwareReader) {
+        return ((SourceAwareReader) this.input).getSource();
+      } else {
+        return Optional.empty();
+      }
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+      return input.read(cbuf, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+      input.close();
+    }
+  }
 }

--- a/src/main/java/de/digitalcollections/solrocr/util/SourceAwareReader.java
+++ b/src/main/java/de/digitalcollections/solrocr/util/SourceAwareReader.java
@@ -1,0 +1,2 @@
+package de.digitalcollections.solrocr.util;public interface SourceAwareReader {
+}

--- a/src/test/java/de/digitalcollections/solrocr/formats/hocr/HocrParserTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/formats/hocr/HocrParserTest.java
@@ -1,11 +1,11 @@
 package de.digitalcollections.solrocr.formats.hocr;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import de.digitalcollections.solrocr.formats.OcrParser;
 import de.digitalcollections.solrocr.lucene.filters.ExternalUtf8ContentFilterFactory;
 import de.digitalcollections.solrocr.model.OcrBox;
-import de.digitalcollections.solrocr.model.OcrFormat;
 import de.digitalcollections.solrocr.model.OcrPage;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -153,4 +153,22 @@ public class HocrParserTest {
         .allMatch(b -> b.getTrailingChars().contains(" "));
   }
 
+  @Test
+  public void testParsingErrorBeginningHasSource() throws XMLStreamException {
+    Path p = Paths.get("src/test/resources/data/multicolumn.hocr");
+    String ptr = p.toString() + "[5000:8000]";
+    CharFilter input = (CharFilter) filterFac.create(new StringReader(ptr));
+    assertThatThrownBy(() -> new HocrParser(input))
+        .hasMessageContaining(ptr);
+  }
+
+  @Test
+  public void testParsingErrorEndHasSource() throws XMLStreamException {
+    Path p = Paths.get("src/test/resources/data/multicolumn.hocr");
+    String ptr = p.toString() + "[3275:96251]";
+    CharFilter input = (CharFilter) filterFac.create(new StringReader(ptr));
+    OcrParser parser = new HocrParser(input);
+    assertThatThrownBy(() -> parser.stream().count())
+        .hasMessageContaining(ptr);
+  }
 }

--- a/src/test/java/de/digitalcollections/solrocr/lucene/ExternalUtf8ContentFilterTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/lucene/ExternalUtf8ContentFilterTest.java
@@ -1,6 +1,8 @@
 package de.digitalcollections.solrocr.lucene;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.ImmutableList;
 import de.digitalcollections.solrocr.lucene.filters.ExternalUtf8ContentFilter;
 import de.digitalcollections.solrocr.lucene.filters.ExternalUtf8ContentFilterFactory;
@@ -23,8 +25,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.lucene.analysis.CharFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExternalUtf8ContentFilterTest {
   private ExternalUtf8ContentFilterFactory fac;
@@ -56,7 +56,8 @@ public class ExternalUtf8ContentFilterTest {
     Path p = Paths.get("src/test/resources/data/hocr.html");
     CharFilter filter = new ExternalUtf8ContentFilter(
         new BufferedReader(new FileReader(p.toFile())),
-        ImmutableList.of(new SourcePointer.Region(0, (int) p.toFile().length())));
+        ImmutableList.of(new SourcePointer.Region(0, (int) p.toFile().length())),
+        p.toString());
     String full = new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
     String filtered = IOUtils.toString(filter);
     assertThat(filtered).isNotEmpty();

--- a/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
@@ -36,10 +36,11 @@ public class SanitizingXmlFilterTest {
 
   @Test
   public void sanityTest() throws IOException {
-    String brokenXml = "<b><c>hello</c></b></a><a><b><c>servus</c>";
+    String brokenXml = "<b><c>h&ello</c></b></a><a><b><c>ser>vus&lt;<br>welt<</c>";
     CharFilter filter = new SanitizingXmlFilter(new StringReader(brokenXml));
     String filtered = IOUtils.toString(filter);
-    assertThat(filtered).isEqualTo("<b><c>hello</c></b>    <a><b><c>servus</c></b></a>");
+    assertThat(filtered).matches(this::isWellFormed, "is well formed XML");
+    assertThat(filtered).isEqualTo("<b><c>h_ello</c></b>    <a><b><c>ser>vus&lt;    welt_</c></b></a>");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
@@ -37,12 +37,12 @@ public class SanitizingXmlFilterTest {
   @Test
   public void sanityTest() throws IOException {
     String brokenXml =
-        "<b><c>h&el<»?>lo</c></b></a><a><b><c>ser>vus&lt;<br>welt dieses xml ist&;ganz schön kaputt<</c>";
+        "<b><c>h&el<»?>lo</c></b></a><a><b><c>ser>vus&lt;<br>welt dieses xml ist&;ganz schön kap<>utt<</c>";
     CharFilter filter = new SanitizingXmlFilter(new StringReader(brokenXml));
     String filtered = IOUtils.toString(filter);
     assertThat(filtered).matches(this::isWellFormed, "is well formed XML");
     assertThat(filtered).isEqualTo(
-        "<b><c>h_el_»?_lo</c></b>    <a><b><c>ser>vus&lt;    welt dieses xml ist_;ganz schön kaputt_</c></b></a>");
+        "<b><c>h_el_»?_lo</c></b>    <a><b><c>ser>vus&lt;    welt dieses xml ist_;ganz schön kap__utt_</c></b></a>");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
@@ -36,11 +36,11 @@ public class SanitizingXmlFilterTest {
 
   @Test
   public void sanityTest() throws IOException {
-    String brokenXml = "<b><c>h&ello</c></b></a><a><b><c>ser>vus&lt;<br>welt<</c>";
+    String brokenXml = "<b><c>h&el<»?>lo</c></b></a><a><b><c>ser>vus&lt;<br>welt<</c>";
     CharFilter filter = new SanitizingXmlFilter(new StringReader(brokenXml));
     String filtered = IOUtils.toString(filter);
     assertThat(filtered).matches(this::isWellFormed, "is well formed XML");
-    assertThat(filtered).isEqualTo("<b><c>h_ello</c></b>    <a><b><c>ser>vus&lt;    welt_</c></b></a>");
+    assertThat(filtered).isEqualTo("<b><c>h_el_»?_lo</c></b>    <a><b><c>ser>vus&lt;    welt_</c></b></a>");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
@@ -37,12 +37,12 @@ public class SanitizingXmlFilterTest {
   @Test
   public void sanityTest() throws IOException {
     String brokenXml =
-        "<b><c>h&el<»?>lo</c></b></a><a><b><c>ser>vus&lt;<br>welt dieses xml ist&;ganz schön kap<>utt<</c>";
+        "<b><c>h&el<»?>lo</c></b></a><a><b><c>ser>vus&lt;<br>welt <!,!!>dieses xml ist&;ganz schön kap<>utt<? wa<</c>";
     CharFilter filter = new SanitizingXmlFilter(new StringReader(brokenXml));
     String filtered = IOUtils.toString(filter);
     assertThat(filtered).matches(this::isWellFormed, "is well formed XML");
     assertThat(filtered).isEqualTo(
-        "<b><c>h_el_»?_lo</c></b>    <a><b><c>ser>vus&lt;    welt dieses xml ist_;ganz schön kap__utt_</c></b></a>");
+        "<b><c>h_el_»?_lo</c></b>    <a><b><c>ser>vus&lt;    welt _!,!!_dieses xml ist_;ganz schön kap__utt_? wa_</c></b></a>");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
@@ -36,11 +36,13 @@ public class SanitizingXmlFilterTest {
 
   @Test
   public void sanityTest() throws IOException {
-    String brokenXml = "<b><c>h&el<»?>lo</c></b></a><a><b><c>ser>vus&lt;<br>welt<</c>";
+    String brokenXml =
+        "<b><c>h&el<»?>lo</c></b></a><a><b><c>ser>vus&lt;<br>welt dieses xml ist&;ganz schön kaputt<</c>";
     CharFilter filter = new SanitizingXmlFilter(new StringReader(brokenXml));
     String filtered = IOUtils.toString(filter);
     assertThat(filtered).matches(this::isWellFormed, "is well formed XML");
-    assertThat(filtered).isEqualTo("<b><c>h_el_»?_lo</c></b>    <a><b><c>ser>vus&lt;    welt_</c></b></a>");
+    assertThat(filtered).isEqualTo(
+        "<b><c>h_el_»?_lo</c></b>    <a><b><c>ser>vus&lt;    welt dieses xml ist_;ganz schön kaputt_</c></b></a>");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
@@ -37,12 +37,12 @@ public class SanitizingXmlFilterTest {
   @Test
   public void sanityTest() throws IOException {
     String brokenXml =
-        "<b><c>h&el<»?>lo</c></b></a><a><b><c>ser>vus&lt;<br>welt <!,!!>dieses xml ist&;ganz schön kap<>utt<? wa<</c>";
+        "<b><c>h&el<»?>lo</c></b></a><a><b><c><>ser>vus&lt;<br>>welt <!,!!>dieses xml ist&;ganz schön kap<>utt<? wa<</c>";
     CharFilter filter = new SanitizingXmlFilter(new StringReader(brokenXml), true);
     String filtered = IOUtils.toString(filter);
     assertThat(filtered).matches(this::isWellFormed, "is well formed XML");
     assertThat(filtered).isEqualTo(
-        "<b><c>h_el_»?_lo</c></b>    <a><b><c>ser>vus&lt;    welt _!,!!_dieses xml ist_;ganz schön kap__utt_? wa_</c></b></a>");
+        "<b><c>h_el_»?_lo</c></b>    <a><b><c>__ser>vus&lt;    >welt _!,!!_dieses xml ist_;ganz schön kap__utt_? wa_</c></b></a>");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/lucene/SanitizingXmlFilterTest.java
@@ -38,7 +38,7 @@ public class SanitizingXmlFilterTest {
   public void sanityTest() throws IOException {
     String brokenXml =
         "<b><c>h&el<»?>lo</c></b></a><a><b><c>ser>vus&lt;<br>welt <!,!!>dieses xml ist&;ganz schön kap<>utt<? wa<</c>";
-    CharFilter filter = new SanitizingXmlFilter(new StringReader(brokenXml));
+    CharFilter filter = new SanitizingXmlFilter(new StringReader(brokenXml), true);
     String filtered = IOUtils.toString(filter);
     assertThat(filtered).matches(this::isWellFormed, "is well formed XML");
     assertThat(filtered).isEqualTo(
@@ -49,7 +49,7 @@ public class SanitizingXmlFilterTest {
   public void testWellformedXMLDoesntChange() throws IOException {
     Path p = Paths.get("src/test/resources/data/alto_nospace.xml");
     String alto = new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
-    CharFilter filter = new SanitizingXmlFilter(new InputStreamReader(new FileInputStream(p.toFile())));
+    CharFilter filter = new SanitizingXmlFilter(new InputStreamReader(new FileInputStream(p.toFile())), true);
     String filtered = IOUtils.toString(filter);
     assertThat(filtered).isEqualTo(alto);
   }
@@ -58,7 +58,7 @@ public class SanitizingXmlFilterTest {
   public void testAltoPageCrossing() throws IOException {
     Path p = Paths.get("src/test/resources/data/alto.xml");
     String alto = new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
-    CharFilter filter = new SanitizingXmlFilter(new StringReader(alto.substring(99762, 100508)));
+    CharFilter filter = new SanitizingXmlFilter(new StringReader(alto.substring(99762, 100508)), false);
     String filtered = IOUtils.toString(filter);
     assertThat(isWellFormed(filtered)).isTrue();
   }
@@ -78,7 +78,7 @@ public class SanitizingXmlFilterTest {
     String ptr = Paths.get("src/test/resources/data/multicolumn.hocr").toString();
     Reader reader = new ExternalUtf8ContentFilterFactory(new HashMap<>())
         .create(new StringReader(ptr));
-    Reader filteredReader = new PeekingReader(new SanitizingXmlFilter(reader), 2048, 16384);
+    Reader filteredReader = new PeekingReader(new SanitizingXmlFilter(reader, false), 2048, 16384);
     String filtered = IOUtils.toString(filteredReader);
     assertThat(filtered).isNotEmpty();
   }

--- a/src/test/java/de/digitalcollections/solrocr/util/PeekingReaderTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/util/PeekingReaderTest.java
@@ -97,7 +97,7 @@ class PeekingReaderTest {
         "\n" +
         "    <p class='ocr_par' id='par_17_6' lang='frk' title=\"bbox 185 823 1498 1084\">\n" +
         "     ";
-    Reader peekingReader = new PeekingReader(new SanitizingXmlFilter(new StringReader(fragment)), 2048, 16384);
+    Reader peekingReader = new PeekingReader(new SanitizingXmlFilter(new StringReader(fragment), false), 2048, 16384);
     HocrParser parser = new HocrParser(peekingReader);
     List<OcrBox> boxes = parser.stream().collect(Collectors.toList());
     assertThat(boxes).isNotEmpty();


### PR DESCRIPTION
- New `fixMarkup` parameter for `OcrCharFilterFactory` that enables code branches that try to "fix" broken/invalid markup. These fixes come with a bit of a performance hit and are thus disabled by default, since most users will have no need for them. The fixes that  are attempted are:
   * Unescaped pointy (`<>`) brackets
   * Illegal/partial entity declarations (i.e. caused by unescaped `&`)
- Errors raised during indexing will now always include the  source pointer of the document that caused the crash, which should help greatly with debugging