### PR TITLE
Add new `hl.ocr.scorePassages` parameter to toggle passage scoring (#151)

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -179,3 +179,10 @@ Additionally, the plugin allows you to customize various OCR-specific parameters
     This can improve highlighting performance, since less of the input file needs to be read and should
     be disabled when you index your documents at the page-level, i.e. when the identify of the page is
     encoded elsewhere in the document.
+
+`hl.ocr.scorePassages`:
+:   When `off` (defaults to `on`), the snippets are returned in order of their occurrence in the document. Otherwise,
+    it will follow Solr's default strategy for scoring highlighting snippets, which treats each candidate snippet as
+    a 'mini-document' that is scored using TF-IDF/BM25, treating the parent document as the corpus. This results in
+    a relevance score in relation to the parent document, i.e. the first snippet should be the most relevant snippet
+    in the document.

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
@@ -300,10 +300,11 @@ public class OcrHighlighter extends UnifiedHighlighter {
           int snippetLimit = Math.max(
               maxPassages[fieldIdx],
               params.getInt(OcrHighlightParams.MAX_OCR_PASSAGES, DEFAULT_SNIPPET_LIMIT));
+          boolean scorePassages = params.getBool(OcrHighlightParams.SCORE_PASSAGES, true);
           try {
             resultByDocIn[docInIndex] = fieldHighlighter.highlightFieldForDoc(
                 leafReader, docId, breakLocator, formatter, content,
-                params.get(OcrHighlightParams.PAGE_ID), snippetLimit);
+                params.get(OcrHighlightParams.PAGE_ID), snippetLimit, scorePassages);
           } catch (ExitingIterCharSeq.ExitingIterCharSeqException | ExitableDirectoryReader.ExitingReaderException e) {
             log.warn("OCR Highlighting timed out while handling " + content.getPointer(), e);
             respHeader.put(PARTIAL_OCR_HIGHLIGHTS, Boolean.TRUE);

--- a/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightParams.java
+++ b/src/main/java/de/digitalcollections/solrocr/solr/OcrHighlightParams.java
@@ -11,6 +11,7 @@ public interface OcrHighlightParams extends HighlightParams {
   String SCORE_BOOST_EARLY = "hl.score.boostEarly";
   String ABSOLUTE_HIGHLIGHTS = "hl.ocr.absoluteHighlights";
   String MAX_OCR_PASSAGES = "hl.ocr.maxPassages";
+  String SCORE_PASSAGES = "hl.ocr.scorePassages";
   String TIME_ALLOWED = "hl.ocr.timeAllowed";
   String ALIGN_SPANS = "hl.ocr.alignSpans";
   String TRACK_PAGES = "hl.ocr.trackPages";

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -409,4 +409,15 @@ public class HocrTest extends SolrTestCaseJ4 {
         "q", "ocr_text:\"returns the ee\"", "hl.weightMatches", "true");
     assertQ(req, "contains(((//lst[@name='47371']//arr[@name='snippets'])[1]/lst/str[@name='text'])[1]/text(), \"<em>returning Saturday. !>ee</em>\")");
   }
+
+  public void testUnscoredSnippets() {
+    SolrQueryRequest req = xmlQ("q", "fenitſchka", "hl.ocr.scorePassages", "off");
+    assertQ(
+        req,
+        "((//lst[@name='42']//arr[@name='pages'])[1]/lst/str[@name='id'])[1]/text()='page_88'",
+        "((//lst[@name='42']//arr[@name='pages'])[2]/lst/str[@name='id'])[1]/text()='page_89'",
+        "((//lst[@name='42']//arr[@name='pages'])[3]/lst/str[@name='id'])[1]/text()='page_92'",
+        "((//lst[@name='42']//arr[@name='pages'])[4]/lst/str[@name='id'])[1]/text()='page_92'",
+        "((//lst[@name='42']//arr[@name='pages'])[5]/lst/str[@name='id'])[1]/text()='page_97'");
+  }
 }


### PR DESCRIPTION
Setting this option to `off` or `false` will make sure that the passages are simply returned in order of their occurrence in the input document, and not based on their relevancy score in relation to the document.