### PR TITLE
Be more tolerant of incomplete bounding boxes during parsing (#154)

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
@@ -5,6 +5,7 @@ import de.digitalcollections.solrocr.model.OcrBox;
 import de.digitalcollections.solrocr.model.OcrPage;
 import java.awt.Dimension;
 import java.io.Reader;
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -12,8 +13,12 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import org.apache.commons.lang3.StringUtils;
 import org.codehaus.stax2.XMLStreamReader2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HocrParser extends OcrParser {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   private boolean noMoreWords;
   private OcrPage currentPage;
   private OcrBox hyphenEnd = null;
@@ -118,13 +123,20 @@ public class HocrParser extends OcrParser {
 
   private void parseCoordinates(OcrBox box, String bboxStr) {
     String[] parts = bboxStr.split(" ");
-    if (parts.length != 4) {
-      throw new IllegalStateException("hOCR bbox property must have exactly 4 values.");
+    if (parts.length > 0) {
+      box.setUlx(Integer.parseInt(parts[0]));
     }
-    box.setUlx(Integer.parseInt(parts[0]));
-    box.setUly(Integer.parseInt(parts[1]));
-    box.setLrx(Integer.parseInt(parts[2]));
-    box.setLry(Integer.parseInt(parts[3]));
+    if (parts.length > 1) {
+      box.setUly(Integer.parseInt(parts[1]));
+    }
+    if (parts.length > 2) {
+      box.setLrx(Integer.parseInt(parts[2]));
+    }
+    if (parts.length > 3) {
+      box.setLry(Integer.parseInt(parts[3]));
+    } else {
+      log.warn("bbox attribute '{}' is incomplete.", bboxStr);
+    }
   }
 
   private void parseText(

--- a/src/main/java/de/digitalcollections/solrocr/formats/miniocr/MiniOcrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/miniocr/MiniOcrParser.java
@@ -5,13 +5,17 @@ import de.digitalcollections.solrocr.model.OcrBox;
 import de.digitalcollections.solrocr.model.OcrPage;
 import java.awt.Dimension;
 import java.io.Reader;
+import java.lang.invoke.MethodHandles;
 import java.util.Set;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import org.apache.commons.lang3.StringUtils;
 import org.codehaus.stax2.XMLStreamReader2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MiniOcrParser extends OcrParser {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final char alternativeMarker = '⇿';
 
   private boolean noMoreWords;
@@ -42,10 +46,20 @@ public class MiniOcrParser extends OcrParser {
     OcrBox box = new OcrBox();
     if (features.contains(ParsingFeature.COORDINATES)) {
       String[] coords = xmlReader.getAttributeValue("", "x").split(" ");
-      box.setUlx(Float.parseFloat(coords[0]));
-      box.setUly(Float.parseFloat(coords[1]));
-      box.setLrx(box.getUlx() + Float.parseFloat(coords[2]));
-      box.setLry(box.getUly() + Float.parseFloat(coords[3]));
+      if (coords.length > 0) {
+        box.setUlx(Float.parseFloat(coords[0]));
+      }
+      if (coords.length > 1) {
+        box.setUly(Float.parseFloat(coords[1]));
+      }
+      if (coords.length > 2) {
+        box.setLrx(box.getUlx() + Float.parseFloat(coords[2]));
+      }
+      if (coords.length > 3) {
+        box.setLry(box.getUly() + Float.parseFloat(coords[3]));
+      } else {
+        log.warn("x attribute is incomplete: '{}'", String.join(" ", coords));
+      }
     }
     if (features.contains(ParsingFeature.CONFIDENCE)) {
       String confidence = xmlReader.getAttributeValue("", "c");


### PR DESCRIPTION
Previously we'd bail with an exception (with a helpful message for hOCR/ALTO, with an ugly NPE for MiniOCR).
I think a few bad words shouldn't cause the whole query to fail, with this PR the missing coordinates will now be just `-1` and the process can continue.