### PR TITLE
Handle empty field values during indexing.

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilterFactory.java
@@ -38,6 +38,10 @@ public class OcrCharFilterFactory extends CharFilterFactory {
   public Reader create(Reader input) {
     PeekingReader peeker = new PeekingReader(
        new SanitizingXmlFilter(input, fixMarkup), BEGIN_BUF_SIZE, CTX_BUF_SIZE);
+    if (peeker.peekBeginning().isEmpty()) {
+      // Empty document, no special treatment necessary
+      return peeker;
+    }
     OcrFormat fmt = FORMATS.stream()
         .filter(f -> f.hasFormat(peeker.peekBeginning()))
         .findFirst()


### PR DESCRIPTION
Previously this would cause an error since the plugin wasn't able to determine an OCR format from the empty string, we now simply forward the empty string to the rest of the analysis chain.