### PR TITLE
Fix handling of documents with no content (fixes #163)

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoParser.java
@@ -42,14 +42,15 @@ public class AltoParser extends OcrParser {
       this.hyphenEnd = null;
       return out;
     }
-    if (noMoreWords) {
-      return null;
-    }
 
     // Advance reader to the next word if neccessary
     if (xmlReader.getEventType() != XMLStreamConstants.START_ELEMENT
         || !"String".equals(xmlReader.getLocalName())) {
       this.seekToNextWord(xmlReader, features.contains(ParsingFeature.PAGES));
+    }
+
+    if (noMoreWords) {
+      return null;
     }
 
     OcrBox box = new OcrBox();

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
@@ -118,6 +118,9 @@ public class HocrParser extends OcrParser {
 
   private Map<String, String> parseTitle(String title) {
     Map<String, String> props = new HashMap<>();
+    if (title == null) {
+      return props;
+    }
     String[] parts = title.split(";");
     for (String part : parts) {
       int spaceIdx = part.indexOf(' ', 3);

--- a/src/main/java/de/digitalcollections/solrocr/formats/miniocr/MiniOcrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/miniocr/MiniOcrParser.java
@@ -36,13 +36,13 @@ public class MiniOcrParser extends OcrParser {
       return out;
     }
 
-    if (noMoreWords) {
-      return null;
-    }
-
     if (xmlReader.getEventType() != XMLStreamConstants.START_ELEMENT
         || !"w".equals(xmlReader.getLocalName())) {
       this.seekToNextWord(xmlReader, features.contains(ParsingFeature.PAGES));
+    }
+
+    if (noMoreWords) {
+      return null;
     }
 
     OcrBox box = new OcrBox();

--- a/src/test/java/de/digitalcollections/solrocr/formats/alto/AltoParserTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/formats/alto/AltoParserTest.java
@@ -161,7 +161,7 @@ public class AltoParserTest {
   }
 
   @Test
-  public void testConsequtiveHyphens() throws FileNotFoundException, XMLStreamException {
+  public void testConsecutiveHyphens() throws FileNotFoundException, XMLStreamException {
     AltoParser parser =
         new AltoParser(
             new FileReader(Paths.get("src/test/resources/data/hyphenconseq.xml").toFile()),
@@ -174,5 +174,13 @@ public class AltoParserTest {
                 .map(OcrBox::getTrailingChars))
         .isEqualTo(Optional.of(""));
     assertThat(OcrParser.boxesToString(boxes)).contains("li-li-li-conse");
+  }
+
+  @Test
+  public void testEmptyDoc() throws XMLStreamException {
+    AltoParser parser = new AltoParser(new StringReader("<?xml version=\"1.0\" encoding=\"UTF-8\"?><alto xmlns=\"http://www.loc.gov/standards/alto/ns-v3#\" ><Description><MeasurementUnit>pixel</MeasurementUnit><sourceImageInformation><fileName>23-n1_343578.pdf</fileName></sourceImageInformation><OCRProcessing ID=\"IdOcr\"><ocrProcessingStep><processingDateTime>2021-05-13T09:26:19Z</processingDateTime><processingSoftware><softwareCreator>CONTRIBUTORS</softwareCreator><softwareName>pdfalto</softwareName><softwareVersion>0.5</softwareVersion></processingSoftware></ocrProcessingStep></OCRProcessing></Description><Styles/><Layout><Page ID=\"Page6\" PHYSICAL_IMG_NR=\"6\" WIDTH=\"595.276\" HEIGHT=\"841.890\"><PrintSpace/></Page></Layout></alto>"));
+    List<OcrBox> boxes = parser.stream().collect(Collectors.toList());
+    assertThat(boxes).isEmpty();
+    assertThat(OcrParser.boxesToString(boxes)).isEmpty();
   }
 }

--- a/src/test/java/de/digitalcollections/solrocr/formats/hocr/HocrParserTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/formats/hocr/HocrParserTest.java
@@ -181,4 +181,11 @@ public class HocrParserTest {
     OcrParser parser = new HocrParser(input);
     assertThatThrownBy(() -> parser.stream().count()).hasMessageContaining(ptr);
   }
+
+  @Test
+  public void testEmptyPage() throws XMLStreamException {
+    String doc = "<html><body><div class=\"ocr_page\" id=\"page_1\"></div></body></html>";
+    HocrParser parser = new HocrParser(new StringReader(doc));
+    assertThat(parser.stream().count()).isZero();
+  }
 }


### PR DESCRIPTION
The plugin would throw an error when a document would have no usable OCR content at all (e.g. with a single-page document that only contains an empty page).
This has now been fixed for all formats.