### PR TITLE
Fix indexing of OCR fields that only contain an empty string (fixes #167)

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.io.StringReader;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
@@ -42,6 +43,9 @@ public class ExternalUtf8ContentFilterFactory extends CharFilterFactory {
       ptrStr = IOUtils.toString(input);
     } catch (IOException e) {
       throw new RuntimeException("Could not read source pointer from the input.", e);
+    }
+    if (ptrStr.isEmpty()) {
+      return new StringReader("");
     }
     try {
       SourcePointer pointer = SourcePointer.parse(ptrStr);

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilter.java
@@ -5,6 +5,7 @@ import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
 import de.digitalcollections.solrocr.formats.OcrParser;
 import de.digitalcollections.solrocr.model.OcrBox;
+import java.io.StringReader;
 import java.util.List;
 import java.util.Optional;
 import org.apache.lucene.analysis.CharFilter;
@@ -18,6 +19,15 @@ public class OcrCharFilter extends BaseCharFilter {
   private char[] curWord;
   private int curWordIdx = -1;
   private int outputOffset = 0;
+
+  public static OcrCharFilter nopFilter() {
+    return new OcrCharFilter();
+  }
+
+  private OcrCharFilter() {
+    super(new StringReader(""));
+    this.parser = null;
+  }
 
   public OcrCharFilter(OcrParser parser) {
     super(parser.getInput());
@@ -117,7 +127,7 @@ public class OcrCharFilter extends BaseCharFilter {
 
   @Override
   public int read(char[] cbuf, int off, int len) {
-    if (!this.parser.hasNext()) {
+    if (this.parser == null || !this.parser.hasNext()) {
       return -1;
     }
 

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilterFactory.java
@@ -38,7 +38,7 @@ public class OcrCharFilterFactory extends CharFilterFactory {
         new PeekingReader(new SanitizingXmlFilter(input, fixMarkup), BEGIN_BUF_SIZE, CTX_BUF_SIZE);
     if (peeker.peekBeginning().isEmpty()) {
       // Empty document, no special treatment necessary
-      return peeker;
+      return OcrCharFilter.nopFilter();
     }
     OcrFormat fmt =
         FORMATS.stream()
@@ -50,7 +50,7 @@ public class OcrCharFilterFactory extends CharFilterFactory {
                         "Could not determine OCR format from chunk: " + peeker.peekBeginning()));
     Reader formatFilter = fmt.filter(peeker, expandAlternatives);
     if (formatFilter == null) {
-      return peeker;
+      return OcrCharFilter.nopFilter();
     } else {
       return formatFilter;
     }

--- a/src/main/java/de/digitalcollections/solrocr/reader/PeekingReader.java
+++ b/src/main/java/de/digitalcollections/solrocr/reader/PeekingReader.java
@@ -42,8 +42,10 @@ public class PeekingReader extends BaseCharFilter implements SourceAwareReader {
       if (numRead < beginPeekSize) {
         // If the input reader has less characters than the requested start peek buffer, use a
         // smaller buffer
-        this.peekStart = new char[numRead];
-        System.arraycopy(buf, 0, this.peekStart, 0, numRead);
+        this.peekStart = new char[Math.max(0, numRead)];
+        if (numRead > 0) {
+          System.arraycopy(buf, 0, this.peekStart, 0, numRead);
+        }
       } else {
         this.peekStart = buf;
       }

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -332,4 +332,9 @@ public class AltoTest extends SolrTestCaseJ4 {
         req,
         "contains(((//lst[@name='47371']//arr[@name='snippets'])[1]/lst/str[@name='text'])[1]/text(), '<em>Ade About Nothings</em>')");
   }
+
+  public void testEmptyDoc() {
+    assertU(adoc("id", "57371"));
+    assertU(adoc("id", "57371", "ocr_text", ""));
+  }
 }

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -489,4 +489,10 @@ public class HocrTest extends SolrTestCaseJ4 {
         "((//lst[@name='42']//arr[@name='pages'])[4]/lst/str[@name='id'])[1]/text()='page_92'",
         "((//lst[@name='42']//arr[@name='pages'])[5]/lst/str[@name='id'])[1]/text()='page_97'");
   }
+
+  public void testEmptyDoc() {
+    assertU(adoc("id", "57371"));
+    assertU(adoc("id", "57371", "ocr_text", ""));
+    assertU(commit());
+  }
 }


### PR DESCRIPTION
We had various spots that didn't handle empty documents very well, this has now been fixed.