### PR TITLE
Skip empty boxes

### DIFF
--- a/integration-tests/data/hocr.html
+++ b/integration-tests/data/hocr.html
@@ -5395,7 +5395,7 @@
 
 </div>
 <div class="ocrx_block" title="bbox 282 1968 412 2003">
-<p class="ocr_par" title="bbox 282 1968 412 2003" style='font-size:15pt;font-family:"Times";font-style:italic;'><span class="ocr_line" title="bbox 282 1968 412 2003"><span class="ocrx_word" title="bbox 282 1968 412 2003">maM</span></span></p>
+<p class="ocr_par" title="bbox 282 1968 412 2003" style='font-size:15pt;font-family:"Times";font-style:italic;'><span class="ocr_line" title="bbox 282 1968 412 2003"><span class="ocrx_word" title="bbox 282 1968 412 2003">maM</span><span class="ocrx_word" title="bbox 1236 107 1304 137"/></span></p>
 
 </div>
 <div class="ocrx_block" title="bbox 0 0 0 0">

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
@@ -104,14 +104,14 @@ public class HocrParser extends OcrParser {
     }
 
     // Boxes without text or coordinates (if either is requested with a feature flag) are ignored
-    // since they break things downstream
+    // since they break things downstream. Skip the current box and continue with next one.
     boolean ignoreBox =
         (features.contains(ParsingFeature.TEXT)
                 && (box.getText() == null || box.getText().isEmpty()))
             || (features.contains(ParsingFeature.COORDINATES)
                 && (box.getLrx() < 0 && box.getLry() < 0 && box.getUlx() < 0 && box.getUly() < 0));
     if (ignoreBox) {
-      return null;
+      box = this.readNext(xmlReader, features);
     }
     return box;
   }

--- a/src/test/java/de/digitalcollections/solrocr/formats/hocr/HocrParserTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/formats/hocr/HocrParserTest.java
@@ -188,4 +188,24 @@ public class HocrParserTest {
     HocrParser parser = new HocrParser(new StringReader(doc));
     assertThat(parser.stream().count()).isZero();
   }
+
+  @Test
+  public void testIgnoredBoxes() throws XMLStreamException {
+    String fragment =
+        "<span class=\"ocr_line\" title=\"bbox 245 1992 1312 2038\"><span class=\"ocrx_word\" title=\"bbox 245 1996 356 2038\">object</span> <span class=\"ocrx_word\" title=\"bbox 1268 1443 1276 1449;x_wconf 75\"/> <span class=\"ocrx_word\" title=\"bbox 1268 1443 1276 1449;x_wconf 75\"/> <span class=\"ocrx_word\" title=\"bbox 370 2003 426 2026\">too</span> <span class=\"ocrx_word\" title=\"bbox 441 1993 568 2035\">hastily,</span> <span class=\"ocrx_word\" title=\"bbox 584 1993 616 2024\">in</span> <span class=\"ocrx_word\" title=\"bbox 632 1992 778 2024\">addition</span> <span class=\"ocrx_word\" title=\"bbox 795 1998 830 2024\">to</span> <span class=\"ocrx_word\" title=\"bbox 847 1993 901 2025\">the</span> <span class=\"ocrx_word\" title=\"bbox 917 1994 1000 2026\">facts</span> <span class=\"ocrx_word\" title=\"bbox 1016 1993 1146 2038\">already</span> <span class=\"ocrx_word\" title=\"bbox 1162 1997 1268 2028\">stated</span> <span class=\"ocrx_word\" title=\"bbox 1286 1997 1312 2027\">it</span> </span><span class=\"ocr_line\" title=\"bbox 244 2035 1316 2083\"><span class=\"ocrx_word\" title=\"bbox 244 2040 348 2083\">ought</span> <span class=\"ocrx_word\" title=\"bbox 363 2045 396 2070\">to</span> <span class=\"ocrx_word\" title=\"bbox 412 2037 453 2069\">be</span> <span class=\"ocrx_word\" title=\"bbox 468 2036 647 2076\">remarked,</span> <span class=\"ocrx_word\" title=\"bbox 660 2035 731 2069\">that</span> <span class=\"ocrx_word\" title=\"bbox 744 2035 911 2080\">Kunnpfer</span> <span class=\"ocrx_word\" title=\"bbox 924 2037 1087 2071\">describes</span> <span class=\"ocrx_word\" title=\"bbox 1105 2039 1161 2072\">the</span> <span class=\"ocrx_word\" title=\"bbox 1174 2045 1265 2072\">coast</span> <span class=\"ocrx_word\" title=\"bbox 1276 2040 1316 2070\">of</span></span>    \n"
+            + "\n"
+            + "<p class=\"ocr_par\" title=\"bbox 1206 2083 1314 2125\" style=\"font-size:11pt;font-family:&quot;Times&quot;;font-style:normal\"><span class=\"ocr_line\" title=\"bbox 1206 2083 1314 2125\"><span class=\"ocrx_word\" title=\"bbox 1206 2083 1314 2125\">\uD83D\uDD25Japan\uD83E\uDDEF</span></span></p>\n"
+            + "\n"
+            + "      \n"
+            + "\n"
+            + "      \n"
+            + "\n"
+            + "\n"
+            + "<div class=\"ocr_page\" id=\"page_249\" title=\"bbox 0 0 1428 2403\">\n"
+            + "\n"
+            + "</div>\n";
+    HocrParser parser = new HocrParser(new StringReader(fragment), OcrParser.ParsingFeature.TEXT);
+    List<OcrBox> boxes = parser.stream().collect(Collectors.toList());
+    assertThat(boxes).hasSize(22);
+  }
 }


### PR DESCRIPTION
This PR fixes a bug, when an empty box element such as:

```xml
<span class="ocrx_word" title="bbox 1268 1443 1276 1449;x_wconf 75"/>
```

occurs in the document. Unfortunately, all following boxes after an empty box won't be correctly parsed (process is stopped).

This PR will skip empty boxes (and reads the next element) to fix this problem.