### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>solr-ocrhighlighting</artifactId>
-  <version>0.7.0-SNAPSHOT</version>
+  <version>0.7.0</version>
 
   <name>Solr OCR Highlighting Plugin</name>
   <description>


### PR DESCRIPTION
Release version including various fixes:

- #163 Documents with no Content
- #171 Indexing documents with elements that contain only an empty string
- #173 Empty OCR highlighting snippets