### PR TITLE
Add support for namespaced ALTO XML (fixes #191)

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoFormat.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/alto/AltoFormat.java
@@ -79,9 +79,11 @@ public class AltoFormat implements OcrFormat {
 
   @Override
   public boolean hasFormat(String ocrChunk) {
-    // Check if the chunk contains any ALTO tags
+    // Check if the chunk contains any ALTO tags, both un-namespaced and namespaced
     return ocrChunk.contains("<alto")
-        || blockTagMapping.values().stream().anyMatch(t -> ocrChunk.contains("<" + t));
+        || ocrChunk.contains(":alto")
+        || blockTagMapping.values().stream()
+            .anyMatch(t -> ocrChunk.contains("<" + t) || ocrChunk.contains(":" + t));
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -179,7 +179,7 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
         // actually
         boolean illegalTag = tagLen == 0;
         for (int i = 0; i < tagLen; i++) {
-          if (!Character.isLetter(cbuf[startTag + i])) {
+          if (!Character.isLetter(cbuf[startTag + i]) && cbuf[startTag + i] != ':') {
             illegalTag = true;
             break;
           }

--- a/src/main/java/de/digitalcollections/solrocr/reader/LegacyBaseCompositeReader.java
+++ b/src/main/java/de/digitalcollections/solrocr/reader/LegacyBaseCompositeReader.java
@@ -48,8 +48,8 @@ import org.apache.lucene.index.Term;
  * synchronization, you should <b>not</b> synchronize on the <code>IndexReader</code> instance; use
  * your own (non-Lucene) objects instead.
  *
- * <p><b>NOTE:</b></p> This is a backport from Lucene 8.8 since the API
- * changed with v8.9, but we still want to support earlier versions.
+ * <p><b>NOTE:</b> This is a backport from Lucene 8.8 since the API changed with v8.9, but we still
+ * want to support earlier versions.
  *
  * @see MultiReader
  * @lucene.internal

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -351,6 +351,19 @@ public class AltoTest extends SolrTestCaseJ4 {
     assertU(adoc("id", "57372", "ocr_text", ptr));
     assertU(commit());
     SolrQueryRequest req = xmlQ("q", "gallega", "hl.snippets", "50");
-    assertQ(req, "count(//arr[@name='snippets']/lst)='24'", "//int[@name='numTotal']/text()='24'");
+    assertQ(
+        req,
+        "count(//lst[@name='57372']//arr[@name='snippets']/lst)='24'",
+        "//int[@name='numTotal']/text()='24'");
+  }
+
+  public void testNamespacedDoc() {
+    Path ocrPath = Paths.get("src/test/resources/data/alto_namespaced.xml");
+    assertU(adoc("ocr_text", ocrPath.toString(), "id", "47378"));
+    assertU(commit());
+    SolrQueryRequest req = xmlQ("q", "ocr_text:campea");
+    assertQ(
+        req,
+        "contains(((//lst[@name='47378']//arr[@name='snippets'])[1]/lst/str[@name='text'])[1]/text(), '<em>campea</em>')");
   }
 }

--- a/src/test/resources/data/alto_namespaced.xml
+++ b/src/test/resources/data/alto_namespaced.xml
@@ -1,0 +1,4394 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<a:alto xmlns="http://www.loc.gov/standards/alto/ns-v2#" xmlns:a="http://www.loc.gov/standards/alto/ns-v2#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/standards/alto/ns-v2# http://www.loc.gov/standards/alto/alto-v2.0a.xsd">
+  <a:Description>
+    <a:MeasurementUnit>pixel</a:MeasurementUnit>
+    <a:sourceImageInformation>
+      <a:fileName>bpp-pug-19240129_id53153\jpeg\bpp-pug-19240129_id53153_0001.jpg</a:fileName>
+      <a:fileIdentifier>31820329</a:fileIdentifier>
+    </a:sourceImageInformation>
+    <a:OCRProcessing ID="OCRPROC001">
+      <a:ocrProcessingStep>
+        <a:processingDateTime>2018-02-16T09:52:29</a:processingDateTime>
+        <a:processingAgency>DIGIBIS S.L.</a:processingAgency>
+        <a:processingStepDescription>FineReader.AnalyzeAndRecognizePage</a:processingStepDescription>
+        <a:processingStepSettings>Profile:Z:\infor\procesosocr\general\prensamcu.ini</a:processingStepSettings>
+        <a:processingSoftware>
+          <a:softwareCreator>Abby</a:softwareCreator>
+          <a:softwareName>FineReader</a:softwareName>
+          <a:softwareVersion>9.0</a:softwareVersion>
+          <a:applicationDescription />
+        </a:processingSoftware>
+      </a:ocrProcessingStep>
+    </a:OCRProcessing>
+  </a:Description>
+  <a:Styles>
+    <a:TextStyle ID="TEXTSTYLE0001" FONTFAMILY="Times New Roman" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="8" FONTSTYLE="bold" />
+    <a:TextStyle ID="TEXTSTYLE0002" FONTFAMILY="Times New Roman" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="8" />
+    <a:TextStyle ID="TEXTSTYLE0003" FONTFAMILY="Times New Roman" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="10" />
+    <a:TextStyle ID="TEXTSTYLE0004" FONTFAMILY="Times New Roman" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="12" FONTSTYLE="bold" />
+    <a:TextStyle ID="TEXTSTYLE0005" FONTFAMILY="Times New Roman" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="13" FONTSTYLE="bold" />
+    <a:TextStyle ID="TEXTSTYLE0006" FONTFAMILY="Times New Roman" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="17" FONTSTYLE="bold" />
+    <a:TextStyle ID="TEXTSTYLE0007" FONTFAMILY="Times New Roman" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="7" FONTSTYLE="bold" />
+    <a:TextStyle ID="TEXTSTYLE0008" FONTFAMILY="Times New Roman" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="33" />
+    <a:TextStyle ID="TEXTSTYLE0009" FONTFAMILY="Times New Roman" FONTTYPE="serif" FONTWIDTH="proportional" FONTSIZE="10" FONTSTYLE="bold" />
+    <a:ParagraphStyle ID="PARSTYLE0001" ALIGN="Block" LEFT="2" RIGHT="0" LINESPACE="103" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0002" LEFT="1388" RIGHT="0" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0003" ALIGN="Block" LEFT="0" RIGHT="0" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0004" ALIGN="Block" LEFT="0" RIGHT="0" LINESPACE="73" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0005" ALIGN="Block" LEFT="15" RIGHT="0" LINESPACE="182" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0006" ALIGN="Block" LEFT="0" RIGHT="6" LINESPACE="53" FIRSTLINE="117" />
+    <a:ParagraphStyle ID="PARSTYLE0007" ALIGN="Block" LEFT="17" RIGHT="5" LINESPACE="53" FIRSTLINE="101" />
+    <a:ParagraphStyle ID="PARSTYLE0008" ALIGN="Block" LEFT="0" RIGHT="37" LINESPACE="54" FIRSTLINE="47" />
+    <a:ParagraphStyle ID="PARSTYLE0009" ALIGN="Block" LEFT="0" RIGHT="12" LINESPACE="53" FIRSTLINE="51" />
+    <a:ParagraphStyle ID="PARSTYLE0010" ALIGN="Block" LEFT="9" RIGHT="0" LINESPACE="53" FIRSTLINE="49" />
+    <a:ParagraphStyle ID="PARSTYLE0011" ALIGN="Block" LEFT="3" RIGHT="22" LINESPACE="54" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0012" ALIGN="Block" LEFT="0" RIGHT="9" LINESPACE="53" FIRSTLINE="51" />
+    <a:ParagraphStyle ID="PARSTYLE0013" ALIGN="Block" LEFT="16" RIGHT="0" LINESPACE="53" FIRSTLINE="52" />
+    <a:ParagraphStyle ID="PARSTYLE0014" ALIGN="Block" LEFT="2" RIGHT="29" LINESPACE="53" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0015" ALIGN="Block" LEFT="0" RIGHT="19" LINESPACE="53" FIRSTLINE="49" />
+    <a:ParagraphStyle ID="PARSTYLE0016" ALIGN="Block" LEFT="33" RIGHT="16" LINESPACE="53" FIRSTLINE="50" />
+    <a:ParagraphStyle ID="PARSTYLE0017" ALIGN="Block" LEFT="40" RIGHT="15" LINESPACE="53" FIRSTLINE="50" />
+    <a:ParagraphStyle ID="PARSTYLE0018" ALIGN="Block" LEFT="41" RIGHT="15" LINESPACE="54" FIRSTLINE="53" />
+    <a:ParagraphStyle ID="PARSTYLE0019" ALIGN="Block" LEFT="44" RIGHT="12" LINESPACE="53" FIRSTLINE="50" />
+    <a:ParagraphStyle ID="PARSTYLE0020" ALIGN="Block" LEFT="49" RIGHT="0" LINESPACE="53" FIRSTLINE="49" />
+    <a:ParagraphStyle ID="PARSTYLE0021" ALIGN="Block" LEFT="0" RIGHT="13" LINESPACE="53" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0022" ALIGN="Block" LEFT="0" RIGHT="4" LINESPACE="53" FIRSTLINE="54" />
+    <a:ParagraphStyle ID="PARSTYLE0023" ALIGN="Block" LEFT="10" RIGHT="4" LINESPACE="53" FIRSTLINE="56" />
+    <a:ParagraphStyle ID="PARSTYLE0024" ALIGN="Block" LEFT="5" RIGHT="0" LINESPACE="53" FIRSTLINE="46" />
+    <a:ParagraphStyle ID="PARSTYLE0025" ALIGN="Right" LEFT="0" RIGHT="3" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0026" ALIGN="Block" LEFT="31" RIGHT="0" LINESPACE="161" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0027" LEFT="329" RIGHT="0" LINESPACE="53" FIRSTLINE="-294" />
+    <a:ParagraphStyle ID="PARSTYLE0028" ALIGN="Block" LEFT="0" RIGHT="1" LINESPACE="53" FIRSTLINE="87" />
+    <a:ParagraphStyle ID="PARSTYLE0029" ALIGN="Block" LEFT="1" RIGHT="12" LINESPACE="53" FIRSTLINE="58" />
+    <a:ParagraphStyle ID="PARSTYLE0030" ALIGN="Block" LEFT="0" RIGHT="10" LINESPACE="53" FIRSTLINE="728" />
+    <a:ParagraphStyle ID="PARSTYLE0031" ALIGN="Block" LEFT="3" RIGHT="8" LINESPACE="54" FIRSTLINE="57" />
+    <a:ParagraphStyle ID="PARSTYLE0032" ALIGN="Block" LEFT="7" RIGHT="9" LINESPACE="54" FIRSTLINE="56" />
+    <a:ParagraphStyle ID="PARSTYLE0033" ALIGN="Block" LEFT="8" RIGHT="5" LINESPACE="54" FIRSTLINE="57" />
+    <a:ParagraphStyle ID="PARSTYLE0034" ALIGN="Block" LEFT="11" RIGHT="4" LINESPACE="53" FIRSTLINE="56" />
+    <a:ParagraphStyle ID="PARSTYLE0035" ALIGN="Block" LEFT="14" RIGHT="0" LINESPACE="52" FIRSTLINE="50" />
+    <a:ParagraphStyle ID="PARSTYLE0036" ALIGN="Block" LEFT="18" RIGHT="2" LINESPACE="52" FIRSTLINE="55" />
+    <a:ParagraphStyle ID="PARSTYLE0037" ALIGN="Block" LEFT="16" RIGHT="3" LINESPACE="51" FIRSTLINE="56" />
+    <a:ParagraphStyle ID="PARSTYLE0038" ALIGN="Right" LEFT="0" RIGHT="8" FIRSTLINE="0" />
+    <a:ParagraphStyle ID="PARSTYLE0039" ALIGN="Left" LEFT="2" RIGHT="0" FIRSTLINE="0" />
+  </a:Styles>
+  <a:Layout>
+    <a:Page ID="PAG0001" HEIGHT="7889" WIDTH="5107" PHYSICAL_IMG_NR="1" PROCESSING="OCRPROC001">
+      <a:PrintSpace HEIGHT="7889" WIDTH="5107" HPOS="0" VPOS="0">
+        <a:Illustration ID="PAG001BLK0001" HEIGHT="423" WIDTH="421" HPOS="278" VPOS="428" />
+        <a:Illustration ID="PAG001BLK0002" HEIGHT="373" WIDTH="657" HPOS="814" VPOS="432" />
+        <a:ComposedBlock ID="PAG001BLK0003" HEIGHT="245" WIDTH="1779" HPOS="344" VPOS="952" />
+        <a:TextBlock ID="PAG001BLK0004" HEIGHT="152" WIDTH="1748" HPOS="358" VPOS="961" STYLEREFS="PARSTYLE0001">
+          <a:TextLine ID="PAG001LIN0001" WIDTH="1747" HEIGHT="51" HPOS="358" VPOS="961">
+            <a:String CONTENT="-:-" HEIGHT="26" WIDTH="52" HPOS="358" VPOS="981" WC="0.96" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="88" HPOS="498" VPOS="967" />
+            <a:String CONTENT="Ei" HEIGHT="37" WIDTH="46" HPOS="498" VPOS="967" WC="0.98" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="572" VPOS="976" />
+            <a:String CONTENT="que" HEIGHT="36" WIDTH="79" HPOS="572" VPOS="976" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="679" VPOS="975" />
+            <a:String CONTENT="sabe" HEIGHT="37" WIDTH="103" HPOS="679" VPOS="964" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="29" HPOS="811" VPOS="968" />
+            <a:String CONTENT="trabajar" HEIGHT="43" WIDTH="185" HPOS="811" VPOS="963" WC="0.98" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="1023" VPOS="973" />
+            <a:String CONTENT="no" HEIGHT="27" WIDTH="54" HPOS="1023" VPOS="973" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="1104" VPOS="974" />
+            <a:String CONTENT="se" HEIGHT="26" WIDTH="49" HPOS="1104" VPOS="974" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="1179" VPOS="974" />
+            <a:String CONTENT="muere" HEIGHT="28" WIDTH="143" HPOS="1179" VPOS="974" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="1349" VPOS="966" />
+            <a:String CONTENT="de" HEIGHT="36" WIDTH="52" HPOS="1349" VPOS="966" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="1427" VPOS="966" />
+            <a:String CONTENT="hambre." HEIGHT="38" WIDTH="187" HPOS="1427" VPOS="964" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="39" HPOS="1653" VPOS="962" />
+            <a:String CONTENT="El" HEIGHT="37" WIDTH="45" HPOS="1653" VPOS="962" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="1726" VPOS="964" />
+            <a:String CONTENT="hambre" HEIGHT="37" WIDTH="175" HPOS="1726" VPOS="961" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="33" HPOS="1934" VPOS="972" />
+            <a:String CONTENT="estÃ¡" HEIGHT="37" WIDTH="93" HPOS="1934" VPOS="963" WC="0.95" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="2053" VPOS="973" />
+            <a:String CONTENT="en" HEIGHT="27" WIDTH="52" HPOS="2053" VPOS="973" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0002" WIDTH="1745" HEIGHT="48" HPOS="360" VPOS="1064">
+            <a:String CONTENT="acecho" HEIGHT="37" WIDTH="158" HPOS="360" VPOS="1072" WC="0.95" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="546" VPOS="1080" />
+            <a:String CONTENT="a" HEIGHT="26" WIDTH="21" HPOS="546" VPOS="1080" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="29" HPOS="596" VPOS="1069" />
+            <a:String CONTENT="la" HEIGHT="35" WIDTH="38" HPOS="596" VPOS="1069" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="660" VPOS="1077" />
+            <a:String CONTENT="puerta" HEIGHT="42" WIDTH="149" HPOS="660" VPOS="1070" WC="0.96" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="836" VPOS="1076" />
+            <a:String CONTENT="&lt;tei" HEIGHT="36" WIDTH="65" HPOS="836" VPOS="1066" WC="0.96" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="34" HPOS="935" VPOS="1065" />
+            <a:String CONTENT="hombre" HEIGHT="37" WIDTH="175" HPOS="935" VPOS="1065" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="34" HPOS="1144" VPOS="1067" />
+            <a:String CONTENT="laborioso," HEIGHT="45" WIDTH="229" HPOS="1144" VPOS="1066" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="33" HPOS="1406" VPOS="1077" />
+            <a:String CONTENT="pero" HEIGHT="35" WIDTH="103" HPOS="1406" VPOS="1076" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="33" HPOS="1542" VPOS="1076" />
+            <a:String CONTENT="no" HEIGHT="27" WIDTH="54" HPOS="1542" VPOS="1076" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="1623" VPOS="1075" />
+            <a:String CONTENT="se" HEIGHT="27" WIDTH="49" HPOS="1623" VPOS="1075" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="32" HPOS="1704" VPOS="1075" />
+            <a:String CONTENT="atreve" HEIGHT="35" WIDTH="150" HPOS="1704" VPOS="1065" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="33" HPOS="1887" VPOS="1075" />
+            <a:String CONTENT="a" HEIGHT="24" WIDTH="24" HPOS="1887" VPOS="1075" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="33" HPOS="1944" VPOS="1064" />
+            <a:String CONTENT="llamar." HEIGHT="38" WIDTH="161" HPOS="1944" VPOS="1064" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0005" HEIGHT="42" WIDTH="289" HPOS="1746" VPOS="1152" STYLEREFS="PARSTYLE0002">
+          <a:TextLine ID="PAG001LIN0003" WIDTH="288" HEIGHT="41" HPOS="1746" VPOS="1152">
+            <a:String CONTENT="FRANKLIN." HEIGHT="41" WIDTH="288" HPOS="1746" VPOS="1152" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0006" HEIGHT="43" WIDTH="52" HPOS="3503" VPOS="944" STYLEREFS="PARSTYLE0003">
+          <a:TextLine ID="PAG001LIN0004" WIDTH="51" HEIGHT="42" HPOS="3503" VPOS="944">
+            <a:String CONTENT="te" HEIGHT="42" WIDTH="51" HPOS="3503" VPOS="944" WC="1" STYLEREFS="TEXTSTYLE0003" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:Illustration ID="PAG001BLK0007" HEIGHT="843" WIDTH="1957" HPOS="1690" VPOS="430" />
+        <a:TextBlock ID="PAG001BLK0008" HEIGHT="199" WIDTH="913" HPOS="3784" VPOS="543" STYLEREFS="PARSTYLE0004">
+          <a:TextLine ID="PAG001LIN0005" WIDTH="910" HEIGHT="53" HPOS="3785" VPOS="543">
+            <a:String CONTENT="Los" HEIGHT="37" WIDTH="85" HPOS="3785" VPOS="550" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="14" HPOS="3884" VPOS="552" />
+            <a:String CONTENT="tiltimos" HEIGHT="39" WIDTH="171" HPOS="3884" VPOS="548" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="12" HPOS="4067" VPOS="560" />
+            <a:String CONTENT="pronÃ³sticos" HEIGHT="49" WIDTH="273" HPOS="4067" VPOS="547" WC="0.99" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="14" HPOS="4354" VPOS="557" />
+            <a:String CONTENT="predicen" HEIGHT="47" WIDTH="203" HPOS="4354" VPOS="545" WC="0.98" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="13" HPOS="4570" VPOS="553" />
+            <a:String CONTENT="vienÂ¬" HEIGHT="36" WIDTH="125" HPOS="4570" VPOS="543" WC="0.99" STYLEREFS="TEXTSTYLE0001" SUBS_TYPE="HypPart1" SUBS_CONTENT="vientos" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0006" WIDTH="911" HEIGHT="48" HPOS="3784" VPOS="620">
+            <a:String CONTENT="tos" HEIGHT="36" WIDTH="69" HPOS="3784" VPOS="623" WC="0.99" STYLEREFS="TEXTSTYLE0001" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="26" HPOS="3879" VPOS="632" />
+            <a:String CONTENT="poco" HEIGHT="36" WIDTH="108" HPOS="3879" VPOS="632" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="19" HPOS="4006" VPOS="623" />
+            <a:String CONTENT="intensos" HEIGHT="37" WIDTH="197" HPOS="4006" VPOS="623" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="20" HPOS="4223" VPOS="623" />
+            <a:String CONTENT="del" HEIGHT="37" WIDTH="67" HPOS="4223" VPOS="621" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="32" HPOS="4322" VPOS="620" />
+            <a:String CONTENT="Norte" HEIGHT="37" WIDTH="132" HPOS="4322" VPOS="620" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="35" HPOS="4489" VPOS="623" />
+            <a:String CONTENT="S" HEIGHT="41" WIDTH="25" HPOS="4489" VPOS="623" WC="0.9" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="25" HPOS="4539" VPOS="627" />
+            <a:String CONTENT="consoÂ¬" HEIGHT="31" WIDTH="156" HPOS="4539" VPOS="623" WC="0.91" STYLEREFS="TEXTSTYLE0001" SUBS_TYPE="HypPart1" SUBS_CONTENT="consolidaciÃ³n" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0007" WIDTH="955" HEIGHT="49" HPOS="3787" VPOS="692">
+            <a:String CONTENT="lidaciÃ³n" HEIGHT="38" WIDTH="186" HPOS="3787" VPOS="694" WC="0.91" STYLEREFS="TEXTSTYLE0001" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="29" HPOS="4002" VPOS="695" />
+            <a:String CONTENT="del" HEIGHT="36" WIDTH="67" HPOS="4002" VPOS="695" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="29" HPOS="4098" VPOS="694" />
+            <a:String CONTENT="buen" HEIGHT="38" WIDTH="112" HPOS="4098" VPOS="694" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="4237" VPOS="696" />
+            <a:String CONTENT="tiempo" HEIGHT="46" WIDTH="158" HPOS="4237" VPOS="695" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="4421" VPOS="704" />
+            <a:String CONTENT="reinante" HEIGHT="39" WIDTH="193" HPOS="4421" VPOS="692" WC="0.98" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="64" HPOS="4678" VPOS="710" />
+            <a:String CONTENT="-" HEIGHT="8" WIDTH="18" HPOS="4678" VPOS="710" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:Illustration ID="PAG001BLK0009" HEIGHT="359" WIDTH="1049" HPOS="3710" VPOS="892" />
+        <a:TextBlock ID="PAG001BLK0010" HEIGHT="58" WIDTH="839" HPOS="292" VPOS="1334" STYLEREFS="PARSTYLE0003">
+          <a:TextLine ID="PAG001LIN0008" WIDTH="838" HEIGHT="57" HPOS="292" VPOS="1334">
+            <a:String CONTENT="Rotativo" HEIGHT="56" WIDTH="273" HPOS="292" VPOS="1335" WC="1" STYLEREFS="TEXTSTYLE0004" />
+            <a:SP WIDTH="53" HPOS="618" VPOS="1337" />
+            <a:String CONTENT="de" HEIGHT="51" WIDTH="81" HPOS="618" VPOS="1337" WC="1" STYLEREFS="TEXTSTYLE0004" />
+            <a:SP WIDTH="55" HPOS="754" VPOS="1338" />
+            <a:String CONTENT="la" HEIGHT="51" WIDTH="56" HPOS="754" VPOS="1338" WC="1" STYLEREFS="TEXTSTYLE0004" />
+            <a:SP WIDTH="53" HPOS="863" VPOS="1348" />
+            <a:String CONTENT="maÃ±ana" HEIGHT="53" WIDTH="267" HPOS="863" VPOS="1334" WC="1" STYLEREFS="TEXTSTYLE0004" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0011" HEIGHT="64" WIDTH="1124" HPOS="1951" VPOS="1329" STYLEREFS="PARSTYLE0003">
+          <a:TextLine ID="PAG001LIN0009" WIDTH="1123" HEIGHT="63" HPOS="1951" VPOS="1329">
+            <a:String CONTENT="VIGO" HEIGHT="55" WIDTH="182" HPOS="1951" VPOS="1329" WC="1" STYLEREFS="TEXTSTYLE0004" />
+            <a:SP WIDTH="53" HPOS="2186" VPOS="1336" />
+            <a:String CONTENT="29" HEIGHT="50" WIDTH="80" HPOS="2186" VPOS="1336" WC="1" STYLEREFS="TEXTSTYLE0004" />
+            <a:SP WIDTH="54" HPOS="2320" VPOS="1337" />
+            <a:String CONTENT="DE" HEIGHT="52" WIDTH="92" HPOS="2320" VPOS="1336" WC="1" STYLEREFS="TEXTSTYLE0004" />
+            <a:SP WIDTH="55" HPOS="2467" VPOS="1339" />
+            <a:String CONTENT="ENERO" HEIGHT="54" WIDTH="249" HPOS="2467" VPOS="1338" WC="1" STYLEREFS="TEXTSTYLE0004" />
+            <a:SP WIDTH="54" HPOS="2770" VPOS="1339" />
+            <a:String CONTENT="DE" HEIGHT="53" WIDTH="94" HPOS="2770" VPOS="1337" WC="1" STYLEREFS="TEXTSTYLE0004" />
+            <a:SP WIDTH="51" HPOS="2915" VPOS="1336" />
+            <a:String CONTENT="1924" HEIGHT="56" WIDTH="159" HPOS="2915" VPOS="1332" WC="1" STYLEREFS="TEXTSTYLE0004" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0012" HEIGHT="55" WIDTH="138" HPOS="3954" VPOS="1328" STYLEREFS="PARSTYLE0003">
+          <a:TextLine ID="PAG001LIN0010" WIDTH="137" HEIGHT="54" HPOS="3954" VPOS="1328">
+            <a:String CONTENT="AÃ±o" HEIGHT="54" WIDTH="137" HPOS="3954" VPOS="1328" WC="1" STYLEREFS="TEXTSTYLE0004" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0013" HEIGHT="54" WIDTH="260" HPOS="4514" VPOS="1333" STYLEREFS="PARSTYLE0003">
+          <a:TextLine ID="PAG001LIN0011" WIDTH="276" HEIGHT="53" HPOS="4514" VPOS="1333">
+            <a:String CONTENT="NÃºm." HEIGHT="53" WIDTH="168" HPOS="4514" VPOS="1333" WC="1" STYLEREFS="TEXTSTYLE0004" />
+            <a:SP WIDTH="54" HPOS="4736" VPOS="1334" />
+            <a:String CONTENT="2" HEIGHT="50" WIDTH="37" HPOS="4736" VPOS="1334" WC="1" STYLEREFS="TEXTSTYLE0004" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0014" HEIGHT="60" WIDTH="1258" HPOS="533" VPOS="1474" STYLEREFS="PARSTYLE0003">
+          <a:TextLine ID="PAG001LIN0012" WIDTH="1257" HEIGHT="59" HPOS="533" VPOS="1474">
+            <a:String CONTENT="HABLA" HEIGHT="52" WIDTH="234" HPOS="533" VPOS="1481" WC="1" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="40" HPOS="807" VPOS="1479" />
+            <a:String CONTENT="Un" HEIGHT="52" WIDTH="97" HPOS="807" VPOS="1479" WC="0.74" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="44" HPOS="948" VPOS="1479" />
+            <a:String CONTENT="PRESTIGIO" HEIGHT="55" WIDTH="384" HPOS="948" VPOS="1474" WC="1" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="40" HPOS="1372" VPOS="1477" />
+            <a:String CONTENT="DE" HEIGHT="50" WIDTH="95" HPOS="1372" VPOS="1476" WC="1" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="39" HPOS="1506" VPOS="1476" />
+            <a:String CONTENT="GALICIA" HEIGHT="52" WIDTH="284" HPOS="1506" VPOS="1475" WC="1" STYLEREFS="TEXTSTYLE0005" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:ComposedBlock ID="PAG001BLK0015" HEIGHT="609" WIDTH="1767" HPOS="282" VPOS="1616" />
+        <a:TextBlock ID="PAG001BLK0016" HEIGHT="133" WIDTH="1735" HPOS="298" VPOS="1640" STYLEREFS="PARSTYLE0005">
+          <a:TextLine ID="PAG001LIN0013" WIDTH="1734" HEIGHT="132" HPOS="298" VPOS="1640">
+            <a:String CONTENT="&quot;EL" HEIGHT="120" WIDTH="252" HPOS="298" VPOS="1652" WC="1" STYLEREFS="TEXTSTYLE0006" />
+            <a:SP WIDTH="40" HPOS="590" VPOS="1646" />
+            <a:String CONTENT="PUEBLO" HEIGHT="128" WIDTH="594" HPOS="590" VPOS="1642" WC="1" STYLEREFS="TEXTSTYLE0006" />
+            <a:SP WIDTH="44" HPOS="1228" VPOS="1642" />
+            <a:String CONTENT="GALLEGO&quot;" HEIGHT="126" WIDTH="804" HPOS="1228" VPOS="1640" WC="1" STYLEREFS="TEXTSTYLE0006" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0017" HEIGHT="155" WIDTH="1744" HPOS="283" VPOS="1843" STYLEREFS="PARSTYLE0006">
+          <a:TextLine ID="PAG001LIN0014" WIDTH="1626" HEIGHT="53" HPOS="400" VPOS="1843">
+            <a:String CONTENT="'Nuestro" HEIGHT="39" WIDTH="176" HPOS="400" VPOS="1849" WC="0.8" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="604" VPOS="1851" />
+            <a:String CONTENT="ilustre" HEIGHT="38" WIDTH="148" HPOS="604" VPOS="1850" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="779" VPOS="1859" />
+            <a:String CONTENT="amiflo," HEIGHT="48" WIDTH="154" HPOS="779" VPOS="1848" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="29" HPOS="962" VPOS="1857" />
+            <a:String CONTENT="el" HEIGHT="40" WIDTH="39" HPOS="962" VPOS="1846" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="25" HPOS="1026" VPOS="1851" />
+            <a:String CONTENT="'Â¿lÃ©-miriistro" HEIGHT="42" WIDTH="271" HPOS="1026" VPOS="1843" WC="0.95" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="1324" VPOS="1855" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="27" HPOS="1324" VPOS="1855" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="25" HPOS="1376" VPOS="1855" />
+            <a:String CONTENT="acadÃ©mico" HEIGHT="41" WIDTH="237" HPOS="1376" VPOS="1843" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="1641" VPOS="1846" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="49" HPOS="1641" VPOS="1846" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="30" HPOS="1720" VPOS="1847" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="40" HPOS="1720" VPOS="1847" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="1788" VPOS="1846" />
+            <a:String CONTENT="Lengua" HEIGHT="49" WIDTH="171" HPOS="1788" VPOS="1846" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="1987" VPOS="1856" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="39" HPOS="1987" VPOS="1846" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0015" WIDTH="1742" HEIGHT="54" HPOS="283" VPOS="1898">
+            <a:String CONTENT=".marquÃ©s" HEIGHT="48" WIDTH="207" HPOS="283" VPOS="1904" WC="0.95" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="513" VPOS="1903" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="49" HPOS="513" VPOS="1903" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="24" HPOS="586" VPOS="1903" />
+            <a:String CONTENT="Figuetoa," HEIGHT="47" WIDTH="218" HPOS="586" VPOS="1903" WC="0.76" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="24" HPOS="828" VPOS="1905" />
+            <a:String CONTENT="trae" HEIGHT="35" WIDTH="90" HPOS="828" VPOS="1905" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="25" HPOS="943" VPOS="1912" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="24" HPOS="943" VPOS="1912" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="990" VPOS="1911" />
+            <a:String CONTENT="estas" HEIGHT="37" WIDTH="109" HPOS="990" VPOS="1903" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="25" HPOS="1124" VPOS="1910" />
+            <a:String CONTENT="pÃ¡ginas" HEIGHT="50" WIDTH="172" HPOS="1124" VPOS="1899" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="24" HPOS="1320" VPOS="1909" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="40" HPOS="1320" VPOS="1899" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="1383" VPOS="1909" />
+            <a:String CONTENT="magnÃ­fico" HEIGHT="50" WIDTH="228" HPOS="1383" VPOS="1898" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="1634" VPOS="1904" />
+            <a:String CONTENT="tÃ©galo" HEIGHT="47" WIDTH="141" HPOS="1634" VPOS="1900" WC="0.87" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="1802" VPOS="1911" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="81" HPOS="1802" VPOS="1910" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="1909" VPOS="1909" />
+            <a:String CONTENT="ofre&quot;" HEIGHT="49" WIDTH="116" HPOS="1909" VPOS="1898" WC="0.68" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0016" WIDTH="637" HEIGHT="41" HPOS="300" VPOS="1956">
+            <a:String CONTENT="cernes" HEIGHT="29" WIDTH="133" HPOS="300" VPOS="1968" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="32" HPOS="465" VPOS="1967" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="27" HPOS="465" VPOS="1967" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="29" HPOS="521" VPOS="1968" />
+            <a:String CONTENT="nuestros" HEIGHT="34" WIDTH="192" HPOS="521" VPOS="1961" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="32" HPOS="745" VPOS="1956" />
+            <a:String CONTENT="lectores." HEIGHT="38" WIDTH="192" HPOS="745" VPOS="1956" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0018" HEIGHT="214" WIDTH="1728" HPOS="300" VPOS="2006" STYLEREFS="PARSTYLE0007">
+          <a:TextLine ID="PAG001LIN0017" WIDTH="1625" HEIGHT="50" HPOS="401" VPOS="2006">
+            <a:String CONTENT="En" HEIGHT="38" WIDTH="64" HPOS="401" VPOS="2011" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="20" HPOS="485" VPOS="2021" />
+            <a:String CONTENT="estaÂ¿" HEIGHT="36" WIDTH="108" HPOS="485" VPOS="2013" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="22" HPOS="615" VPOS="2010" />
+            <a:String CONTENT="lÃ­neas" HEIGHT="38" WIDTH="129" HPOS="615" VPOS="2010" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="21" HPOS="765" VPOS="2019" />
+            <a:String CONTENT="alienta" HEIGHT="38" WIDTH="158" HPOS="765" VPOS="2009" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="19" HPOS="942" VPOS="2019" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="39" HPOS="942" VPOS="2008" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="20" HPOS="1001" VPOS="2019" />
+            <a:String CONTENT="gran" HEIGHT="39" WIDTH="102" HPOS="1001" VPOS="2017" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="21" HPOS="1124" VPOS="2017" />
+            <a:String CONTENT="amor" HEIGHT="29" WIDTH="118" HPOS="1124" VPOS="2017" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="19" HPOS="1261" VPOS="2017" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="24" HPOS="1261" VPOS="2017" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="20" HPOS="1305" VPOS="2006" />
+            <a:String CONTENT="la" HEIGHT="40" WIDTH="39" HPOS="1305" VPOS="2006" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="21" HPOS="1365" VPOS="2010" />
+            <a:String CONTENT="tierra" HEIGHT="39" WIDTH="131" HPOS="1365" VPOS="2007" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="19" HPOS="1515" VPOS="2017" />
+            <a:String CONTENT="y" HEIGHT="39" WIDTH="26" HPOS="1515" VPOS="2017" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="22" HPOS="1563" VPOS="2018" />
+            <a:String CONTENT="campea" HEIGHT="39" WIDTH="171" HPOS="1563" VPOS="2017" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="20" HPOS="1754" VPOS="2019" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="40" HPOS="1754" VPOS="2008" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="21" HPOS="1815" VPOS="2018" />
+            <a:String CONTENT="profundo" HEIGHT="49" WIDTH="211" HPOS="1815" VPOS="2007" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0018" WIDTH="1727" HEIGHT="50" HPOS="300" VPOS="2061">
+            <a:String CONTENT="dÃ³nocimiento" HEIGHT="40" WIDTH="300" HPOS="300" VPOS="2065" WC="0.92" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="626" VPOS="2064" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="50" HPOS="626" VPOS="2064" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="702" VPOS="2074" />
+            <a:String CONTENT="su" HEIGHT="28" WIDTH="50" HPOS="702" VPOS="2074" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="778" VPOS="2072" />
+            <a:String CONTENT="vida" HEIGHT="39" WIDTH="100" HPOS="778" VPOS="2062" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="904" VPOS="2072" />
+            <a:String CONTENT="que" HEIGHT="39" WIDTH="78" HPOS="904" VPOS="2072" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="29" HPOS="1011" VPOS="2061" />
+            <a:String CONTENT="hizo" HEIGHT="39" WIDTH="93" HPOS="1011" VPOS="2061" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="25" HPOS="1129" VPOS="2062" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="1129" VPOS="2062" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="1207" VPOS="2061" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="40" HPOS="1207" VPOS="2061" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="29" HPOS="1276" VPOS="2072" />
+            <a:String CONTENT="conferencia" HEIGHT="48" WIDTH="262" HPOS="1276" VPOS="2061" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="1565" VPOS="2067" />
+            <a:String CONTENT="recientemente" HEIGHT="38" WIDTH="327" HPOS="1565" VPOS="2062" WC="0.96" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="1920" VPOS="2062" />
+            <a:String CONTENT="dada" HEIGHT="38" WIDTH="107" HPOS="1920" VPOS="2061" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0019" WIDTH="1722" HEIGHT="52" HPOS="302" VPOS="2114">
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="51" HPOS="302" VPOS="2130" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="21" HPOS="374" VPOS="2119" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="41" HPOS="374" VPOS="2119" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="21" HPOS="436" VPOS="2117" />
+            <a:String CONTENT="CoruÃ±a" HEIGHT="39" WIDTH="163" HPOS="436" VPOS="2117" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="622" VPOS="2128" />
+            <a:String CONTENT="por" HEIGHT="39" WIDTH="77" HPOS="622" VPOS="2127" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="722" VPOS="2128" />
+            <a:String CONTENT="este" HEIGHT="41" WIDTH="86" HPOS="722" VPOS="2119" WC="0.89" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="24" HPOS="832" VPOS="2126" />
+            <a:String CONTENT="prÃ³cet" HEIGHT="48" WIDTH="148" HPOS="832" VPOS="2115" WC="0.91" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="21" HPOS="1001" VPOS="2126" />
+            <a:String CONTENT="gallego" HEIGHT="52" WIDTH="159" HPOS="1001" VPOS="2114" WC="0.94" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="24" HPOS="1184" VPOS="2126" />
+            <a:String CONTENT="itgo" HEIGHT="42" WIDTH="83" HPOS="1184" VPOS="2118" WC="0.75" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="1290" VPOS="2114" />
+            <a:String CONTENT="da" HEIGHT="46" WIDTH="52" HPOS="1290" VPOS="2114" WC="0.86" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="19" HPOS="1361" VPOS="2115" />
+            <a:String CONTENT="Ã­oÂ«" HEIGHT="40" WIDTH="64" HPOS="1361" VPOS="2115" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1449" VPOS="2124" />
+            <a:String CONTENT="actos" HEIGHT="36" WIDTH="114" HPOS="1449" VPOS="2118" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="24" HPOS="1587" VPOS="2115" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="1587" VPOS="2115" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="1662" VPOS="2125" />
+            <a:String CONTENT="mayor" HEIGHT="37" WIDTH="146" HPOS="1662" VPOS="2125" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="1835" VPOS="2118" />
+            <a:String CONTENT="trascen^" HEIGHT="36" WIDTH="189" HPOS="1835" VPOS="2118" WC="0.95" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0020" WIDTH="574" HEIGHT="49" HPOS="302" VPOS="2170">
+            <a:String CONTENT="dencia" HEIGHT="40" WIDTH="146" HPOS="302" VPOS="2172" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="22" HPOS="470" VPOS="2182" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="52" HPOS="470" VPOS="2181" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="545" VPOS="2182" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="38" HPOS="545" VPOS="2171" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="22" HPOS="605" VPOS="2181" />
+            <a:String CONTENT="pasado" HEIGHT="49" WIDTH="153" HPOS="605" VPOS="2170" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="22" HPOS="780" VPOS="2179" />
+            <a:String CONTENT="aÃ±Oi" HEIGHT="45" WIDTH="96" HPOS="780" VPOS="2170" WC="0.41" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:Illustration ID="PAG001BLK0019" HEIGHT="2153" WIDTH="1435" HPOS="470" VPOS="2344" />
+        <a:TextBlock ID="PAG001BLK0020" HEIGHT="52" WIDTH="749" HPOS="800" VPOS="4508" STYLEREFS="PARSTYLE0003">
+          <a:TextLine ID="PAG001LIN0021" WIDTH="748" HEIGHT="51" HPOS="800" VPOS="4508">
+            <a:String CONTENT="EL" HEIGHT="40" WIDTH="65" HPOS="800" VPOS="4517" WC="0.96" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="31" HPOS="896" VPOS="4517" />
+            <a:String CONTENT="Wl" HEIGHT="37" WIDTH="38" HPOS="896" VPOS="4517" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="7" HPOS="941" VPOS="4516" />
+            <a:String CONTENT="ARQUES" HEIGHT="47" WIDTH="208" HPOS="941" VPOS="4512" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="29" HPOS="1178" VPOS="4513" />
+            <a:String CONTENT="DE" HEIGHT="36" WIDTH="68" HPOS="1178" VPOS="4512" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="13" HPOS="1259" VPOS="4522" />
+            <a:String CONTENT="Â¡" HEIGHT="25" WIDTH="6" HPOS="1259" VPOS="4522" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="10" HPOS="1275" VPOS="4508" />
+            <a:String CONTENT="^IGUEROA" HEIGHT="46" WIDTH="273" HPOS="1275" VPOS="4508" WC="0.95" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:ComposedBlock ID="PAG001BLK0021" HEIGHT="2813" WIDTH="873" HPOS="304" VPOS="4652" />
+        <a:TextBlock ID="PAG001BLK0022" HEIGHT="540" WIDTH="808" HPOS="324" VPOS="4663" STYLEREFS="PARSTYLE0008">
+          <a:TextLine ID="PAG001LIN0022" WIDTH="752" HEIGHT="58" HPOS="374" VPOS="4663">
+            <a:String CONTENT="tTÃ­tulo" HEIGHT="48" WIDTH="150" HPOS="374" VPOS="4673" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="565" VPOS="4687" />
+            <a:String CONTENT="atrayente" HEIGHT="47" WIDTH="227" HPOS="565" VPOS="4673" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="833" VPOS="4679" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="24" HPOS="833" VPOS="4679" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="898" VPOS="4677" />
+            <a:String CONTENT="sugestivo" HEIGHT="50" WIDTH="228" HPOS="898" VPOS="4663" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0023" WIDTH="790" HEIGHT="61" HPOS="327" VPOS="4716">
+            <a:String CONTENT="si" HEIGHT="37" WIDTH="37" HPOS="327" VPOS="4735" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="392" VPOS="4733" />
+            <a:String CONTENT="los" HEIGHT="37" WIDTH="66" HPOS="392" VPOS="4733" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="489" VPOS="4733" />
+            <a:String CONTENT="hay," HEIGHT="44" WIDTH="96" HPOS="489" VPOS="4733" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="615" VPOS="4739" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="37" HPOS="615" VPOS="4728" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="683" VPOS="4727" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="67" HPOS="683" VPOS="4726" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="780" VPOS="4736" />
+            <a:String CONTENT="nuevo" HEIGHT="29" WIDTH="142" HPOS="780" VPOS="4732" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="952" VPOS="4731" />
+            <a:String CONTENT="periÃ³di" HEIGHT="52" WIDTH="165" HPOS="952" VPOS="4716" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0024" WIDTH="799" HEIGHT="59" HPOS="326" VPOS="4772">
+            <a:String CONTENT="co" HEIGHT="27" WIDTH="49" HPOS="326" VPOS="4799" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="411" VPOS="4797" />
+            <a:String CONTENT="viguÃ©s;" HEIGHT="46" WIDTH="177" HPOS="411" VPOS="4785" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="628" VPOS="4782" />
+            <a:String CONTENT="tÃ­tulo" HEIGHT="37" WIDTH="131" HPOS="628" VPOS="4781" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="798" VPOS="4788" />
+            <a:String CONTENT="que" HEIGHT="39" WIDTH="84" HPOS="798" VPOS="4786" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="921" VPOS="4786" />
+            <a:String CONTENT="a" HEIGHT="27" WIDTH="25" HPOS="921" VPOS="4786" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="983" VPOS="4784" />
+            <a:String CONTENT="muclT" HEIGHT="39" WIDTH="142" HPOS="983" VPOS="4772" WC="0.75" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0025" WIDTH="792" HEIGHT="56" HPOS="326" VPOS="4831">
+            <a:String CONTENT="obliga" HEIGHT="46" WIDTH="144" HPOS="326" VPOS="4841" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="508" VPOS="4848" />
+            <a:String CONTENT="en" HEIGHT="27" WIDTH="52" HPOS="508" VPOS="4848" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="601" VPOS="4848" />
+            <a:String CONTENT="relaciÃ³n" HEIGHT="40" WIDTH="196" HPOS="601" VPOS="4834" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="836" VPOS="4842" />
+            <a:String CONTENT="con" HEIGHT="30" WIDTH="85" HPOS="836" VPOS="4839" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="961" VPOS="4839" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="39" HPOS="961" VPOS="4831" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="1039" VPOS="4837" />
+            <a:String CONTENT="puo" HEIGHT="39" WIDTH="79" HPOS="1039" VPOS="4836" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0026" WIDTH="787" HEIGHT="65" HPOS="325" VPOS="4883">
+            <a:String CONTENT="blo," HEIGHT="52" WIDTH="82" HPOS="325" VPOS="4896" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="448" VPOS="4894" />
+            <a:String CONTENT="buscando" HEIGHT="41" WIDTH="228" HPOS="448" VPOS="4890" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="718" VPOS="4896" />
+            <a:String CONTENT="para'" HEIGHT="52" WIDTH="119" HPOS="718" VPOS="4883" WC="0.93" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="867" VPOS="4895" />
+            <a:String CONTENT="mejor," HEIGHT="48" WIDTH="145" HPOS="867" VPOS="4883" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="1051" VPOS="4890" />
+            <a:String CONTENT="se]" HEIGHT="29" WIDTH="61" HPOS="1051" VPOS="4890" WC="0.68" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0027" WIDTH="793" HEIGHT="65" HPOS="324" VPOS="4931">
+            <a:String CONTENT="virÃ­e," HEIGHT="65" WIDTH="121" HPOS="324" VPOS="4931" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="478" VPOS="4956" />
+            <a:String CONTENT="su" HEIGHT="27" WIDTH="52" HPOS="478" VPOS="4956" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="565" VPOS="4945" />
+            <a:String CONTENT="inspiraciÃ³n;" HEIGHT="50" WIDTH="294" HPOS="565" VPOS="4940" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="893" VPOS="4948" />
+            <a:String CONTENT="modo" HEIGHT="38" WIDTH="129" HPOS="893" VPOS="4936" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1054" VPOS="4945" />
+            <a:String CONTENT="ciÃ©" HEIGHT="38" WIDTH="63" HPOS="1054" VPOS="4935" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0028" WIDTH="795" HEIGHT="50" HPOS="325" VPOS="4990">
+            <a:String CONTENT="to" HEIGHT="37" WIDTH="44" HPOS="325" VPOS="5003" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="403" VPOS="5001" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="403" VPOS="5001" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="488" VPOS="5000" />
+            <a:String CONTENT="traer" HEIGHT="36" WIDTH="120" HPOS="488" VPOS="5000" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="643" VPOS="5007" />
+            <a:String CONTENT="a" HEIGHT="27" WIDTH="25" HPOS="643" VPOS="5007" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="700" VPOS="5007" />
+            <a:String CONTENT="unidad" HEIGHT="39" WIDTH="161" HPOS="700" VPOS="4994" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="900" VPOS="5001" />
+            <a:String CONTENT="aspiracio" HEIGHT="48" WIDTH="220" HPOS="900" VPOS="4990" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0029" WIDTH="813" HEIGHT="56" HPOS="324" VPOS="5045">
+            <a:String CONTENT="nes" HEIGHT="30" WIDTH="79" HPOS="324" VPOS="5065" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="443" VPOS="5065" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="81" HPOS="443" VPOS="5063" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="563" VPOS="5061" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="54" HPOS="563" VPOS="5061" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="653" VPOS="5061" />
+            <a:String CONTENT="el" HEIGHT="36" WIDTH="39" HPOS="653" VPOS="5052" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="730" VPOS="5061" />
+            <a:String CONTENT="alma" HEIGHT="38" WIDTH="116" HPOS="730" VPOS="5049" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="885" VPOS="5056" />
+            <a:String CONTENT="gallega" HEIGHT="48" WIDTH="176" HPOS="885" VPOS="5045" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="1099" VPOS="5053" />
+            <a:String CONTENT="s(" HEIGHT="27" WIDTH="32" HPOS="1099" VPOS="5053" WC="0.78" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0030" WIDTH="798" HEIGHT="51" HPOS="325" VPOS="5097">
+            <a:String CONTENT="ofrecen" HEIGHT="37" WIDTH="177" HPOS="325" VPOS="5111" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="548" VPOS="5107" />
+            <a:String CONTENT="indeterminadas" HEIGHT="44" WIDTH="376" HPOS="548" VPOS="5101" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="964" VPOS="5114" />
+            <a:String CONTENT="e" HEIGHT="28" WIDTH="22" HPOS="964" VPOS="5114" WC="0.9" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="1026" VPOS="5099" />
+            <a:String CONTENT="inde" HEIGHT="39" WIDTH="97" HPOS="1026" VPOS="5097" WC="0.82" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0031" WIDTH="133" HEIGHT="38" HPOS="326" VPOS="5164">
+            <a:String CONTENT="cisas." HEIGHT="38" WIDTH="133" HPOS="326" VPOS="5164" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0023" HEIGHT="1170" WIDTH="833" HPOS="324" VPOS="5206" STYLEREFS="PARSTYLE0009">
+          <a:TextLine ID="PAG001LIN0032" WIDTH="770" HEIGHT="54" HPOS="375" VPOS="5206">
+            <a:String CONTENT="[Tal" HEIGHT="44" WIDTH="79" HPOS="375" VPOS="5216" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="488" VPOS="5225" />
+            <a:String CONTENT="es" HEIGHT="29" WIDTH="47" HPOS="488" VPOS="5223" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="566" VPOS="5213" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="43" HPOS="566" VPOS="5213" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="639" VPOS="5223" />
+            <a:String CONTENT="condiciÃ³n," HEIGHT="43" WIDTH="247" HPOS="639" VPOS="5209" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="919" VPOS="5219" />
+            <a:String CONTENT="por" HEIGHT="40" WIDTH="80" HPOS="919" VPOS="5216" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1031" VPOS="5207" />
+            <a:String CONTENT="inteÂ¬" HEIGHT="37" WIDTH="114" HPOS="1031" VPOS="5206" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="interrogadora" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0033" WIDTH="821" HEIGHT="56" HPOS="324" VPOS="5261">
+            <a:String CONTENT="rrogadora" HEIGHT="48" WIDTH="246" HPOS="324" VPOS="5269" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="26" HPOS="596" VPOS="5277" />
+            <a:String CONTENT="no" HEIGHT="28" WIDTH="56" HPOS="596" VPOS="5276" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="682" VPOS="5266" />
+            <a:String CONTENT="fÃ¡cil" HEIGHT="38" WIDTH="105" HPOS="682" VPOS="5264" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="815" VPOS="5273" />
+            <a:String CONTENT="para" HEIGHT="38" WIDTH="110" HPOS="815" VPOS="5272" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="953" VPOS="5261" />
+            <a:String CONTENT="interroÂ¬" HEIGHT="36" WIDTH="192" HPOS="953" VPOS="5261" WC="0.77" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="interrogada" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0034" WIDTH="821" HEIGHT="57" HPOS="325" VPOS="5314">
+            <a:String CONTENT="gada" HEIGHT="46" WIDTH="113" HPOS="325" VPOS="5325" WC="0.77" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="26" HPOS="464" VPOS="5323" />
+            <a:String CONTENT="del" HEIGHT="37" WIDTH="67" HPOS="464" VPOS="5323" WC="0.88" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="559" VPOS="5332" />
+            <a:String CONTENT="alma" HEIGHT="38" WIDTH="117" HPOS="559" VPOS="5320" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="701" VPOS="5329" />
+            <a:String CONTENT="regional." HEIGHT="49" WIDTH="219" HPOS="701" VPOS="5314" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="947" VPOS="5314" />
+            <a:String CONTENT="Hay" HEIGHT="46" WIDTH="90" HPOS="947" VPOS="5314" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1063" VPOS="5323" />
+            <a:String CONTENT="que" HEIGHT="40" WIDTH="83" HPOS="1063" VPOS="5320" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0035" WIDTH="821" HEIGHT="56" HPOS="326" VPOS="5368">
+            <a:String CONTENT="sorprenderla" HEIGHT="50" WIDTH="313" HPOS="326" VPOS="5374" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="664" VPOS="5383" />
+            <a:String CONTENT="en" HEIGHT="27" WIDTH="50" HPOS="664" VPOS="5382" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="743" VPOS="5381" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="37" HPOS="743" VPOS="5371" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="806" VPOS="5381" />
+            <a:String CONTENT="silencio" HEIGHT="40" WIDTH="187" HPOS="806" VPOS="5368" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1018" VPOS="5368" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="50" HPOS="1018" VPOS="5368" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1094" VPOS="5376" />
+            <a:String CONTENT="su" HEIGHT="32" WIDTH="53" HPOS="1094" VPOS="5376" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0036" WIDTH="822" HEIGHT="57" HPOS="325" VPOS="5423">
+            <a:String CONTENT="retiro," HEIGHT="49" WIDTH="153" HPOS="325" VPOS="5431" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="12" HPOS="490" VPOS="5458" />
+            <a:String CONTENT=".hay" HEIGHT="44" WIDTH="99" HPOS="490" VPOS="5430" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="616" VPOS="5437" />
+            <a:String CONTENT="que" HEIGHT="39" WIDTH="81" HPOS="616" VPOS="5435" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="723" VPOS="5425" />
+            <a:String CONTENT="despertarla" HEIGHT="47" WIDTH="281" HPOS="723" VPOS="5423" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="1027" VPOS="5431" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="23" HPOS="1027" VPOS="5431" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1076" VPOS="5430" />
+            <a:String CONTENT="mo" HEIGHT="29" WIDTH="71" HPOS="1076" VPOS="5429" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0037" WIDTH="822" HEIGHT="53" HPOS="326" VPOS="5475">
+            <a:String CONTENT="verla;" HEIGHT="44" WIDTH="141" HPOS="326" VPOS="5484" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="496" VPOS="5482" />
+            <a:String CONTENT="los" HEIGHT="38" WIDTH="67" HPOS="496" VPOS="5482" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="592" VPOS="5483" />
+            <a:String CONTENT="hijos" HEIGHT="47" WIDTH="118" HPOS="592" VPOS="5481" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="740" VPOS="5479" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="740" VPOS="5479" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="818" VPOS="5477" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="41" HPOS="818" VPOS="5477" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="885" VPOS="5485" />
+            <a:String CONTENT="noble" HEIGHT="38" WIDTH="131" HPOS="885" VPOS="5475" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1045" VPOS="5484" />
+            <a:String CONTENT="raza" HEIGHT="28" WIDTH="103" HPOS="1045" VPOS="5482" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0038" WIDTH="822" HEIGHT="54" HPOS="326" VPOS="5527">
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="326" VPOS="5540" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="411" VPOS="5548" />
+            <a:String CONTENT="ella" HEIGHT="38" WIDTH="83" HPOS="411" VPOS="5536" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="529" VPOS="5536" />
+            <a:String CONTENT="dignos," HEIGHT="45" WIDTH="172" HPOS="529" VPOS="5536" WC="0.82" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="735" VPOS="5543" />
+            <a:String CONTENT="viven" HEIGHT="37" WIDTH="125" HPOS="735" VPOS="5532" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="896" VPOS="5540" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="55" HPOS="896" VPOS="5538" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="984" VPOS="5528" />
+            <a:String CONTENT="la" HEIGHT="41" WIDTH="40" HPOS="984" VPOS="5528" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="1057" VPOS="5528" />
+            <a:String CONTENT="disÂ¬" HEIGHT="38" WIDTH="91" HPOS="1057" VPOS="5527" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="dispersiÃ³n;" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0039" WIDTH="820" HEIGHT="59" HPOS="328" VPOS="5580">
+            <a:String CONTENT="persiÃ³n;" HEIGHT="50" WIDTH="200" HPOS="328" VPOS="5589" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="34" HPOS="562" VPOS="5598" />
+            <a:String CONTENT="admirable" HEIGHT="40" WIDTH="241" HPOS="562" VPOS="5585" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="839" VPOS="5585" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="40" HPOS="839" VPOS="5585" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="915" VPOS="5592" />
+            <a:String CONTENT="serenidad" HEIGHT="40" WIDTH="233" HPOS="915" VPOS="5580" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0040" WIDTH="824" HEIGHT="57" HPOS="326" VPOS="5634">
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="326" VPOS="5646" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="404" VPOS="5644" />
+            <a:String CONTENT="Ã¡nimo," HEIGHT="48" WIDTH="163" HPOS="404" VPOS="5643" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="594" VPOS="5651" />
+            <a:String CONTENT="con" HEIGHT="29" WIDTH="80" HPOS="594" VPOS="5649" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="705" VPOS="5648" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="82" HPOS="705" VPOS="5648" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="816" VPOS="5647" />
+            <a:String CONTENT="saben" HEIGHT="38" WIDTH="140" HPOS="816" VPOS="5637" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="983" VPOS="5645" />
+            <a:String CONTENT="conlleÂ¬" HEIGHT="39" WIDTH="167" HPOS="983" VPOS="5634" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="conllevar" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0041" WIDTH="824" HEIGHT="52" HPOS="327" VPOS="5690">
+            <a:String CONTENT="var" HEIGHT="27" WIDTH="77" HPOS="327" VPOS="5708" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="28" HPOS="432" VPOS="5696" />
+            <a:String CONTENT="la" HEIGHT="46" WIDTH="42" HPOS="432" VPOS="5696" WC="0.67" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="502" VPOS="5696" />
+            <a:String CONTENT="desgracia;" HEIGHT="47" WIDTH="254" HPOS="502" VPOS="5693" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="785" VPOS="5701" />
+            <a:String CONTENT="prueba" HEIGHT="48" WIDTH="167" HPOS="785" VPOS="5690" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="984" VPOS="5699" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="82" HPOS="984" VPOS="5698" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1096" VPOS="5697" />
+            <a:String CONTENT="en" HEIGHT="27" WIDTH="55" HPOS="1096" VPOS="5697" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0042" WIDTH="824" HEIGHT="54" HPOS="326" VPOS="5741">
+            <a:String CONTENT="el" HEIGHT="36" WIDTH="40" HPOS="326" VPOS="5752" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="391" VPOS="5760" />
+            <a:String CONTENT="recogimiento" HEIGHT="49" WIDTH="321" HPOS="391" VPOS="5746" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="737" VPOS="5745" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="737" VPOS="5745" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="815" VPOS="5755" />
+            <a:String CONTENT="su" HEIGHT="27" WIDTH="51" HPOS="815" VPOS="5754" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="897" VPOS="5745" />
+            <a:String CONTENT="interior" HEIGHT="38" WIDTH="185" HPOS="897" VPOS="5742" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1108" VPOS="5751" />
+            <a:String CONTENT="vi" HEIGHT="38" WIDTH="42" HPOS="1108" VPOS="5741" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0043" WIDTH="823" HEIGHT="48" HPOS="328" VPOS="5797">
+            <a:String CONTENT="da" HEIGHT="38" WIDTH="55" HPOS="328" VPOS="5805" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="422" VPOS="5803" />
+            <a:String CONTENT="Ies" HEIGHT="38" WIDTH="64" HPOS="422" VPOS="5803" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="527" VPOS="5802" />
+            <a:String CONTENT="fortalece" HEIGHT="40" WIDTH="216" HPOS="527" VPOS="5799" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="782" VPOS="5808" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="25" HPOS="782" VPOS="5808" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="846" VPOS="5807" />
+            <a:String CONTENT="mejora." HEIGHT="46" WIDTH="189" HPOS="846" VPOS="5797" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="1073" VPOS="5797" />
+            <a:String CONTENT="Asi" HEIGHT="36" WIDTH="78" HPOS="1073" VPOS="5797" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0044" WIDTH="825" HEIGHT="49" HPOS="328" VPOS="5849">
+            <a:String CONTENT="conservan" HEIGHT="32" WIDTH="248" HPOS="328" VPOS="5865" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="606" VPOS="5856" />
+            <a:String CONTENT="la" HEIGHT="36" WIDTH="41" HPOS="606" VPOS="5856" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="677" VPOS="5863" />
+            <a:String CONTENT="originalidad" HEIGHT="49" WIDTH="295" HPOS="677" VPOS="5849" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1003" VPOS="5849" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="66" HPOS="1003" VPOS="5849" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1099" VPOS="5859" />
+            <a:String CONTENT="ca" HEIGHT="30" WIDTH="54" HPOS="1099" VPOS="5857" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0045" WIDTH="823" HEIGHT="53" HPOS="329" VPOS="5901">
+            <a:String CONTENT="rÃ¡cter," HEIGHT="43" WIDTH="147" HPOS="329" VPOS="5911" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="512" VPOS="5908" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="39" HPOS="512" VPOS="5908" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="589" VPOS="5917" />
+            <a:String CONTENT="expontaneidad" HEIGHT="50" WIDTH="327" HPOS="589" VPOS="5902" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="957" VPOS="5902" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="63" HPOS="957" VPOS="5901" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="1058" VPOS="5911" />
+            <a:String CONTENT="senÂ¬" HEIGHT="30" WIDTH="94" HPOS="1058" VPOS="5910" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="sentimiento;" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0046" WIDTH="823" HEIGHT="51" HPOS="331" VPOS="5955">
+            <a:String CONTENT="timiento;" HEIGHT="43" WIDTH="225" HPOS="331" VPOS="5963" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="44" HPOS="600" VPOS="5961" />
+            <a:String CONTENT="facultad" HEIGHT="40" WIDTH="200" HPOS="600" VPOS="5958" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="842" VPOS="5957" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="69" HPOS="842" VPOS="5956" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="955" VPOS="5965" />
+            <a:String CONTENT="ensueÃ±o" HEIGHT="38" WIDTH="199" HPOS="955" VPOS="5955" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0047" WIDTH="823" HEIGHT="64" HPOS="329" VPOS="6010">
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="25" HPOS="329" VPOS="6037" WC="0.91" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="386" VPOS="6019" />
+            <a:String CONTENT="don" HEIGHT="38" WIDTH="86" HPOS="386" VPOS="6019" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="505" VPOS="6016" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="52" HPOS="505" VPOS="6016" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="591" VPOS="6023" />
+            <a:String CONTENT="observar." HEIGHT="37" WIDTH="225" HPOS="591" VPOS="6014" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="850" VPOS="6011" />
+            <a:String CONTENT="Impresiones" HEIGHT="46" WIDTH="302" HPOS="850" VPOS="6010" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0048" WIDTH="822" HEIGHT="56" HPOS="331" VPOS="6064">
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="83" HPOS="331" VPOS="6082" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="444" VPOS="6082" />
+            <a:String CONTENT="no" HEIGHT="29" WIDTH="56" HPOS="444" VPOS="6080" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="531" VPOS="6069" />
+            <a:String CONTENT="del" HEIGHT="39" WIDTH="66" HPOS="531" VPOS="6068" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="629" VPOS="6068" />
+            <a:String CONTENT="todo" HEIGHT="38" WIDTH="104" HPOS="629" VPOS="6067" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="763" VPOS="6076" />
+            <a:String CONTENT="ocultan" HEIGHT="39" WIDTH="183" HPOS="763" VPOS="6064" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="978" VPOS="6073" />
+            <a:String CONTENT="aunque" HEIGHT="36" WIDTH="175" HPOS="978" VPOS="6073" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0049" WIDTH="823" HEIGHT="54" HPOS="331" VPOS="6116">
+            <a:String CONTENT="sus" HEIGHT="28" WIDTH="77" HPOS="331" VPOS="6135" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="434" VPOS="6135" />
+            <a:String CONTENT="expresiones" HEIGHT="46" WIDTH="286" HPOS="434" VPOS="6124" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="746" VPOS="6119" />
+            <a:String CONTENT="las" HEIGHT="36" WIDTH="64" HPOS="746" VPOS="6119" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="835" VPOS="6128" />
+            <a:String CONTENT="recatan." HEIGHT="38" WIDTH="200" HPOS="835" VPOS="6116" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1059" VPOS="6117" />
+            <a:String CONTENT="Inte" HEIGHT="37" WIDTH="95" HPOS="1059" VPOS="6116" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0050" WIDTH="820" HEIGHT="53" HPOS="336" VPOS="6169">
+            <a:String CONTENT="rÃ©s" HEIGHT="38" WIDTH="72" HPOS="336" VPOS="6179" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="454" VPOS="6187" />
+            <a:String CONTENT="singularÃ­simo" HEIGHT="49" WIDTH="340" HPOS="454" VPOS="6173" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="838" VPOS="6171" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="838" VPOS="6171" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="47" HPOS="936" VPOS="6180" />
+            <a:String CONTENT="esa" HEIGHT="35" WIDTH="77" HPOS="936" VPOS="6179" WC="0.62" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="1054" VPOS="6180" />
+            <a:String CONTENT="vida" HEIGHT="38" WIDTH="102" HPOS="1054" VPOS="6169" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0051" WIDTH="821" HEIGHT="55" HPOS="334" VPOS="6223">
+            <a:String CONTENT="apartada" HEIGHT="49" WIDTH="215" HPOS="334" VPOS="6229" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="575" VPOS="6238" />
+            <a:String CONTENT="y" HEIGHT="36" WIDTH="27" HPOS="575" VPOS="6238" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="631" VPOS="6237" />
+            <a:String CONTENT="silenciosa;" HEIGHT="43" WIDTH="261" HPOS="631" VPOS="6225" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="921" VPOS="6235" />
+            <a:String CONTENT="poesÃ­a" HEIGHT="49" WIDTH="155" HPOS="921" VPOS="6223" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1103" VPOS="6223" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="52" HPOS="1103" VPOS="6223" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0052" WIDTH="821" HEIGHT="54" HPOS="335" VPOS="6276">
+            <a:String CONTENT="las" HEIGHT="37" WIDTH="66" HPOS="335" VPOS="6285" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="432" VPOS="6293" />
+            <a:String CONTENT="quejas" HEIGHT="48" WIDTH="157" HPOS="432" VPOS="6282" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="622" VPOS="6279" />
+            <a:String CONTENT="Ã­ntimas" HEIGHT="38" WIDTH="181" HPOS="622" VPOS="6279" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="831" VPOS="6287" />
+            <a:String CONTENT="y" HEIGHT="36" WIDTH="28" HPOS="831" VPOS="6287" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="887" VPOS="6276" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="52" HPOS="887" VPOS="6276" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="969" VPOS="6276" />
+            <a:String CONTENT="las" HEIGHT="39" WIDTH="67" HPOS="969" VPOS="6276" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1066" VPOS="6277" />
+            <a:String CONTENT="iroÂ¬" HEIGHT="38" WIDTH="90" HPOS="1066" VPOS="6277" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="ironÃ­as" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0053" WIDTH="322" HEIGHT="41" HPOS="333" VPOS="6334">
+            <a:String CONTENT="nÃ­as" HEIGHT="37" WIDTH="97" HPOS="333" VPOS="6338" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="42" HPOS="472" VPOS="6337" />
+            <a:String CONTENT="hondas." HEIGHT="38" WIDTH="183" HPOS="472" VPOS="6334" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0024" HEIGHT="1070" WIDTH="836" HPOS="333" VPOS="6382" STYLEREFS="PARSTYLE0010">
+          <a:TextLine ID="PAG001LIN0054" WIDTH="775" HEIGHT="51" HPOS="383" VPOS="6382">
+            <a:String CONTENT="ITodo" HEIGHT="44" WIDTH="121" HPOS="383" VPOS="6388" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="539" VPOS="6398" />
+            <a:String CONTENT="eso" HEIGHT="27" WIDTH="76" HPOS="539" VPOS="6398" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="646" VPOS="6397" />
+            <a:String CONTENT="prepara" HEIGHT="40" WIDTH="188" HPOS="646" VPOS="6393" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="868" VPOS="6393" />
+            <a:String CONTENT="para" HEIGHT="37" WIDTH="112" HPOS="868" VPOS="6393" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1011" VPOS="6382" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="43" HPOS="1011" VPOS="6382" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1085" VPOS="6392" />
+            <a:String CONTENT="exÂ¬" HEIGHT="33" WIDTH="73" HPOS="1085" VPOS="6388" WC="0.97" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="expansiÃ³n," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0055" WIDTH="823" HEIGHT="56" HPOS="334" VPOS="6436">
+            <a:String CONTENT="pansiÃ³n," HEIGHT="51" WIDTH="204" HPOS="334" VPOS="6441" WC="0.97" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="569" VPOS="6450" />
+            <a:String CONTENT="para" HEIGHT="38" WIDTH="109" HPOS="569" VPOS="6449" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="705" VPOS="6449" />
+            <a:String CONTENT="vida" HEIGHT="37" WIDTH="100" HPOS="705" VPOS="6438" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="835" VPOS="6447" />
+            <a:String CONTENT="exterior," HEIGHT="47" WIDTH="207" HPOS="835" VPOS="6436" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1072" VPOS="6447" />
+            <a:String CONTENT="pÃºÂ¬" HEIGHT="48" WIDTH="85" HPOS="1072" VPOS="6436" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="pÃºblica," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0056" WIDTH="823" HEIGHT="53" HPOS="334" VPOS="6490">
+            <a:String CONTENT="blica," HEIGHT="46" WIDTH="128" HPOS="334" VPOS="6497" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="493" VPOS="6504" />
+            <a:String CONTENT="que" HEIGHT="36" WIDTH="83" HPOS="493" VPOS="6504" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="606" VPOS="6504" />
+            <a:String CONTENT="corresponda" HEIGHT="47" WIDTH="305" HPOS="606" VPOS="6490" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="941" VPOS="6508" />
+            <a:String CONTENT="a" HEIGHT="29" WIDTH="25" HPOS="941" VPOS="6508" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="996" VPOS="6490" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="41" HPOS="996" VPOS="6490" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1066" VPOS="6490" />
+            <a:String CONTENT="inte" HEIGHT="38" WIDTH="91" HPOS="1066" VPOS="6490" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0057" WIDTH="823" HEIGHT="46" HPOS="335" VPOS="6545">
+            <a:String CONTENT="rior" HEIGHT="37" WIDTH="91" HPOS="335" VPOS="6551" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="461" VPOS="6548" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="50" HPOS="461" VPOS="6548" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="549" VPOS="6546" />
+            <a:String CONTENT="las" HEIGHT="37" WIDTH="66" HPOS="549" VPOS="6546" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="654" VPOS="6556" />
+            <a:String CONTENT="almas," HEIGHT="46" WIDTH="157" HPOS="654" VPOS="6545" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="848" VPOS="6552" />
+            <a:String CONTENT="congregadas" HEIGHT="43" WIDTH="310" HPOS="848" VPOS="6547" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0058" WIDTH="824" HEIGHT="46" HPOS="336" VPOS="6597">
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="54" HPOS="336" VPOS="6614" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="417" VPOS="6605" />
+            <a:String CONTENT="la" HEIGHT="36" WIDTH="40" HPOS="417" VPOS="6605" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="483" VPOS="6601" />
+            <a:String CONTENT="tambiÃ©n" HEIGHT="41" WIDTH="197" HPOS="483" VPOS="6599" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="707" VPOS="6598" />
+            <a:String CONTENT="Ã­ntima" HEIGHT="37" WIDTH="159" HPOS="707" VPOS="6598" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="892" VPOS="6606" />
+            <a:String CONTENT="comunidad" HEIGHT="39" WIDTH="268" HPOS="892" VPOS="6597" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0059" WIDTH="824" HEIGHT="49" HPOS="336" VPOS="6649">
+            <a:String CONTENT="familiar;" HEIGHT="44" WIDTH="218" HPOS="336" VPOS="6653" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="579" VPOS="6662" />
+            <a:String CONTENT="nunca" HEIGHT="29" WIDTH="148" HPOS="579" VPOS="6661" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="754" VPOS="6660" />
+            <a:String CONTENT="exenta," HEIGHT="45" WIDTH="172" HPOS="754" VPOS="6649" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="952" VPOS="6650" />
+            <a:String CONTENT="tampoco" HEIGHT="48" WIDTH="208" HPOS="952" VPOS="6650" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0060" WIDTH="823" HEIGHT="48" HPOS="337" VPOS="6701">
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="48" HPOS="337" VPOS="6709" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="429" VPOS="6715" />
+            <a:String CONTENT="sufrimientos," HEIGHT="45" WIDTH="303" HPOS="429" VPOS="6704" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="47" HPOS="779" VPOS="6701" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="50" HPOS="779" VPOS="6701" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="875" VPOS="6710" />
+            <a:String CONTENT="contrariedaÂ¬" HEIGHT="40" WIDTH="285" HPOS="875" VPOS="6701" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="contrariedades" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0061" WIDTH="824" HEIGHT="48" HPOS="337" VPOS="6756">
+            <a:String CONTENT="des" HEIGHT="39" WIDTH="76" HPOS="337" VPOS="6763" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="49" HPOS="462" VPOS="6760" />
+            <a:String CONTENT="de" HEIGHT="36" WIDTH="49" HPOS="462" VPOS="6760" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="551" VPOS="6758" />
+            <a:String CONTENT="imposiciones." HEIGHT="47" WIDTH="333" HPOS="551" VPOS="6757" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="918" VPOS="6756" />
+            <a:String CONTENT="Se" HEIGHT="38" WIDTH="53" HPOS="918" VPOS="6756" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="1008" VPOS="6766" />
+            <a:String CONTENT="sobreÂ¬" HEIGHT="38" WIDTH="153" HPOS="1008" VPOS="6757" WC="0.89" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="sobreponen" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0062" WIDTH="824" HEIGHT="58" HPOS="338" VPOS="6808">
+            <a:String CONTENT="ponen" HEIGHT="44" WIDTH="146" HPOS="338" VPOS="6822" WC="0.89" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="23" HPOS="507" VPOS="6822" />
+            <a:String CONTENT="unas," HEIGHT="40" WIDTH="131" HPOS="507" VPOS="6820" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="665" VPOS="6809" />
+            <a:String CONTENT="les" HEIGHT="38" WIDTH="64" HPOS="665" VPOS="6809" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="757" VPOS="6819" />
+            <a:String CONTENT="rodean" HEIGHT="38" WIDTH="167" HPOS="757" VPOS="6808" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="950" VPOS="6819" />
+            <a:String CONTENT="otraSj" HEIGHT="53" WIDTH="138" HPOS="950" VPOS="6810" WC="0.23" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1115" VPOS="6811" />
+            <a:String CONTENT="to" HEIGHT="39" WIDTH="47" HPOS="1115" VPOS="6811" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0063" WIDTH="825" HEIGHT="48" HPOS="338" VPOS="6862">
+            <a:String CONTENT="das" HEIGHT="37" WIDTH="73" HPOS="338" VPOS="6870" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="55" HPOS="466" VPOS="6876" />
+            <a:String CONTENT="contribuyen" HEIGHT="46" WIDTH="273" HPOS="466" VPOS="6863" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="54" HPOS="793" VPOS="6871" />
+            <a:String CONTENT="al" HEIGHT="37" WIDTH="37" HPOS="793" VPOS="6862" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="56" HPOS="886" VPOS="6872" />
+            <a:String CONTENT="aislamiento," HEIGHT="47" WIDTH="277" HPOS="886" VPOS="6863" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0064" WIDTH="835" HEIGHT="52" HPOS="333" VPOS="6915">
+            <a:String CONTENT="entorpecen" HEIGHT="44" WIDTH="246" HPOS="333" VPOS="6923" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="616" VPOS="6916" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="39" HPOS="616" VPOS="6916" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="689" VPOS="6925" />
+            <a:String CONTENT="comunicaciÃ³n," HEIGHT="48" WIDTH="325" HPOS="689" VPOS="6915" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1049" VPOS="6927" />
+            <a:String CONTENT="manÂ¬" HEIGHT="30" WIDTH="119" HPOS="1049" VPOS="6927" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="mantienen," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0065" WIDTH="822" HEIGHT="50" HPOS="340" VPOS="6969">
+            <a:String CONTENT="tienen," HEIGHT="40" WIDTH="161" HPOS="340" VPOS="6977" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="32" HPOS="533" VPOS="6982" />
+            <a:String CONTENT="con" HEIGHT="30" WIDTH="83" HPOS="533" VPOS="6979" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="644" VPOS="6969" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="43" HPOS="644" VPOS="6969" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="717" VPOS="6969" />
+            <a:String CONTENT="desconfianza," HEIGHT="50" WIDTH="332" HPOS="717" VPOS="6969" WC="0.91" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1080" VPOS="6971" />
+            <a:String CONTENT="duÂ¬" HEIGHT="38" WIDTH="82" HPOS="1080" VPOS="6971" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="dudas," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0066" WIDTH="824" HEIGHT="57" HPOS="339" VPOS="7022">
+            <a:String CONTENT="das," HEIGHT="49" WIDTH="93" HPOS="339" VPOS="7030" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="51" HPOS="483" VPOS="7026" />
+            <a:String CONTENT="indecisiones" HEIGHT="39" WIDTH="299" HPOS="483" VPOS="7023" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="51" HPOS="833" VPOS="7022" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="69" HPOS="833" VPOS="7022" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="50" HPOS="952" VPOS="7034" />
+            <a:String CONTENT="espÃ­ritu;" HEIGHT="48" WIDTH="211" HPOS="952" VPOS="7024" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0067" WIDTH="822" HEIGHT="51" HPOS="342" VPOS="7076">
+            <a:String CONTENT="son" HEIGHT="28" WIDTH="83" HPOS="342" VPOS="7094" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="460" VPOS="7079" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="65" HPOS="460" VPOS="7079" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="563" VPOS="7078" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="563" VPOS="7078" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="650" VPOS="7087" />
+            <a:String CONTENT="cada" HEIGHT="39" WIDTH="108" HPOS="650" VPOS="7076" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="793" VPOS="7081" />
+            <a:String CONTENT="espÃ­ritu" HEIGHT="46" WIDTH="192" HPOS="793" VPOS="7076" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1020" VPOS="7088" />
+            <a:String CONTENT="y" HEIGHT="39" WIDTH="28" HPOS="1020" VPOS="7088" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1080" VPOS="7088" />
+            <a:String CONTENT="son" HEIGHT="29" WIDTH="84" HPOS="1080" VPOS="7088" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0068" WIDTH="822" HEIGHT="50" HPOS="342" VPOS="7129">
+            <a:String CONTENT="las" HEIGHT="37" WIDTH="66" HPOS="342" VPOS="7137" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="440" VPOS="7134" />
+            <a:String CONTENT="del" HEIGHT="39" WIDTH="67" HPOS="440" VPOS="7133" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="540" VPOS="7142" />
+            <a:String CONTENT="espÃ­ritu" HEIGHT="49" WIDTH="189" HPOS="540" VPOS="7130" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="760" VPOS="7139" />
+            <a:String CONTENT="regional;" HEIGHT="47" WIDTH="226" HPOS="760" VPOS="7129" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="1019" VPOS="7141" />
+            <a:String CONTENT="sufriÃ³" HEIGHT="38" WIDTH="145" HPOS="1019" VPOS="7132" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0069" WIDTH="821" HEIGHT="55" HPOS="344" VPOS="7182">
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="55" HPOS="344" VPOS="7200" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="426" VPOS="7199" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="37" HPOS="426" VPOS="7189" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="492" VPOS="7196" />
+            <a:String CONTENT="olvido," HEIGHT="43" WIDTH="157" HPOS="492" VPOS="7186" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="674" VPOS="7200" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="27" HPOS="674" VPOS="7200" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="728" VPOS="7192" />
+            <a:String CONTENT="sufre" HEIGHT="38" WIDTH="124" HPOS="728" VPOS="7182" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="881" VPOS="7192" />
+            <a:String CONTENT="por" HEIGHT="37" WIDTH="83" HPOS="881" VPOS="7192" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="992" VPOS="7187" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="43" HPOS="992" VPOS="7187" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1060" VPOS="7196" />
+            <a:String CONTENT="conÂ¬" HEIGHT="29" WIDTH="105" HPOS="1060" VPOS="7195" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="contradicciÃ³n." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0070" WIDTH="820" HEIGHT="46" HPOS="346" VPOS="7236">
+            <a:String CONTENT="tradicciÃ³n." HEIGHT="46" WIDTH="260" HPOS="346" VPOS="7236" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="44" HPOS="650" VPOS="7239" />
+            <a:String CONTENT="Malas" HEIGHT="38" WIDTH="139" HPOS="650" VPOS="7237" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="828" VPOS="7244" />
+            <a:String CONTENT="artes" HEIGHT="37" WIDTH="125" HPOS="828" VPOS="7236" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="995" VPOS="7238" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="51" HPOS="995" VPOS="7238" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="1088" VPOS="7250" />
+            <a:String CONTENT="cuÂ¬" HEIGHT="28" WIDTH="78" HPOS="1088" VPOS="7250" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="curias" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0071" WIDTH="823" HEIGHT="47" HPOS="343" VPOS="7290">
+            <a:String CONTENT="rias" HEIGHT="38" WIDTH="92" HPOS="343" VPOS="7299" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="30" HPOS="465" VPOS="7308" />
+            <a:String CONTENT="administrativas" HEIGHT="45" WIDTH="384" HPOS="465" VPOS="7290" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="878" VPOS="7298" />
+            <a:String CONTENT="o" HEIGHT="29" WIDTH="24" HPOS="878" VPOS="7298" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="929" VPOS="7291" />
+            <a:String CONTENT="judiciales" HEIGHT="46" WIDTH="237" HPOS="929" VPOS="7291" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0072" WIDTH="822" HEIGHT="52" HPOS="344" VPOS="7344">
+            <a:String CONTENT="Enlace," HEIGHT="44" WIDTH="178" HPOS="344" VPOS="7352" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="549" VPOS="7350" />
+            <a:String CONTENT="trabazÃ³n" HEIGHT="43" WIDTH="213" HPOS="549" VPOS="7344" WC="0.93" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="790" VPOS="7355" />
+            <a:String CONTENT="en" HEIGHT="31" WIDTH="53" HPOS="790" VPOS="7352" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="871" VPOS="7352" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="83" HPOS="871" VPOS="7352" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="984" VPOS="7354" />
+            <a:String CONTENT="se" HEIGHT="28" WIDTH="46" HPOS="984" VPOS="7354" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1057" VPOS="7356" />
+            <a:String CONTENT="enea" HEIGHT="33" WIDTH="109" HPOS="1057" VPOS="7352" WC="0.91" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0073" WIDTH="821" HEIGHT="54" HPOS="345" VPOS="7397">
+            <a:String CONTENT="denan" HEIGHT="40" WIDTH="146" HPOS="345" VPOS="7406" WC="0.91" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="527" VPOS="7443" />
+            <a:String CONTENT=",todos" HEIGHT="49" WIDTH="130" HPOS="527" VPOS="7401" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="694" VPOS="7408" />
+            <a:String CONTENT="y" HEIGHT="42" WIDTH="29" HPOS="694" VPOS="7408" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="757" VPOS="7415" />
+            <a:String CONTENT="Â¡quedan" HEIGHT="52" WIDTH="177" HPOS="757" VPOS="7397" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="973" VPOS="7408" />
+            <a:String CONTENT="aprisioÂ¬" HEIGHT="51" WIDTH="193" HPOS="973" VPOS="7400" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:ComposedBlock ID="PAG001BLK0025" HEIGHT="2813" WIDTH="863" HPOS="1218" VPOS="4638" />
+        <a:TextBlock ID="PAG001BLK0026" HEIGHT="691" WIDTH="823" HPOS="1230" VPOS="4655" STYLEREFS="PARSTYLE0011">
+          <a:TextLine ID="PAG001LIN0074" WIDTH="818" HEIGHT="51" HPOS="1230" VPOS="4655">
+            <a:String CONTENT="nados" HEIGHT="39" WIDTH="134" HPOS="1230" VPOS="4663" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1388" VPOS="4663" />
+            <a:String CONTENT="los" HEIGHT="38" WIDTH="66" HPOS="1388" VPOS="4663" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="1477" VPOS="4672" />
+            <a:String CONTENT="mismos" HEIGHT="37" WIDTH="187" HPOS="1477" VPOS="4662" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="20" HPOS="1684" VPOS="4669" />
+            <a:String CONTENT="que" HEIGHT="39" WIDTH="82" HPOS="1684" VPOS="4667" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="18" HPOS="1784" VPOS="4667" />
+            <a:String CONTENT="aprisionan" HEIGHT="49" WIDTH="264" HPOS="1784" VPOS="4655" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0075" WIDTH="812" HEIGHT="49" HPOS="1234" VPOS="4711">
+            <a:String CONTENT="Palso" HEIGHT="39" WIDTH="125" HPOS="1234" VPOS="4717" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="1399" VPOS="4728" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="40" HPOS="1399" VPOS="4717" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="1477" VPOS="4726" />
+            <a:String CONTENT="ordenamiento," HEIGHT="49" WIDTH="352" HPOS="1477" VPOS="4711" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="1870" VPOS="4719" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="56" HPOS="1870" VPOS="4718" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="1964" VPOS="4717" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="82" HPOS="1964" VPOS="4716" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0076" WIDTH="816" HEIGHT="55" HPOS="1238" VPOS="4760">
+            <a:String CONTENT=")1" HEIGHT="36" WIDTH="25" HPOS="1238" VPOS="4772" WC="0.86" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="1306" VPOS="4770" />
+            <a:String CONTENT="desorden" HEIGHT="39" WIDTH="201" HPOS="1306" VPOS="4769" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="1553" VPOS="4778" />
+            <a:String CONTENT="perdura." HEIGHT="49" WIDTH="196" HPOS="1553" VPOS="4766" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="1793" VPOS="4764" />
+            <a:String CONTENT="Viciada" HEIGHT="40" WIDTH="175" HPOS="1793" VPOS="4761" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="2011" VPOS="4760" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="38" HPOS="2011" VPOS="4760" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0077" WIDTH="804" HEIGHT="53" HPOS="1243" VPOS="4815">
+            <a:String CONTENT="â– onducta;" HEIGHT="43" WIDTH="222" HPOS="1243" VPOS="4825" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1496" VPOS="4833" />
+            <a:String CONTENT="vicioso" HEIGHT="38" WIDTH="169" HPOS="1496" VPOS="4822" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="16" HPOS="1681" VPOS="4851" />
+            <a:String CONTENT="," HEIGHT="10" WIDTH="4" HPOS="1681" VPOS="4851" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="12" HPOS="1697" VPOS="4829" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="39" HPOS="1697" VPOS="4820" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1768" VPOS="4828" />
+            <a:String CONTENT="sistema." HEIGHT="38" WIDTH="201" HPOS="1768" VPOS="4817" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1999" VPOS="4815" />
+            <a:String CONTENT="Ll" HEIGHT="37" WIDTH="48" HPOS="1999" VPOS="4815" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0078" WIDTH="811" HEIGHT="49" HPOS="1237" VPOS="4872">
+            <a:String CONTENT="jertades" HEIGHT="38" WIDTH="195" HPOS="1237" VPOS="4879" WC="0.8" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1460" VPOS="4878" />
+            <a:String CONTENT="individuales," HEIGHT="48" WIDTH="307" HPOS="1460" VPOS="4873" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1792" VPOS="4873" />
+            <a:String CONTENT="justamen-" HEIGHT="48" WIDTH="256" HPOS="1792" VPOS="4872" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="justamenle" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0079" WIDTH="816" HEIGHT="51" HPOS="1233" VPOS="4925">
+            <a:String CONTENT="le" HEIGHT="32" WIDTH="37" HPOS="1233" VPOS="4940" WC="0.99" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="26" HPOS="1296" VPOS="4943" />
+            <a:String CONTENT="encarecidas," HEIGHT="44" WIDTH="299" HPOS="1296" VPOS="4930" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1620" VPOS="4939" />
+            <a:String CONTENT="pero" HEIGHT="38" WIDTH="106" HPOS="1620" VPOS="4938" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1752" VPOS="4936" />
+            <a:String CONTENT="servidas" HEIGHT="38" WIDTH="202" HPOS="1752" VPOS="4925" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1981" VPOS="4927" />
+            <a:String CONTENT="tor" HEIGHT="34" WIDTH="68" HPOS="1981" VPOS="4927" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0080" WIDTH="818" HEIGHT="57" HPOS="1232" VPOS="4978">
+            <a:String CONTENT="peÃ­nente," HEIGHT="48" WIDTH="214" HPOS="1232" VPOS="4987" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1473" VPOS="4994" />
+            <a:String CONTENT="por" HEIGHT="38" WIDTH="81" HPOS="1473" VPOS="4994" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1581" VPOS="4993" />
+            <a:String CONTENT="quienes" HEIGHT="48" WIDTH="184" HPOS="1581" VPOS="4981" WC="0.76" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1793" VPOS="4991" />
+            <a:String CONTENT="no" HEIGHT="29" WIDTH="59" HPOS="1793" VPOS="4990" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1882" VPOS="4990" />
+            <a:String CONTENT="acaban" HEIGHT="38" WIDTH="168" HPOS="1882" VPOS="4978" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0081" WIDTH="820" HEIGHT="54" HPOS="1231" VPOS="5032">
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="48" HPOS="1231" VPOS="5043" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1309" VPOS="5051" />
+            <a:String CONTENT="comprender" HEIGHT="48" WIDTH="291" HPOS="1309" VPOS="5038" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="1" HPOS="1601" VPOS="5059" />
+            <a:String CONTENT="â€”" HEIGHT="7" WIDTH="54" HPOS="1601" VPOS="5059" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="1657" VPOS="5046" />
+            <a:String CONTENT="quizÃ¡s" HEIGHT="49" WIDTH="153" HPOS="1657" VPOS="5033" WC="0.62" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1840" VPOS="5043" />
+            <a:String CONTENT="no" HEIGHT="28" WIDTH="59" HPOS="1840" VPOS="5043" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1929" VPOS="5042" />
+            <a:String CONTENT="quieÂ¬" HEIGHT="47" WIDTH="122" HPOS="1929" VPOS="5032" WC="0.81" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="quieren" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0082" WIDTH="820" HEIGHT="51" HPOS="1231" VPOS="5088">
+            <a:String CONTENT="ren" HEIGHT="28" WIDTH="79" HPOS="1231" VPOS="5105" WC="0.81" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="1" HPOS="1311" VPOS="5117" />
+            <a:String CONTENT="â€”" HEIGHT="6" WIDTH="54" HPOS="1311" VPOS="5117" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="1367" VPOS="5103" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="81" HPOS="1367" VPOS="5101" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1480" VPOS="5101" />
+            <a:String CONTENT="sobre" HEIGHT="37" WIDTH="129" HPOS="1480" VPOS="5091" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1640" VPOS="5092" />
+            <a:String CONTENT="todo" HEIGHT="45" WIDTH="103" HPOS="1640" VPOS="5089" WC="0.74" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1775" VPOS="5089" />
+            <a:String CONTENT="han" HEIGHT="36" WIDTH="89" HPOS="1775" VPOS="5089" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1895" VPOS="5088" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="52" HPOS="1895" VPOS="5088" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1975" VPOS="5096" />
+            <a:String CONTENT="vaÂ¬" HEIGHT="28" WIDTH="76" HPOS="1975" VPOS="5095" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="valer" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0083" WIDTH="819" HEIGHT="55" HPOS="1232" VPOS="5140">
+            <a:String CONTENT="ler" HEIGHT="36" WIDTH="63" HPOS="1232" VPOS="5150" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="25" HPOS="1320" VPOS="5158" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="26" HPOS="1320" VPOS="5158" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1372" VPOS="5158" />
+            <a:String CONTENT="contar" HEIGHT="39" WIDTH="157" HPOS="1372" VPOS="5146" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1555" VPOS="5155" />
+            <a:String CONTENT="como" HEIGHT="29" WIDTH="126" HPOS="1555" VPOS="5153" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1708" VPOS="5143" />
+            <a:String CONTENT="libertades" HEIGHT="39" WIDTH="241" HPOS="1708" VPOS="5140" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1978" VPOS="5151" />
+            <a:String CONTENT="soÂ¬" HEIGHT="30" WIDTH="73" HPOS="1978" VPOS="5148" WC="0.94" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="sociales1." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0084" WIDTH="819" HEIGHT="47" HPOS="1233" VPOS="5195">
+            <a:String CONTENT="ciales1." HEIGHT="39" WIDTH="150" HPOS="1233" VPOS="5202" WC="0.94" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="41" HPOS="1424" VPOS="5199" />
+            <a:String CONTENT="Solo" HEIGHT="38" WIDTH="100" HPOS="1424" VPOS="5199" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="1564" VPOS="5209" />
+            <a:String CONTENT="asÃ­" HEIGHT="39" WIDTH="69" HPOS="1564" VPOS="5197" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="1673" VPOS="5207" />
+            <a:String CONTENT="adquieren" HEIGHT="47" WIDTH="243" HPOS="1673" VPOS="5195" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="1953" VPOS="5205" />
+            <a:String CONTENT="verÂ¬" HEIGHT="30" WIDTH="99" HPOS="1953" VPOS="5203" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="verdadero" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0085" WIDTH="820" HEIGHT="49" HPOS="1232" VPOS="5248">
+            <a:String CONTENT="dadero" HEIGHT="38" WIDTH="161" HPOS="1232" VPOS="5255" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="24" HPOS="1417" VPOS="5253" />
+            <a:String CONTENT="doctrinal" HEIGHT="38" WIDTH="218" HPOS="1417" VPOS="5252" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="1658" VPOS="5262" />
+            <a:String CONTENT="valor" HEIGHT="39" WIDTH="124" HPOS="1658" VPOS="5249" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="1804" VPOS="5259" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="28" HPOS="1804" VPOS="5259" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="1853" VPOS="5259" />
+            <a:String CONTENT="prÃ¡ctica" HEIGHT="49" WIDTH="199" HPOS="1853" VPOS="5248" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0086" WIDTH="186" HEIGHT="39" HPOS="1233" VPOS="5306">
+            <a:String CONTENT="eficacia." HEIGHT="39" WIDTH="186" HPOS="1233" VPOS="5306" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0027" HEIGHT="1112" WIDTH="838" HPOS="1228" VPOS="5366" STYLEREFS="PARSTYLE0012">
+          <a:TextLine ID="PAG001LIN0087" WIDTH="779" HEIGHT="49" HPOS="1286" VPOS="5366">
+            <a:String CONTENT="CundiÃ³" HEIGHT="39" WIDTH="165" HPOS="1286" VPOS="5370" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="1491" VPOS="5369" />
+            <a:String CONTENT="la" HEIGHT="43" WIDTH="42" HPOS="1491" VPOS="5369" WC="0.85" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="1570" VPOS="5369" />
+            <a:String CONTENT="desorganizaciÃ³n;" HEIGHT="49" WIDTH="421" HPOS="1570" VPOS="5366" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2028" VPOS="5377" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="27" HPOS="2028" VPOS="5377" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0088" WIDTH="819" HEIGHT="46" HPOS="1235" VPOS="5421">
+            <a:String CONTENT="como" HEIGHT="28" WIDTH="125" HPOS="1235" VPOS="5435" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1395" VPOS="5434" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="52" HPOS="1395" VPOS="5434" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1479" VPOS="5434" />
+            <a:String CONTENT="ella" HEIGHT="38" WIDTH="86" HPOS="1479" VPOS="5423" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1597" VPOS="5434" />
+            <a:String CONTENT="no" HEIGHT="29" WIDTH="58" HPOS="1597" VPOS="5433" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1687" VPOS="5433" />
+            <a:String CONTENT="cabe" HEIGHT="38" WIDTH="105" HPOS="1687" VPOS="5422" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1827" VPOS="5431" />
+            <a:String CONTENT="subsistir," HEIGHT="46" WIDTH="227" HPOS="1827" VPOS="5421" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0089" WIDTH="821" HEIGHT="45" HPOS="1236" VPOS="5479">
+            <a:String CONTENT="como," HEIGHT="35" WIDTH="139" HPOS="1236" VPOS="5488" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1402" VPOS="5487" />
+            <a:String CONTENT="por" HEIGHT="37" WIDTH="79" HPOS="1402" VPOS="5487" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1505" VPOS="5487" />
+            <a:String CONTENT="una" HEIGHT="28" WIDTH="89" HPOS="1505" VPOS="5486" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1619" VPOS="5487" />
+            <a:String CONTENT="u" HEIGHT="27" WIDTH="28" HPOS="1619" VPOS="5487" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1674" VPOS="5485" />
+            <a:String CONTENT="otra" HEIGHT="35" WIDTH="97" HPOS="1674" VPOS="5479" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1797" VPOS="5485" />
+            <a:String CONTENT="manera" HEIGHT="31" WIDTH="186" HPOS="1797" VPOS="5485" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2009" VPOS="5487" />
+            <a:String CONTENT="sÂ»" HEIGHT="28" WIDTH="48" HPOS="2009" VPOS="5485" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0090" WIDTH="822" HEIGHT="49" HPOS="1236" VPOS="5531">
+            <a:String CONTENT="ha" HEIGHT="37" WIDTH="57" HPOS="1236" VPOS="5532" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1320" VPOS="5532" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="49" HPOS="1320" VPOS="5532" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1399" VPOS="5542" />
+            <a:String CONTENT="atajar," HEIGHT="49" WIDTH="161" HPOS="1399" VPOS="5531" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1589" VPOS="5541" />
+            <a:String CONTENT="es" HEIGHT="28" WIDTH="46" HPOS="1589" VPOS="5540" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1665" VPOS="5531" />
+            <a:String CONTENT="forzoso" HEIGHT="36" WIDTH="180" HPOS="1665" VPOS="5531" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1874" VPOS="5540" />
+            <a:String CONTENT="caer" HEIGHT="28" WIDTH="102" HPOS="1874" VPOS="5539" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2005" VPOS="5540" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="53" HPOS="2005" VPOS="5539" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0091" WIDTH="834" HEIGHT="49" HPOS="1228" VPOS="5582">
+            <a:String CONTENT="nuevas" HEIGHT="30" WIDTH="156" HPOS="1228" VPOS="5593" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1413" VPOS="5583" />
+            <a:String CONTENT="imposiciones" HEIGHT="48" WIDTH="294" HPOS="1413" VPOS="5583" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1736" VPOS="5593" />
+            <a:String CONTENT="asÃ­," HEIGHT="45" WIDTH="73" HPOS="1736" VPOS="5582" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1840" VPOS="5592" />
+            <a:String CONTENT="que" HEIGHT="39" WIDTH="82" HPOS="1840" VPOS="5592" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1952" VPOS="5592" />
+            <a:String CONTENT="sienÂ¬" HEIGHT="38" WIDTH="110" HPOS="1952" VPOS="5583" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="siendo" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0092" WIDTH="820" HEIGHT="48" HPOS="1237" VPOS="5636">
+            <a:String CONTENT="do" HEIGHT="38" WIDTH="54" HPOS="1237" VPOS="5639" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="44" HPOS="1335" VPOS="5639" />
+            <a:String CONTENT="las" HEIGHT="37" WIDTH="65" HPOS="1335" VPOS="5639" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="45" HPOS="1445" VPOS="5637" />
+            <a:String CONTENT="imposiciones" HEIGHT="48" WIDTH="317" HPOS="1445" VPOS="5636" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="1806" VPOS="5647" />
+            <a:String CONTENT="anteriores" HEIGHT="39" WIDTH="251" HPOS="1806" VPOS="5636" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0093" WIDTH="825" HEIGHT="50" HPOS="1233" VPOS="5689">
+            <a:String CONTENT="â€”" HEIGHT="7" WIDTH="54" HPOS="1233" VPOS="5715" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="0" HPOS="1287" VPOS="5692" />
+            <a:String CONTENT="torpes" HEIGHT="47" WIDTH="151" HPOS="1287" VPOS="5692" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1470" VPOS="5701" />
+            <a:String CONTENT="e" HEIGHT="27" WIDTH="20" HPOS="1470" VPOS="5701" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="1523" VPOS="5691" />
+            <a:String CONTENT="inadecuadas" HEIGHT="42" WIDTH="297" HPOS="1523" VPOS="5691" WC="0.84" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="3" HPOS="1823" VPOS="5712" />
+            <a:String CONTENT="â€”" HEIGHT="7" WIDTH="60" HPOS="1823" VPOS="5712" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="1885" VPOS="5701" />
+            <a:String CONTENT="corolaÂ¬" HEIGHT="40" WIDTH="173" HPOS="1885" VPOS="5689" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="corolario" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0094" WIDTH="823" HEIGHT="47" HPOS="1235" VPOS="5744">
+            <a:String CONTENT="rio" HEIGHT="37" WIDTH="68" HPOS="1235" VPOS="5746" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="30" HPOS="1333" VPOS="5753" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="27" HPOS="1333" VPOS="5753" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1392" VPOS="5755" />
+            <a:String CONTENT="consecuencia," HEIGHT="46" WIDTH="336" HPOS="1392" VPOS="5745" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="1765" VPOS="5754" />
+            <a:String CONTENT="siempre" HEIGHT="47" WIDTH="194" HPOS="1765" VPOS="5744" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="1993" VPOS="5744" />
+            <a:String CONTENT="laÂ¬" HEIGHT="38" WIDTH="65" HPOS="1993" VPOS="5744" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="lamentable," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0095" WIDTH="820" HEIGHT="48" HPOS="1239" VPOS="5797">
+            <a:String CONTENT="mentable," HEIGHT="45" WIDTH="234" HPOS="1239" VPOS="5797" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="44" HPOS="1517" VPOS="5808" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="25" HPOS="1517" VPOS="5808" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="1582" VPOS="5798" />
+            <a:String CONTENT="fe" HEIGHT="38" WIDTH="44" HPOS="1582" VPOS="5798" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="1669" VPOS="5807" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="82" HPOS="1669" VPOS="5807" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="1793" VPOS="5798" />
+            <a:String CONTENT="dejarÃ­a" HEIGHT="47" WIDTH="174" HPOS="1793" VPOS="5798" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2008" VPOS="5798" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="2008" VPOS="5798" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0096" WIDTH="821" HEIGHT="55" HPOS="1238" VPOS="5850">
+            <a:String CONTENT="serlo," HEIGHT="55" WIDTH="131" HPOS="1238" VPOS="5850" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1394" VPOS="5868" />
+            <a:String CONTENT="si" HEIGHT="44" WIDTH="36" HPOS="1394" VPOS="5851" WC="0.7" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1455" VPOS="5852" />
+            <a:String CONTENT="fuese" HEIGHT="36" WIDTH="126" HPOS="1455" VPOS="5852" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1606" VPOS="5862" />
+            <a:String CONTENT="consecuencia" HEIGHT="39" WIDTH="326" HPOS="1606" VPOS="5852" WC="0.8" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="1954" VPOS="5851" />
+            <a:String CONTENT="ÃºltiÂ¬" HEIGHT="39" WIDTH="105" HPOS="1954" VPOS="5850" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="Ãºltima;" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0097" WIDTH="835" HEIGHT="46" HPOS="1244" VPOS="5904">
+            <a:String CONTENT="ma;" HEIGHT="35" WIDTH="93" HPOS="1244" VPOS="5915" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="59" HPOS="1396" VPOS="5915" />
+            <a:String CONTENT="si" HEIGHT="38" WIDTH="38" HPOS="1396" VPOS="5904" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="57" HPOS="1491" VPOS="5914" />
+            <a:String CONTENT="seÃ±alara" HEIGHT="37" WIDTH="212" HPOS="1491" VPOS="5905" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="57" HPOS="1760" VPOS="5905" />
+            <a:String CONTENT="tÃ©rmino" HEIGHT="39" WIDTH="195" HPOS="1760" VPOS="5905" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="62" HPOS="2017" VPOS="5915" />
+            <a:String CONTENT="al" HEIGHT="39" WIDTH="41" HPOS="2017" VPOS="5904" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0098" WIDTH="823" HEIGHT="49" HPOS="1240" VPOS="5958">
+            <a:String CONTENT="proceso" HEIGHT="40" WIDTH="188" HPOS="1240" VPOS="5965" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1456" VPOS="5958" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="50" HPOS="1456" VPOS="5958" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1535" VPOS="5968" />
+            <a:String CONTENT="perdiciÃ³n," HEIGHT="49" WIDTH="240" HPOS="1535" VPOS="5958" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1803" VPOS="5968" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="26" HPOS="1803" VPOS="5968" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1857" VPOS="5969" />
+            <a:String CONTENT="permitiÃ³" HEIGHT="49" WIDTH="206" HPOS="1857" VPOS="5958" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0099" WIDTH="822" HEIGHT="50" HPOS="1241" VPOS="6010">
+            <a:String CONTENT="ra" HEIGHT="28" WIDTH="46" HPOS="1241" VPOS="6020" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="1320" VPOS="6010" />
+            <a:String CONTENT="iniciar" HEIGHT="38" WIDTH="150" HPOS="1320" VPOS="6010" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1500" VPOS="6021" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="37" HPOS="1500" VPOS="6011" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1567" VPOS="6011" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="1567" VPOS="6011" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1649" VPOS="6020" />
+            <a:String CONTENT="salud." HEIGHT="40" WIDTH="131" HPOS="1649" VPOS="6011" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1808" VPOS="6012" />
+            <a:String CONTENT="Ello" HEIGHT="39" WIDTH="92" HPOS="1808" VPOS="6011" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="1934" VPOS="6022" />
+            <a:String CONTENT="signiÂ¬" HEIGHT="48" WIDTH="129" HPOS="1934" VPOS="6012" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="significarÃ­a" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0100" WIDTH="819" HEIGHT="47" HPOS="1244" VPOS="6064">
+            <a:String CONTENT="ficarÃ­a" HEIGHT="38" WIDTH="160" HPOS="1244" VPOS="6064" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="43" HPOS="1447" VPOS="6074" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="82" HPOS="1447" VPOS="6074" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="1571" VPOS="6075" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="39" HPOS="1571" VPOS="6065" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="1651" VPOS="6075" />
+            <a:String CONTENT="mal" HEIGHT="37" WIDTH="87" HPOS="1651" VPOS="6066" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="47" HPOS="1785" VPOS="6066" />
+            <a:String CONTENT="&quot;habÃ­a" HEIGHT="41" WIDTH="159" HPOS="1785" VPOS="6065" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="1986" VPOS="6068" />
+            <a:String CONTENT="heÂ¬" HEIGHT="36" WIDTH="77" HPOS="1986" VPOS="6068" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="hecho" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0101" WIDTH="823" HEIGHT="45" HPOS="1242" VPOS="6118">
+            <a:String CONTENT="cho" HEIGHT="36" WIDTH="82" HPOS="1242" VPOS="6120" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="32" HPOS="1356" VPOS="6128" />
+            <a:String CONTENT="crisis&quot;" HEIGHT="38" WIDTH="158" HPOS="1356" VPOS="6118" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="1558" VPOS="6119" />
+            <a:String CONTENT="(tras" HEIGHT="44" WIDTH="114" HPOS="1558" VPOS="6119" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1703" VPOS="6121" />
+            <a:String CONTENT="tantas" HEIGHT="37" WIDTH="154" HPOS="1703" VPOS="6120" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1889" VPOS="6131" />
+            <a:String CONTENT="alterna" HEIGHT="39" WIDTH="176" HPOS="1889" VPOS="6120" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0102" WIDTH="818" HEIGHT="49" HPOS="1244" VPOS="6171">
+            <a:String CONTENT="tivas" HEIGHT="37" WIDTH="115" HPOS="1244" VPOS="6172" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1394" VPOS="6171" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="1394" VPOS="6171" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="1478" VPOS="6182" />
+            <a:String CONTENT="crisis)" HEIGHT="46" WIDTH="154" HPOS="1478" VPOS="6172" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="1674" VPOS="6184" />
+            <a:String CONTENT="y" HEIGHT="36" WIDTH="25" HPOS="1674" VPOS="6184" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="1732" VPOS="6183" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="82" HPOS="1732" VPOS="6183" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="1850" VPOS="6193" />
+            <a:String CONTENT="se" HEIGHT="31" WIDTH="48" HPOS="1850" VPOS="6188" WC="0.79" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="1932" VPOS="6173" />
+            <a:String CONTENT="habÃ­a" HEIGHT="38" WIDTH="130" HPOS="1932" VPOS="6173" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0103" WIDTH="822" HEIGHT="46" HPOS="1243" VPOS="6224">
+            <a:String CONTENT="evitado" HEIGHT="39" WIDTH="163" HPOS="1243" VPOS="6224" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="1440" VPOS="6225" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="39" HPOS="1440" VPOS="6225" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1511" VPOS="6235" />
+            <a:String CONTENT="recaÃ­da;" HEIGHT="45" WIDTH="184" HPOS="1511" VPOS="6225" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="1728" VPOS="6226" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="39" HPOS="1728" VPOS="6226" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="1803" VPOS="6225" />
+            <a:String CONTENT="&quot;reincidenÂ¬" HEIGHT="40" WIDTH="262" HPOS="1803" VPOS="6225" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="&quot;reincidencia&quot;" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0104" WIDTH="822" HEIGHT="49" HPOS="1242" VPOS="6277">
+            <a:String CONTENT="cia&quot;" HEIGHT="40" WIDTH="93" HPOS="1242" VPOS="6277" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="43" HPOS="1378" VPOS="6289" />
+            <a:String CONTENT="al" HEIGHT="37" WIDTH="39" HPOS="1378" VPOS="6280" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="53" HPOS="1470" VPOS="6289" />
+            <a:String CONTENT="palÃºdico" HEIGHT="47" WIDTH="206" HPOS="1470" VPOS="6279" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="53" HPOS="1729" VPOS="6290" />
+            <a:String CONTENT="estado" HEIGHT="38" WIDTH="156" HPOS="1729" VPOS="6281" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="56" HPOS="1941" VPOS="6291" />
+            <a:String CONTENT="anteÂ¬" HEIGHT="38" WIDTH="123" HPOS="1941" VPOS="6280" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="anterior," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0105" WIDTH="821" HEIGHT="49" HPOS="1243" VPOS="6333">
+            <a:String CONTENT="rior," HEIGHT="48" WIDTH="104" HPOS="1243" VPOS="6334" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="37" HPOS="1384" VPOS="6345" />
+            <a:String CONTENT="al" HEIGHT="39" WIDTH="39" HPOS="1384" VPOS="6333" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="1459" VPOS="6334" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="49" HPOS="1459" VPOS="6334" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="1544" VPOS="6343" />
+            <a:String CONTENT="estancamiento" HEIGHT="39" WIDTH="358" HPOS="1544" VPOS="6334" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="1938" VPOS="6346" />
+            <a:String CONTENT="en" HEIGHT="30" WIDTH="54" HPOS="1938" VPOS="6344" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2026" VPOS="6348" />
+            <a:String CONTENT="el" HEIGHT="44" WIDTH="38" HPOS="2026" VPOS="6333" WC="0.8" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0106" WIDTH="822" HEIGHT="47" HPOS="1242" VPOS="6387">
+            <a:String CONTENT="pantano," HEIGHT="46" WIDTH="209" HPOS="1242" VPOS="6387" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1476" VPOS="6397" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="83" HPOS="1476" VPOS="6397" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1583" VPOS="6397" />
+            <a:String CONTENT="serÃ­a" HEIGHT="38" WIDTH="120" HPOS="1583" VPOS="6387" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="1725" VPOS="6388" />
+            <a:String CONTENT="definitivamen" HEIGHT="38" WIDTH="339" HPOS="1725" VPOS="6388" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0107" WIDTH="248" HEIGHT="38" HPOS="1245" VPOS="6439">
+            <a:String CONTENT="te" HEIGHT="37" WIDTH="43" HPOS="1245" VPOS="6440" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1317" VPOS="6450" />
+            <a:String CONTENT="mortal." HEIGHT="38" WIDTH="176" HPOS="1317" VPOS="6439" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0028" HEIGHT="953" WIDTH="831" HPOS="1244" VPOS="6494" STYLEREFS="PARSTYLE0013">
+          <a:TextLine ID="PAG001LIN0108" WIDTH="771" HEIGHT="47" HPOS="1296" VPOS="6494">
+            <a:String CONTENT="Lo" HEIGHT="37" WIDTH="60" HPOS="1296" VPOS="6494" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1380" VPOS="6495" />
+            <a:String CONTENT="fracasado" HEIGHT="38" WIDTH="238" HPOS="1380" VPOS="6495" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="1641" VPOS="6505" />
+            <a:String CONTENT="es" HEIGHT="36" WIDTH="47" HPOS="1641" VPOS="6505" WC="0.64" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1712" VPOS="6506" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="38" HPOS="1712" VPOS="6495" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1775" VPOS="6505" />
+            <a:String CONTENT="sistema" HEIGHT="40" WIDTH="190" HPOS="1775" VPOS="6495" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="1988" VPOS="6505" />
+            <a:String CONTENT="cen" HEIGHT="29" WIDTH="79" HPOS="1988" VPOS="6504" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0109" WIDTH="825" HEIGHT="51" HPOS="1244" VPOS="6545">
+            <a:String CONTENT="tralizador," HEIGHT="48" WIDTH="252" HPOS="1244" VPOS="6545" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1521" VPOS="6558" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="40" HPOS="1521" VPOS="6549" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="1583" VPOS="6558" />
+            <a:String CONTENT="rÃ©gimen" HEIGHT="48" WIDTH="201" HPOS="1583" VPOS="6548" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="1807" VPOS="6550" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="1807" VPOS="6550" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1885" VPOS="6550" />
+            <a:String CONTENT="imposiÂ¬" HEIGHT="49" WIDTH="184" HPOS="1885" VPOS="6547" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="impositiva" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0110" WIDTH="822" HEIGHT="43" HPOS="1245" VPOS="6600">
+            <a:String CONTENT="tiva" HEIGHT="41" WIDTH="89" HPOS="1245" VPOS="6600" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="1365" VPOS="6601" />
+            <a:String CONTENT="fuerza" HEIGHT="38" WIDTH="153" HPOS="1365" VPOS="6601" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="1" HPOS="1519" VPOS="6625" />
+            <a:String CONTENT="â€”" HEIGHT="8" WIDTH="54" HPOS="1519" VPOS="6625" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="1" HPOS="1574" VPOS="6602" />
+            <a:String CONTENT="falsamente" HEIGHT="41" WIDTH="272" HPOS="1574" VPOS="6602" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1878" VPOS="6603" />
+            <a:String CONTENT="titulado" HEIGHT="40" WIDTH="189" HPOS="1878" VPOS="6601" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0111" WIDTH="823" HEIGHT="50" HPOS="1246" VPOS="6653">
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="1246" VPOS="6653" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="1335" VPOS="6653" />
+            <a:String CONTENT="libertad" HEIGHT="39" WIDTH="188" HPOS="1335" VPOS="6653" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="1" HPOS="1524" VPOS="6678" />
+            <a:String CONTENT="â€”" HEIGHT="7" WIDTH="54" HPOS="1524" VPOS="6678" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="1580" VPOS="6666" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="82" HPOS="1580" VPOS="6666" WC="0.82" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="1701" VPOS="6667" />
+            <a:String CONTENT="mantiene" HEIGHT="37" WIDTH="227" HPOS="1701" VPOS="6657" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="1966" VPOS="6657" />
+            <a:String CONTENT="toda" HEIGHT="38" WIDTH="103" HPOS="1966" VPOS="6656" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0112" WIDTH="821" HEIGHT="50" HPOS="1246" VPOS="6707">
+            <a:String CONTENT="una" HEIGHT="28" WIDTH="90" HPOS="1246" VPOS="6716" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="1369" VPOS="6717" />
+            <a:String CONTENT="yida" HEIGHT="43" WIDTH="99" HPOS="1369" VPOS="6707" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1503" VPOS="6719" />
+            <a:String CONTENT="convencional" HEIGHT="39" WIDTH="319" HPOS="1503" VPOS="6709" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1857" VPOS="6719" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="27" HPOS="1857" VPOS="6719" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="1918" VPOS="6719" />
+            <a:String CONTENT="artifiÂ¬" HEIGHT="40" WIDTH="149" HPOS="1918" VPOS="6707" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="artificiosa." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0113" WIDTH="822" HEIGHT="57" HPOS="1248" VPOS="6759">
+            <a:String CONTENT="ciosa." HEIGHT="41" WIDTH="138" HPOS="1248" VPOS="6759" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="24" HPOS="1410" VPOS="6761" />
+            <a:String CONTENT="Es" HEIGHT="38" WIDTH="61" HPOS="1410" VPOS="6761" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1497" VPOS="6771" />
+            <a:String CONTENT="mÃ¡s" HEIGHT="38" WIDTH="98" HPOS="1497" VPOS="6762" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1623" VPOS="6763" />
+            <a:String CONTENT="triste," HEIGHT="53" WIDTH="144" HPOS="1623" VPOS="6763" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1793" VPOS="6772" />
+            <a:String CONTENT="es" HEIGHT="29" WIDTH="48" HPOS="1793" VPOS="6772" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1870" VPOS="6772" />
+            <a:String CONTENT="mÃ¡s" HEIGHT="39" WIDTH="97" HPOS="1870" VPOS="6761" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1995" VPOS="6763" />
+            <a:String CONTENT="daÂ¬" HEIGHT="38" WIDTH="75" HPOS="1995" VPOS="6763" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="daÃ±oso," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0114" WIDTH="822" HEIGHT="51" HPOS="1247" VPOS="6814">
+            <a:String CONTENT="Ã±oso," HEIGHT="45" WIDTH="126" HPOS="1247" VPOS="6814" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="26" HPOS="1399" VPOS="6824" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="82" HPOS="1399" VPOS="6824" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1505" VPOS="6827" />
+            <a:String CONTENT="no" HEIGHT="29" WIDTH="59" HPOS="1505" VPOS="6827" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1588" VPOS="6828" />
+            <a:String CONTENT="pueda" HEIGHT="48" WIDTH="144" HPOS="1588" VPOS="6817" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="1753" VPOS="6828" />
+            <a:String CONTENT="vivir" HEIGHT="38" WIDTH="115" HPOS="1753" VPOS="6817" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="1892" VPOS="6815" />
+            <a:String CONTENT="la" HEIGHT="46" WIDTH="44" HPOS="1892" VPOS="6815" WC="0.75" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1961" VPOS="6825" />
+            <a:String CONTENT="suya" HEIGHT="39" WIDTH="108" HPOS="1961" VPOS="6824" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0115" WIDTH="826" HEIGHT="46" HPOS="1247" VPOS="6868">
+            <a:String CONTENT="regiÃ³n" HEIGHT="46" WIDTH="158" HPOS="1247" VPOS="6868" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="1439" VPOS="6880" />
+            <a:String CONTENT="como" HEIGHT="29" WIDTH="126" HPOS="1439" VPOS="6879" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="1602" VPOS="6870" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="41" HPOS="1602" VPOS="6870" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="1680" VPOS="6879" />
+            <a:String CONTENT="nuestra" HEIGHT="38" WIDTH="188" HPOS="1680" VPOS="6870" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="1905" VPOS="6870" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="1905" VPOS="6870" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="1994" VPOS="6870" />
+            <a:String CONTENT="taiÂ»" HEIGHT="40" WIDTH="79" HPOS="1994" VPOS="6870" WC="0.93" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0116" WIDTH="822" HEIGHT="49" HPOS="1250" VPOS="6922">
+            <a:String CONTENT="original" HEIGHT="46" WIDTH="190" HPOS="1250" VPOS="6922" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1470" VPOS="6934" />
+            <a:String CONTENT="carÃ¡cter" HEIGHT="39" WIDTH="202" HPOS="1470" VPOS="6923" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1701" VPOS="6935" />
+            <a:String CONTENT="propio." HEIGHT="47" WIDTH="173" HPOS="1701" VPOS="6924" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1900" VPOS="6924" />
+            <a:String CONTENT="La" HEIGHT="37" WIDTH="64" HPOS="1900" VPOS="6924" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1992" VPOS="6933" />
+            <a:String CONTENT="cen" HEIGHT="30" WIDTH="80" HPOS="1992" VPOS="6932" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0117" WIDTH="822" HEIGHT="54" HPOS="1251" VPOS="6973">
+            <a:String CONTENT="tralizaciÃ³n" HEIGHT="43" WIDTH="262" HPOS="1251" VPOS="6973" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="1557" VPOS="6988" />
+            <a:String CONTENT="sobreponiÃ©ndose," HEIGHT="51" WIDTH="424" HPOS="1557" VPOS="6976" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="2025" VPOS="6987" />
+            <a:String CONTENT="es" HEIGHT="30" WIDTH="48" HPOS="2025" VPOS="6985" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0118" WIDTH="822" HEIGHT="51" HPOS="1250" VPOS="7027">
+            <a:String CONTENT="mÃ¡s" HEIGHT="38" WIDTH="97" HPOS="1250" VPOS="7027" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1379" VPOS="7039" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="83" HPOS="1379" VPOS="7039" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1491" VPOS="7040" />
+            <a:String CONTENT="por" HEIGHT="38" WIDTH="82" HPOS="1491" VPOS="7040" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1602" VPOS="7041" />
+            <a:String CONTENT="esto" HEIGHT="37" WIDTH="100" HPOS="1602" VPOS="7032" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1729" VPOS="7040" />
+            <a:String CONTENT="nociva" HEIGHT="39" WIDTH="160" HPOS="1729" VPOS="7030" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1918" VPOS="7040" />
+            <a:String CONTENT="por" HEIGHT="38" WIDTH="84" HPOS="1918" VPOS="7039" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2030" VPOS="7030" />
+            <a:String CONTENT="lo" HEIGHT="38" WIDTH="42" HPOS="2030" VPOS="7030" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0119" WIDTH="820" HEIGHT="49" HPOS="1252" VPOS="7082">
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="82" HPOS="1252" VPOS="7090" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1369" VPOS="7093" />
+            <a:String CONTENT="agosta," HEIGHT="46" WIDTH="172" HPOS="1369" VPOS="7083" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="1572" VPOS="7094" />
+            <a:String CONTENT="por" HEIGHT="37" WIDTH="82" HPOS="1572" VPOS="7094" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1686" VPOS="7085" />
+            <a:String CONTENT="lo" HEIGHT="37" WIDTH="41" HPOS="1686" VPOS="7085" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="1760" VPOS="7094" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="84" HPOS="1760" VPOS="7094" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="1878" VPOS="7093" />
+            <a:String CONTENT="exterill-" HEIGHT="38" WIDTH="194" HPOS="1878" VPOS="7082" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="exterillza;" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0120" WIDTH="824" HEIGHT="49" HPOS="1250" VPOS="7135">
+            <a:String CONTENT="za;" HEIGHT="35" WIDTH="64" HPOS="1250" VPOS="7144" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="55" HPOS="1369" VPOS="7145" />
+            <a:String CONTENT="ahogados" HEIGHT="49" WIDTH="206" HPOS="1369" VPOS="7135" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="59" HPOS="1634" VPOS="7138" />
+            <a:String CONTENT="los" HEIGHT="37" WIDTH="61" HPOS="1634" VPOS="7138" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="60" HPOS="1755" VPOS="7146" />
+            <a:String CONTENT="raros" HEIGHT="30" WIDTH="118" HPOS="1755" VPOS="7145" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="61" HPOS="1934" VPOS="7136" />
+            <a:String CONTENT="brotes" HEIGHT="38" WIDTH="140" HPOS="1934" VPOS="7135" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0121" WIDTH="819" HEIGHT="39" HPOS="1254" VPOS="7190">
+            <a:String CONTENT="en" HEIGHT="27" WIDTH="52" HPOS="1254" VPOS="7199" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1341" VPOS="7199" />
+            <a:String CONTENT="su" HEIGHT="28" WIDTH="52" HPOS="1341" VPOS="7199" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="1426" VPOS="7201" />
+            <a:String CONTENT="mismo" HEIGHT="37" WIDTH="161" HPOS="1426" VPOS="7192" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="1621" VPOS="7202" />
+            <a:String CONTENT="nacimiento." HEIGHT="39" WIDTH="286" HPOS="1621" VPOS="7190" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1939" VPOS="7190" />
+            <a:String CONTENT="A" HEIGHT="36" WIDTH="35" HPOS="1939" VPOS="7190" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2007" VPOS="7190" />
+            <a:String CONTENT="los" HEIGHT="36" WIDTH="66" HPOS="2007" VPOS="7190" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0122" WIDTH="818" HEIGHT="53" HPOS="1253" VPOS="7242">
+            <a:String CONTENT="gÃ©rmenes" HEIGHT="50" WIDTH="231" HPOS="1253" VPOS="7242" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1511" VPOS="7255" />
+            <a:String CONTENT="no" HEIGHT="29" WIDTH="59" HPOS="1511" VPOS="7255" WC="0.78" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1598" VPOS="7245" />
+            <a:String CONTENT="Hega," HEIGHT="50" WIDTH="128" HPOS="1598" VPOS="7245" WC="0.78" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1754" VPOS="7255" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="83" HPOS="1754" VPOS="7254" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1865" VPOS="7254" />
+            <a:String CONTENT="estÃ¡n" HEIGHT="37" WIDTH="130" HPOS="1865" VPOS="7244" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2021" VPOS="7252" />
+            <a:String CONTENT="en" HEIGHT="27" WIDTH="50" HPOS="2021" VPOS="7252" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0123" WIDTH="821" HEIGHT="50" HPOS="1253" VPOS="7295">
+            <a:String CONTENT="las" HEIGHT="39" WIDTH="67" HPOS="1253" VPOS="7295" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="1347" VPOS="7307" />
+            <a:String CONTENT="almas" HEIGHT="40" WIDTH="141" HPOS="1347" VPOS="7296" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1513" VPOS="7308" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="27" HPOS="1513" VPOS="7308" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="1565" VPOS="7308" />
+            <a:String CONTENT="son" HEIGHT="29" WIDTH="80" HPOS="1565" VPOS="7308" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1673" VPOS="7312" />
+            <a:String CONTENT="esperanza" HEIGHT="39" WIDTH="245" HPOS="1673" VPOS="7306" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1944" VPOS="7306" />
+            <a:String CONTENT="seguÂ¬" HEIGHT="37" WIDTH="130" HPOS="1944" VPOS="7305" WC="0.94" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="segura" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0124" WIDTH="822" HEIGHT="46" HPOS="1251" VPOS="7348">
+            <a:String CONTENT="ra" HEIGHT="32" WIDTH="52" HPOS="1251" VPOS="7359" WC="0.94" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="26" HPOS="1329" VPOS="7350" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="50" HPOS="1329" VPOS="7350" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1405" VPOS="7361" />
+            <a:String CONTENT="un" HEIGHT="28" WIDTH="61" HPOS="1405" VPOS="7361" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="1492" VPOS="7353" />
+            <a:String CONTENT="futuro" HEIGHT="38" WIDTH="154" HPOS="1492" VPOS="7353" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="1675" VPOS="7364" />
+            <a:String CONTENT="cierto," HEIGHT="42" WIDTH="149" HPOS="1675" VPOS="7352" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1854" VPOS="7351" />
+            <a:String CONTENT="beneficio" HEIGHT="40" WIDTH="219" HPOS="1854" VPOS="7348" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0125" WIDTH="816" HEIGHT="44" HPOS="1254" VPOS="7402">
+            <a:String CONTENT="sÃ¡mente" HEIGHT="41" WIDTH="201" HPOS="1254" VPOS="7405" WC="0.86" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="1483" VPOS="7405" />
+            <a:String CONTENT="fecundÃ©'" HEIGHT="38" WIDTH="187" HPOS="1483" VPOS="7405" WC="0.67" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="1702" VPOS="7417" />
+            <a:String CONTENT="?;" HEIGHT="32" WIDTH="33" HPOS="1702" VPOS="7408" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="1765" VPOS="7418" />
+            <a:String CONTENT="on" HEIGHT="27" WIDTH="47" HPOS="1765" VPOS="7416" WC="0.93" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="1847" VPOS="7415" />
+            <a:String CONTENT="verdad" HEIGHT="39" WIDTH="158" HPOS="1847" VPOS="7402" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2034" VPOS="7402" />
+            <a:String CONTENT="la" HEIGHT="36" WIDTH="36" HPOS="2034" VPOS="7402" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:ComposedBlock ID="PAG001BLK0029" HEIGHT="5989" WIDTH="883" HPOS="2112" VPOS="1464" />
+        <a:TextBlock ID="PAG001BLK0030" HEIGHT="2367" WIDTH="847" HPOS="2115" VPOS="1475" STYLEREFS="PARSTYLE0014">
+          <a:TextLine ID="PAG001LIN0126" WIDTH="829" HEIGHT="44" HPOS="2115" VPOS="1475">
+            <a:String CONTENT="expansiÃ³n" HEIGHT="44" WIDTH="246" HPOS="2115" VPOS="1475" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2393" VPOS="1487" />
+            <a:String CONTENT="no" HEIGHT="27" WIDTH="58" HPOS="2393" VPOS="1487" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2485" VPOS="1478" />
+            <a:String CONTENT="halla" HEIGHT="37" WIDTH="122" HPOS="2485" VPOS="1478" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2640" VPOS="1480" />
+            <a:String CONTENT="dificultades." HEIGHT="40" WIDTH="304" HPOS="2640" VPOS="1477" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0127" WIDTH="831" HEIGHT="53" HPOS="2115" VPOS="1526">
+            <a:String CONTENT="Nunca" HEIGHT="39" WIDTH="154" HPOS="2115" VPOS="1526" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2296" VPOS="1528" />
+            <a:String CONTENT="faltarÃ¡n" HEIGHT="39" WIDTH="201" HPOS="2296" VPOS="1528" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2527" VPOS="1541" />
+            <a:String CONTENT="quienes" HEIGHT="45" WIDTH="188" HPOS="2527" VPOS="1532" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2744" VPOS="1532" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="69" HPOS="2744" VPOS="1532" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2841" VPOS="1541" />
+            <a:String CONTENT="proÂ¬" HEIGHT="40" WIDTH="105" HPOS="2841" VPOS="1539" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="procuren" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0128" WIDTH="830" HEIGHT="50" HPOS="2117" VPOS="1583">
+            <a:String CONTENT="curen" HEIGHT="29" WIDTH="137" HPOS="2117" VPOS="1590" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="33" HPOS="2287" VPOS="1594" />
+            <a:String CONTENT="poniendo" HEIGHT="48" WIDTH="223" HPOS="2287" VPOS="1583" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2546" VPOS="1585" />
+            <a:String CONTENT="trabas;" HEIGHT="46" WIDTH="179" HPOS="2546" VPOS="1585" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2760" VPOS="1596" />
+            <a:String CONTENT="preten-:" HEIGHT="46" WIDTH="187" HPOS="2760" VPOS="1587" WC="0.87" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0129" WIDTH="830" HEIGHT="54" HPOS="2117" VPOS="1634">
+            <a:String CONTENT="diendo" HEIGHT="38" WIDTH="158" HPOS="2117" VPOS="1634" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2300" VPOS="1645" />
+            <a:String CONTENT="servir," HEIGHT="46" WIDTH="156" HPOS="2300" VPOS="1636" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2479" VPOS="1638" />
+            <a:String CONTENT="han" HEIGHT="36" WIDTH="91" HPOS="2479" VPOS="1638" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="2591" VPOS="1648" />
+            <a:String CONTENT="otros" HEIGHT="39" WIDTH="125" HPOS="2591" VPOS="1638" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2739" VPOS="1639" />
+            <a:String CONTENT="de" HEIGHT="40" WIDTH="53" HPOS="2739" VPOS="1639" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="21" HPOS="2813" VPOS="1648" />
+            <a:String CONTENT="perju" HEIGHT="50" WIDTH="134" HPOS="2813" VPOS="1638" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0130" WIDTH="831" HEIGHT="52" HPOS="2118" VPOS="1689">
+            <a:String CONTENT="dicar" HEIGHT="38" WIDTH="122" HPOS="2118" VPOS="1689" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2272" VPOS="1700" />
+            <a:String CONTENT="con" HEIGHT="29" WIDTH="85" HPOS="2272" VPOS="1699" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2388" VPOS="1700" />
+            <a:String CONTENT="engaÃ±os," HEIGHT="46" WIDTH="218" HPOS="2388" VPOS="1692" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2638" VPOS="1703" />
+            <a:String CONTENT="con" HEIGHT="31" WIDTH="85" HPOS="2638" VPOS="1701" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2753" VPOS="1704" />
+            <a:String CONTENT="precipiÂ¬" HEIGHT="48" WIDTH="196" HPOS="2753" VPOS="1693" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="precipitaciones," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0131" WIDTH="831" HEIGHT="53" HPOS="2118" VPOS="1742">
+            <a:String CONTENT="taciones," HEIGHT="49" WIDTH="215" HPOS="2118" VPOS="1742" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="28" HPOS="2361" VPOS="1753" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="84" HPOS="2361" VPOS="1753" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2472" VPOS="1745" />
+            <a:String CONTENT="desvÃ­an" HEIGHT="41" WIDTH="189" HPOS="2472" VPOS="1745" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2685" VPOS="1756" />
+            <a:String CONTENT="o" HEIGHT="29" WIDTH="26" HPOS="2685" VPOS="1756" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2737" VPOS="1757" />
+            <a:String CONTENT="compro?!" HEIGHT="40" WIDTH="212" HPOS="2737" VPOS="1755" WC="0.73" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0132" WIDTH="830" HEIGHT="49" HPOS="2119" VPOS="1797">
+            <a:String CONTENT="meten." HEIGHT="38" WIDTH="162" HPOS="2119" VPOS="1797" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2314" VPOS="1798" />
+            <a:String CONTENT="No" HEIGHT="38" WIDTH="63" HPOS="2314" VPOS="1798" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2411" VPOS="1807" />
+            <a:String CONTENT="se" HEIGHT="28" WIDTH="48" HPOS="2411" VPOS="1807" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2493" VPOS="1798" />
+            <a:String CONTENT="improvisa" HEIGHT="48" WIDTH="247" HPOS="2493" VPOS="1798" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2772" VPOS="1801" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="44" HPOS="2772" VPOS="1801" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2846" VPOS="1812" />
+            <a:String CONTENT="vida" HEIGHT="43" WIDTH="103" HPOS="2846" VPOS="1800" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0133" WIDTH="827" HEIGHT="49" HPOS="2121" VPOS="1850">
+            <a:String CONTENT="local," HEIGHT="45" WIDTH="127" HPOS="2121" VPOS="1851" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2277" VPOS="1851" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="2277" VPOS="1851" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2355" VPOS="1850" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="44" HPOS="2355" VPOS="1850" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2426" VPOS="1861" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="85" HPOS="2426" VPOS="1861" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2538" VPOS="1852" />
+            <a:String CONTENT="han" HEIGHT="38" WIDTH="92" HPOS="2538" VPOS="1852" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2656" VPOS="1853" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="2656" VPOS="1853" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="2736" VPOS="1863" />
+            <a:String CONTENT="ser," HEIGHT="34" WIDTH="77" HPOS="2736" VPOS="1863" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2838" VPOS="1864" />
+            <a:String CONTENT="con-;" HEIGHT="30" WIDTH="110" HPOS="2838" VPOS="1863" WC="0.81" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0134" WIDTH="830" HEIGHT="51" HPOS="2120" VPOS="1904">
+            <a:String CONTENT="tinuaciÃ³n," HEIGHT="51" WIDTH="244" HPOS="2120" VPOS="1904" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2394" VPOS="1915" />
+            <a:String CONTENT="recibiendo" HEIGHT="42" WIDTH="256" HPOS="2394" VPOS="1906" WC="0.9" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2676" VPOS="1917" />
+            <a:String CONTENT="vital" HEIGHT="40" WIDTH="113" HPOS="2676" VPOS="1907" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2818" VPOS="1913" />
+            <a:String CONTENT="Ã©senr" HEIGHT="33" WIDTH="132" HPOS="2818" VPOS="1913" WC="0.76" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0135" WIDTH="830" HEIGHT="49" HPOS="2119" VPOS="1958">
+            <a:String CONTENT="cia" HEIGHT="37" WIDTH="69" HPOS="2119" VPOS="1960" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="2210" VPOS="1969" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="26" HPOS="2210" VPOS="1969" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2260" VPOS="1968" />
+            <a:String CONTENT="por" HEIGHT="39" WIDTH="82" HPOS="2260" VPOS="1968" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2366" VPOS="1969" />
+            <a:String CONTENT="ella" HEIGHT="42" WIDTH="87" HPOS="2366" VPOS="1958" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2476" VPOS="1960" />
+            <a:String CONTENT="tomando" HEIGHT="43" WIDTH="214" HPOS="2476" VPOS="1960" WC="0.9" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2715" VPOS="1960" />
+            <a:String CONTENT="forma," HEIGHT="47" WIDTH="164" HPOS="2715" VPOS="1960" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2902" VPOS="1962" />
+            <a:String CONTENT="to" HEIGHT="38" WIDTH="47" HPOS="2902" VPOS="1962" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0136" WIDTH="833" HEIGHT="51" HPOS="2119" VPOS="2012">
+            <a:String CONTENT="das" HEIGHT="37" WIDTH="79" HPOS="2119" VPOS="2013" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2234" VPOS="2012" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="68" HPOS="2234" VPOS="2012" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2337" VPOS="2022" />
+            <a:String CONTENT="organizaciones" HEIGHT="47" WIDTH="372" HPOS="2337" VPOS="2013" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2744" VPOS="2023" />
+            <a:String CONTENT="superioÂ¬" HEIGHT="48" WIDTH="208" HPOS="2744" VPOS="2015" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="superiores." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0137" WIDTH="831" HEIGHT="48" HPOS="2120" VPOS="2066">
+            <a:String CONTENT="res." HEIGHT="28" WIDTH="87" HPOS="2120" VPOS="2076" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="30" HPOS="2237" VPOS="2066" />
+            <a:String CONTENT="Antes" HEIGHT="38" WIDTH="138" HPOS="2237" VPOS="2066" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2408" VPOS="2076" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="83" HPOS="2408" VPOS="2076" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2521" VPOS="2077" />
+            <a:String CONTENT="ningunas" HEIGHT="48" WIDTH="232" HPOS="2521" VPOS="2066" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2785" VPOS="2069" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="69" HPOS="2785" VPOS="2069" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2884" VPOS="2069" />
+            <a:String CONTENT="loÂ¬" HEIGHT="39" WIDTH="67" HPOS="2884" VPOS="2069" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="locales," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0138" WIDTH="829" HEIGHT="54" HPOS="2122" VPOS="2120">
+            <a:String CONTENT="cales," HEIGHT="54" WIDTH="133" HPOS="2122" VPOS="2120" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="39" HPOS="2294" VPOS="2120" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="67" HPOS="2294" VPOS="2120" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2401" VPOS="2130" />
+            <a:String CONTENT="originarias" HEIGHT="48" WIDTH="274" HPOS="2401" VPOS="2120" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2712" VPOS="2132" />
+            <a:String CONTENT="necesitan" HEIGHT="42" WIDTH="239" HPOS="2712" VPOS="2122" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0139" WIDTH="830" HEIGHT="53" HPOS="2123" VPOS="2172">
+            <a:String CONTENT="adquirir" HEIGHT="50" WIDTH="200" HPOS="2123" VPOS="2172" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2358" VPOS="2174" />
+            <a:String CONTENT="firme" HEIGHT="44" WIDTH="133" HPOS="2358" VPOS="2174" WC="0.71" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2527" VPOS="2185" />
+            <a:String CONTENT="consistencia" HEIGHT="41" WIDTH="307" HPOS="2527" VPOS="2175" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2869" VPOS="2186" />
+            <a:String CONTENT="paÂ«" HEIGHT="39" WIDTH="84" HPOS="2869" VPOS="2186" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0140" WIDTH="830" HEIGHT="50" HPOS="2122" VPOS="2227">
+            <a:String CONTENT="ra" HEIGHT="28" WIDTH="48" HPOS="2122" VPOS="2237" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2210" VPOS="2237" />
+            <a:String CONTENT="ser" HEIGHT="28" WIDTH="71" HPOS="2210" VPOS="2237" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2322" VPOS="2237" />
+            <a:String CONTENT="por" HEIGHT="38" WIDTH="80" HPOS="2322" VPOS="2237" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2441" VPOS="2237" />
+            <a:String CONTENT="sÃ­" HEIGHT="39" WIDTH="39" HPOS="2441" VPOS="2227" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="2523" VPOS="2236" />
+            <a:String CONTENT="mismas," HEIGHT="48" WIDTH="185" HPOS="2523" VPOS="2227" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="2750" VPOS="2238" />
+            <a:String CONTENT="para" HEIGHT="39" WIDTH="107" HPOS="2750" VPOS="2238" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2898" VPOS="2240" />
+            <a:String CONTENT="no" HEIGHT="30" WIDTH="54" HPOS="2898" VPOS="2238" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0141" WIDTH="829" HEIGHT="50" HPOS="2124" VPOS="2281">
+            <a:String CONTENT="estar" HEIGHT="39" WIDTH="123" HPOS="2124" VPOS="2282" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2277" VPOS="2297" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="25" HPOS="2277" VPOS="2297" WC="0.93" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2329" VPOS="2292" />
+            <a:String CONTENT="merced" HEIGHT="39" WIDTH="177" HPOS="2329" VPOS="2282" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2532" VPOS="2281" />
+            <a:String CONTENT="'de" HEIGHT="41" WIDTH="54" HPOS="2532" VPOS="2281" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2617" VPOS="2293" />
+            <a:String CONTENT="cualquier" HEIGHT="48" WIDTH="234" HPOS="2617" VPOS="2283" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2879" VPOS="2293" />
+            <a:String CONTENT="gol" HEIGHT="46" WIDTH="74" HPOS="2879" VPOS="2285" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0142" WIDTH="828" HEIGHT="49" HPOS="2124" VPOS="2336">
+            <a:String CONTENT="pe" HEIGHT="38" WIDTH="51" HPOS="2124" VPOS="2346" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2206" VPOS="2336" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="2206" VPOS="2336" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2283" VPOS="2346" />
+            <a:String CONTENT="viento." HEIGHT="40" WIDTH="170" HPOS="2283" VPOS="2336" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2482" VPOS="2336" />
+            <a:String CONTENT="Mudanzas" HEIGHT="47" WIDTH="243" HPOS="2482" VPOS="2336" WC="0.62" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2757" VPOS="2346" />
+            <a:String CONTENT="siempre" HEIGHT="47" WIDTH="195" HPOS="2757" VPOS="2338" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0143" WIDTH="821" HEIGHT="49" HPOS="2131" VPOS="2388">
+            <a:String CONTENT="peligrosas," HEIGHT="48" WIDTH="264" HPOS="2131" VPOS="2389" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="2438" VPOS="2388" />
+            <a:String CONTENT="de" HEIGHT="40" WIDTH="53" HPOS="2438" VPOS="2388" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="45" HPOS="2536" VPOS="2399" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="84" HPOS="2536" VPOS="2399" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="2662" VPOS="2390" />
+            <a:String CONTENT="Ãºnicamente" HEIGHT="39" WIDTH="290" HPOS="2662" VPOS="2390" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0144" WIDTH="830" HEIGHT="50" HPOS="2125" VPOS="2442">
+            <a:String CONTENT="pasarÃ¡" HEIGHT="50" WIDTH="166" HPOS="2125" VPOS="2442" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2317" VPOS="2453" />
+            <a:String CONTENT="el" HEIGHT="36" WIDTH="40" HPOS="2317" VPOS="2444" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2384" VPOS="2452" />
+            <a:String CONTENT="peligro" HEIGHT="47" WIDTH="174" HPOS="2384" VPOS="2443" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2584" VPOS="2454" />
+            <a:String CONTENT="con" HEIGHT="31" WIDTH="85" HPOS="2584" VPOS="2452" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2696" VPOS="2454" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="40" HPOS="2696" VPOS="2444" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2763" VPOS="2445" />
+            <a:String CONTENT="fortaleÂ¬" HEIGHT="40" WIDTH="192" HPOS="2763" VPOS="2444" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="fortalecimiento" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0145" WIDTH="830" HEIGHT="42" HPOS="2125" VPOS="2497">
+            <a:String CONTENT="cimiento" HEIGHT="39" WIDTH="210" HPOS="2125" VPOS="2497" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="42" HPOS="2377" VPOS="2497" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="2377" VPOS="2497" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2470" VPOS="2498" />
+            <a:String CONTENT="instituciones" HEIGHT="42" WIDTH="321" HPOS="2470" VPOS="2497" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="2833" VPOS="2498" />
+            <a:String CONTENT="locaÂ¬" HEIGHT="40" WIDTH="122" HPOS="2833" VPOS="2498" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="locales" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0146" WIDTH="824" HEIGHT="49" HPOS="2131" VPOS="2550">
+            <a:String CONTENT="les" HEIGHT="38" WIDTH="64" HPOS="2131" VPOS="2550" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="42" HPOS="2237" VPOS="2559" />
+            <a:String CONTENT="que" HEIGHT="40" WIDTH="88" HPOS="2237" VPOS="2559" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2365" VPOS="2560" />
+            <a:String CONTENT="verdaderamente" HEIGHT="39" WIDTH="399" HPOS="2365" VPOS="2550" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="2810" VPOS="2562" />
+            <a:String CONTENT="arraiÂ¬" HEIGHT="37" WIDTH="145" HPOS="2810" VPOS="2554" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="arraiguen" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0147" WIDTH="828" HEIGHT="49" HPOS="2125" VPOS="2603">
+            <a:String CONTENT="guen" HEIGHT="39" WIDTH="118" HPOS="2125" VPOS="2613" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="24" HPOS="2267" VPOS="2614" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="54" HPOS="2267" VPOS="2613" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2344" VPOS="2613" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="40" HPOS="2344" VPOS="2603" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2407" VPOS="2613" />
+            <a:String CONTENT="paÃ­s." HEIGHT="48" WIDTH="115" HPOS="2407" VPOS="2603" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="20" HPOS="2542" VPOS="2605" />
+            <a:String CONTENT="Es" HEIGHT="38" WIDTH="60" HPOS="2542" VPOS="2605" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2627" VPOS="2615" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="56" HPOS="2627" VPOS="2615" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="2704" VPOS="2615" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="40" HPOS="2704" VPOS="2605" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2768" VPOS="2615" />
+            <a:String CONTENT="seno" HEIGHT="30" WIDTH="112" HPOS="2768" VPOS="2615" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="2902" VPOS="2606" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="51" HPOS="2902" VPOS="2606" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0148" WIDTH="831" HEIGHT="52" HPOS="2125" VPOS="2657">
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="43" HPOS="2125" VPOS="2658" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2195" VPOS="2667" />
+            <a:String CONTENT="naturaleza," HEIGHT="52" WIDTH="278" HPOS="2195" VPOS="2657" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2503" VPOS="2658" />
+            <a:String CONTENT="donde" HEIGHT="39" WIDTH="142" HPOS="2503" VPOS="2658" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2674" VPOS="2660" />
+            <a:String CONTENT="lia" HEIGHT="39" WIDTH="59" HPOS="2674" VPOS="2658" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2759" VPOS="2659" />
+            <a:String CONTENT="'de" HEIGHT="44" WIDTH="56" HPOS="2759" VPOS="2659" WC="0.82" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2843" VPOS="2660" />
+            <a:String CONTENT="bus-," HEIGHT="39" WIDTH="113" HPOS="2843" VPOS="2660" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0149" WIDTH="830" HEIGHT="48" HPOS="2126" VPOS="2712">
+            <a:String CONTENT="carso" HEIGHT="30" WIDTH="128" HPOS="2126" VPOS="2720" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2285" VPOS="2721" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="25" HPOS="2285" VPOS="2721" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2341" VPOS="2712" />
+            <a:String CONTENT="los" HEIGHT="37" WIDTH="67" HPOS="2341" VPOS="2712" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2438" VPOS="2722" />
+            <a:String CONTENT="naturales," HEIGHT="48" WIDTH="251" HPOS="2438" VPOS="2712" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2719" VPOS="2722" />
+            <a:String CONTENT="extendida" HEIGHT="40" WIDTH="237" HPOS="2719" VPOS="2712" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0150" WIDTH="828" HEIGHT="51" HPOS="2127" VPOS="2764">
+            <a:String CONTENT="al" HEIGHT="38" WIDTH="43" HPOS="2127" VPOS="2766" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2196" VPOS="2765" />
+            <a:String CONTENT="&quot;agro&quot;" HEIGHT="49" WIDTH="161" HPOS="2196" VPOS="2764" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2384" VPOS="2765" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="43" HPOS="2384" VPOS="2765" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="2446" VPOS="2776" />
+            <a:String CONTENT="vida" HEIGHT="42" WIDTH="103" HPOS="2446" VPOS="2766" WC="0.89" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="2571" VPOS="2777" />
+            <a:String CONTENT="pÃºblica," HEIGHT="49" WIDTH="193" HPOS="2571" VPOS="2766" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2789" VPOS="2777" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="85" HPOS="2789" VPOS="2777" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="2896" VPOS="2773" />
+            <a:String CONTENT="no" HEIGHT="34" WIDTH="59" HPOS="2896" VPOS="2773" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0151" WIDTH="830" HEIGHT="51" HPOS="2127" VPOS="2819">
+            <a:String CONTENT="es" HEIGHT="29" WIDTH="47" HPOS="2127" VPOS="2830" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2197" VPOS="2829" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="40" HPOS="2197" VPOS="2822" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="2258" VPOS="2829" />
+            <a:String CONTENT="vano" HEIGHT="29" WIDTH="115" HPOS="2258" VPOS="2828" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2396" VPOS="2829" />
+            <a:String CONTENT="politiqueo," HEIGHT="50" WIDTH="263" HPOS="2396" VPOS="2819" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2682" VPOS="2831" />
+            <a:String CONTENT="anteponien" HEIGHT="50" WIDTH="275" HPOS="2682" VPOS="2820" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0152" WIDTH="827" HEIGHT="49" HPOS="2128" VPOS="2872">
+            <a:String CONTENT="do" HEIGHT="39" WIDTH="54" HPOS="2128" VPOS="2874" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2214" VPOS="2881" />
+            <a:String CONTENT="a" HEIGHT="29" WIDTH="29" HPOS="2214" VPOS="2881" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2276" VPOS="2872" />
+            <a:String CONTENT="la" HEIGHT="44" WIDTH="44" HPOS="2276" VPOS="2872" WC="0.91" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2355" VPOS="2882" />
+            <a:String CONTENT="urbana" HEIGHT="40" WIDTH="174" HPOS="2355" VPOS="2873" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2566" VPOS="2874" />
+            <a:String CONTENT="la" HEIGHT="47" WIDTH="42" HPOS="2566" VPOS="2874" WC="0.61" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2640" VPOS="2884" />
+            <a:String CONTENT="rural;" HEIGHT="46" WIDTH="148" HPOS="2640" VPOS="2873" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2825" VPOS="2875" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="2825" VPOS="2875" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2913" VPOS="2875" />
+            <a:String CONTENT="lo" HEIGHT="39" WIDTH="42" HPOS="2913" VPOS="2875" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0153" WIDTH="831" HEIGHT="50" HPOS="2127" VPOS="2925">
+            <a:String CONTENT="que" HEIGHT="39" WIDTH="79" HPOS="2127" VPOS="2936" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2239" VPOS="2935" />
+            <a:String CONTENT="esta" HEIGHT="39" WIDTH="90" HPOS="2239" VPOS="2925" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2360" VPOS="2935" />
+            <a:String CONTENT="gane," HEIGHT="39" WIDTH="116" HPOS="2360" VPOS="2935" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2510" VPOS="2935" />
+            <a:String CONTENT="aquella," HEIGHT="48" WIDTH="176" HPOS="2510" VPOS="2925" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2720" VPOS="2936" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="50" HPOS="2720" VPOS="2936" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2804" VPOS="2937" />
+            <a:String CONTENT="no" HEIGHT="29" WIDTH="53" HPOS="2804" VPOS="2937" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2891" VPOS="2937" />
+            <a:String CONTENT="esÂ¬" HEIGHT="28" WIDTH="67" HPOS="2891" VPOS="2937" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="escaso" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0154" WIDTH="830" HEIGHT="48" HPOS="2127" VPOS="2980">
+            <a:String CONTENT="caso" HEIGHT="30" WIDTH="105" HPOS="2127" VPOS="2990" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="26" HPOS="2258" VPOS="2990" />
+            <a:String CONTENT="grado" HEIGHT="48" WIDTH="138" HPOS="2258" VPOS="2980" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2421" VPOS="2989" />
+            <a:String CONTENT="se" HEIGHT="33" WIDTH="48" HPOS="2421" VPOS="2989" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2492" VPOS="2981" />
+            <a:String CONTENT="beneficiarÃ¡." HEIGHT="40" WIDTH="294" HPOS="2492" VPOS="2981" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2809" VPOS="2983" />
+            <a:String CONTENT="El" HEIGHT="38" WIDTH="52" HPOS="2809" VPOS="2982" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2886" VPOS="2992" />
+            <a:String CONTENT="esÂ¬" HEIGHT="28" WIDTH="71" HPOS="2886" VPOS="2992" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="espÃ­ritu" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0155" WIDTH="829" HEIGHT="49" HPOS="2127" VPOS="3034">
+            <a:String CONTENT="pÃ­ritu" HEIGHT="49" WIDTH="140" HPOS="2127" VPOS="3034" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="36" HPOS="2303" VPOS="3044" />
+            <a:String CONTENT="prÃ¡ctico" HEIGHT="48" WIDTH="202" HPOS="2303" VPOS="3034" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2544" VPOS="3035" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="2544" VPOS="3035" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2633" VPOS="3045" />
+            <a:String CONTENT="nuestros" HEIGHT="40" WIDTH="217" HPOS="2633" VPOS="3035" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2889" VPOS="3047" />
+            <a:String CONTENT="alÂ¬" HEIGHT="39" WIDTH="67" HPOS="2889" VPOS="3036" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="aldeanos," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0156" WIDTH="831" HEIGHT="48" HPOS="2128" VPOS="3087">
+            <a:String CONTENT="deanos," HEIGHT="45" WIDTH="183" HPOS="2128" VPOS="3089" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="35" HPOS="2346" VPOS="3098" />
+            <a:String CONTENT="relegado" HEIGHT="48" WIDTH="211" HPOS="2346" VPOS="3087" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2595" VPOS="3099" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="27" HPOS="2595" VPOS="3099" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2658" VPOS="3089" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="68" HPOS="2658" VPOS="3089" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2762" VPOS="3099" />
+            <a:String CONTENT="relacioÂ¬" HEIGHT="40" WIDTH="197" HPOS="2762" VPOS="3088" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="relaciones" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0157" WIDTH="832" HEIGHT="48" HPOS="2126" VPOS="3141">
+            <a:String CONTENT="nes" HEIGHT="28" WIDTH="81" HPOS="2126" VPOS="3151" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="34" HPOS="2241" VPOS="3152" />
+            <a:String CONTENT="privadas" HEIGHT="48" WIDTH="211" HPOS="2241" VPOS="3141" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2487" VPOS="3142" />
+            <a:String CONTENT="tiene" HEIGHT="38" WIDTH="117" HPOS="2487" VPOS="3142" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2638" VPOS="3152" />
+            <a:String CONTENT="muchos" HEIGHT="41" WIDTH="191" HPOS="2638" VPOS="3141" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2862" VPOS="3153" />
+            <a:String CONTENT="moÂ¬" HEIGHT="29" WIDTH="96" HPOS="2862" VPOS="3153" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="modos" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0158" WIDTH="831" HEIGHT="46" HPOS="2129" VPOS="3195">
+            <a:String CONTENT="dos" HEIGHT="38" WIDTH="80" HPOS="2129" VPOS="3196" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="42" HPOS="2251" VPOS="3195" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="2251" VPOS="3195" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2342" VPOS="3205" />
+            <a:String CONTENT="mostrarse," HEIGHT="46" WIDTH="266" HPOS="2342" VPOS="3195" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="2651" VPOS="3207" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="55" HPOS="2651" VPOS="3206" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2746" VPOS="3206" />
+            <a:String CONTENT="su" HEIGHT="29" WIDTH="53" HPOS="2746" VPOS="3206" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2840" VPOS="3207" />
+            <a:String CONTENT="nada" HEIGHT="40" WIDTH="120" HPOS="2840" VPOS="3197" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0159" WIDTH="830" HEIGHT="40" HPOS="2129" VPOS="3249">
+            <a:String CONTENT="fÃ¡cil" HEIGHT="39" WIDTH="109" HPOS="2129" VPOS="3249" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2268" VPOS="3259" />
+            <a:String CONTENT="existencia." HEIGHT="38" WIDTH="258" HPOS="2268" VPOS="3250" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2559" VPOS="3250" />
+            <a:String CONTENT="Conllevando" HEIGHT="40" WIDTH="301" HPOS="2559" VPOS="3249" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2891" VPOS="3250" />
+            <a:String CONTENT="inÂ¬" HEIGHT="38" WIDTH="68" HPOS="2891" VPOS="3250" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="innÃºmeras" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0160" WIDTH="833" HEIGHT="55" HPOS="2126" VPOS="3303">
+            <a:String CONTENT="nÃºmeras" HEIGHT="38" WIDTH="215" HPOS="2126" VPOS="3303" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="28" HPOS="2369" VPOS="3312" />
+            <a:String CONTENT="contrariedades," HEIGHT="55" WIDTH="382" HPOS="2369" VPOS="3303" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2781" VPOS="3313" />
+            <a:String CONTENT="abunda" HEIGHT="39" WIDTH="178" HPOS="2781" VPOS="3304" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0161" WIDTH="828" HEIGHT="48" HPOS="2130" VPOS="3356">
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="40" HPOS="2130" VPOS="3356" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2203" VPOS="3368" />
+            <a:String CONTENT="avisado" HEIGHT="38" WIDTH="183" HPOS="2203" VPOS="3357" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2421" VPOS="3357" />
+            <a:String CONTENT="labriego" HEIGHT="47" WIDTH="200" HPOS="2421" VPOS="3357" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2655" VPOS="3367" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="56" HPOS="2655" VPOS="3367" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2744" VPOS="3368" />
+            <a:String CONTENT="observaÂ¬" HEIGHT="40" WIDTH="214" HPOS="2744" VPOS="3357" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="observaciones" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0162" WIDTH="827" HEIGHT="52" HPOS="2131" VPOS="3409">
+            <a:String CONTENT="ciones" HEIGHT="38" WIDTH="152" HPOS="2131" VPOS="3411" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="2314" VPOS="3410" />
+            <a:String CONTENT="de" HEIGHT="42" WIDTH="51" HPOS="2314" VPOS="3410" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2397" VPOS="3409" />
+            <a:String CONTENT="humorismo" HEIGHT="40" WIDTH="282" HPOS="2397" VPOS="3409" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2707" VPOS="3412" />
+            <a:String CONTENT="fino," HEIGHT="46" WIDTH="115" HPOS="2707" VPOS="3411" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2852" VPOS="3423" />
+            <a:String CONTENT="proÂ¬" HEIGHT="40" WIDTH="106" HPOS="2852" VPOS="3421" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="profundo," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0163" WIDTH="830" HEIGHT="55" HPOS="2131" VPOS="3464">
+            <a:String CONTENT="fundo," HEIGHT="50" WIDTH="154" HPOS="2131" VPOS="3464" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="36" HPOS="2321" VPOS="3473" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="83" HPOS="2321" VPOS="3473" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2437" VPOS="3473" />
+            <a:String CONTENT="oculta," HEIGHT="55" WIDTH="165" HPOS="2437" VPOS="3464" WC="0.86" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2636" VPOS="3464" />
+            <a:String CONTENT="bajo" HEIGHT="48" WIDTH="105" HPOS="2636" VPOS="3464" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2775" VPOS="3464" />
+            <a:String CONTENT="la" HEIGHT="40" WIDTH="44" HPOS="2775" VPOS="3464" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2854" VPOS="3475" />
+            <a:String CONTENT="sen-," HEIGHT="32" WIDTH="107" HPOS="2854" VPOS="3472" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0164" WIDTH="827" HEIGHT="49" HPOS="2132" VPOS="3517">
+            <a:String CONTENT="cillez" HEIGHT="39" WIDTH="124" HPOS="2132" VPOS="3517" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2288" VPOS="3528" />
+            <a:String CONTENT="y" HEIGHT="36" WIDTH="27" HPOS="2288" VPOS="3528" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2346" VPOS="3528" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="55" HPOS="2346" VPOS="3528" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2434" VPOS="3517" />
+            <a:String CONTENT="la" HEIGHT="48" WIDTH="43" HPOS="2434" VPOS="3517" WC="0.68" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2508" VPOS="3518" />
+            <a:String CONTENT="tosquedad," HEIGHT="47" WIDTH="262" HPOS="2508" VPOS="3518" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2802" VPOS="3528" />
+            <a:String CONTENT="por" HEIGHT="38" WIDTH="83" HPOS="2802" VPOS="3528" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2918" VPOS="3519" />
+            <a:String CONTENT="lo" HEIGHT="38" WIDTH="41" HPOS="2918" VPOS="3519" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0165" WIDTH="826" HEIGHT="47" HPOS="2132" VPOS="3571">
+            <a:String CONTENT="inferior" HEIGHT="37" WIDTH="190" HPOS="2132" VPOS="3571" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2358" VPOS="3571" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="2358" VPOS="3571" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="55" HPOS="2464" VPOS="3581" />
+            <a:String CONTENT="su" HEIGHT="28" WIDTH="53" HPOS="2464" VPOS="3581" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="53" HPOS="2570" VPOS="3581" />
+            <a:String CONTENT="situaciÃ³n," HEIGHT="46" WIDTH="239" HPOS="2570" VPOS="3572" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="52" HPOS="2861" VPOS="3582" />
+            <a:String CONTENT="mÃ¡s" HEIGHT="39" WIDTH="97" HPOS="2861" VPOS="3572" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0166" WIDTH="828" HEIGHT="40" HPOS="2132" VPOS="3624">
+            <a:String CONTENT="triste" HEIGHT="38" WIDTH="131" HPOS="2132" VPOS="3624" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2287" VPOS="3635" />
+            <a:String CONTENT="cuando" HEIGHT="38" WIDTH="173" HPOS="2287" VPOS="3625" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2485" VPOS="3626" />
+            <a:String CONTENT="la" HEIGHT="36" WIDTH="43" HPOS="2485" VPOS="3626" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2551" VPOS="3635" />
+            <a:String CONTENT="condiciÃ³n" HEIGHT="38" WIDTH="236" HPOS="2551" VPOS="3625" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2811" VPOS="3636" />
+            <a:String CONTENT="es" HEIGHT="29" WIDTH="48" HPOS="2811" VPOS="3635" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2886" VPOS="3636" />
+            <a:String CONTENT="suÂ¬" HEIGHT="28" WIDTH="74" HPOS="2886" VPOS="3636" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="superior" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0167" WIDTH="829" HEIGHT="50" HPOS="2133" VPOS="3677">
+            <a:String CONTENT="perior" HEIGHT="48" WIDTH="149" HPOS="2133" VPOS="3677" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="38" HPOS="2320" VPOS="3691" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="25" HPOS="2320" VPOS="3691" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2383" VPOS="3680" />
+            <a:String CONTENT="la" HEIGHT="36" WIDTH="42" HPOS="2383" VPOS="3680" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2461" VPOS="3678" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="53" HPOS="2461" VPOS="3678" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2554" VPOS="3689" />
+            <a:String CONTENT="aquellos" HEIGHT="48" WIDTH="203" HPOS="2554" VPOS="3678" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2797" VPOS="3690" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="85" HPOS="2797" VPOS="3690" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2922" VPOS="3680" />
+            <a:String CONTENT="le" HEIGHT="38" WIDTH="38" HPOS="2922" VPOS="3680" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0168" WIDTH="827" HEIGHT="52" HPOS="2133" VPOS="3731">
+            <a:String CONTENT="oprimen" HEIGHT="46" WIDTH="203" HPOS="2133" VPOS="3731" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="2378" VPOS="3741" />
+            <a:String CONTENT="por" HEIGHT="37" WIDTH="81" HPOS="2378" VPOS="3741" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2488" VPOS="3731" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="52" HPOS="2488" VPOS="3731" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2571" VPOS="3732" />
+            <a:String CONTENT="fuera" HEIGHT="39" WIDTH="130" HPOS="2571" VPOS="3732" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2733" VPOS="3743" />
+            <a:String CONTENT="afinados," HEIGHT="50" WIDTH="227" HPOS="2733" VPOS="3733" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0169" WIDTH="753" HEIGHT="56" HPOS="2134" VPOS="3785">
+            <a:String CONTENT="en" HEIGHT="27" WIDTH="53" HPOS="2134" VPOS="3794" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2211" VPOS="3795" />
+            <a:String CONTENT="realidad" HEIGHT="39" WIDTH="198" HPOS="2211" VPOS="3785" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2432" VPOS="3796" />
+            <a:String CONTENT="vulgares" HEIGHT="47" WIDTH="212" HPOS="2432" VPOS="3785" WC="0.81" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2667" VPOS="3804" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="28" HPOS="2667" VPOS="3804" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2718" VPOS="3787" />
+            <a:String CONTENT="torpes." HEIGHT="48" WIDTH="169" HPOS="2718" VPOS="3787" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0031" HEIGHT="1701" WIDTH="859" HPOS="2113" VPOS="3837" STYLEREFS="PARSTYLE0015">
+          <a:TextLine ID="PAG001LIN0170" WIDTH="774" HEIGHT="48" HPOS="2184" VPOS="3837">
+            <a:String CONTENT="Interesantes" HEIGHT="38" WIDTH="306" HPOS="2184" VPOS="3837" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2518" VPOS="3849" />
+            <a:String CONTENT="plÃ¡ticas" HEIGHT="46" WIDTH="192" HPOS="2518" VPOS="3839" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2739" VPOS="3840" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="69" HPOS="2739" VPOS="3840" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2840" VPOS="3841" />
+            <a:String CONTENT="&quot;lar&quot;" HEIGHT="39" WIDTH="118" HPOS="2840" VPOS="3839" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0171" WIDTH="825" HEIGHT="52" HPOS="2135" VPOS="3891">
+            <a:String CONTENT="do^rie" HEIGHT="35" WIDTH="138" HPOS="2135" VPOS="3891" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="2295" VPOS="3929" />
+            <a:String CONTENT="..diT'" HEIGHT="52" WIDTH="105" HPOS="2295" VPOS="3891" WC="0" STYLEREFS="TEXTSTYLE0007" />
+            <a:SP WIDTH="47" HPOS="2447" VPOS="3891" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="48" HPOS="2447" VPOS="3891" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2536" VPOS="3892" />
+            <a:String CONTENT="tas" HEIGHT="36" WIDTH="66" HPOS="2536" VPOS="3892" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2642" VPOS="3902" />
+            <a:String CONTENT="cosas" HEIGHT="27" WIDTH="131" HPOS="2642" VPOS="3901" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2809" VPOS="3903" />
+            <a:String CONTENT="priva-" HEIGHT="45" WIDTH="151" HPOS="2809" VPOS="3894" WC="0.87" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="privacÃ­as;" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0172" WIDTH="826" HEIGHT="56" HPOS="2133" VPOS="3929">
+            <a:String CONTENT="cÃ­as;" HEIGHT="54" WIDTH="99" HPOS="2133" VPOS="3931" WC="0.87" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="33" HPOS="2265" VPOS="3953" />
+            <a:String CONTENT="cbmeiii" HEIGHT="50" WIDTH="171" HPOS="2265" VPOS="3929" WC="0.64" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="11" HPOS="2447" VPOS="3952" />
+            <a:String CONTENT="arios" HEIGHT="41" WIDTH="119" HPOS="2447" VPOS="3939" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2601" VPOS="3952" />
+            <a:String CONTENT="mÃ¡s" HEIGHT="39" WIDTH="96" HPOS="2601" VPOS="3943" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2730" VPOS="3945" />
+            <a:String CONTENT="interesan" HEIGHT="39" WIDTH="229" HPOS="2730" VPOS="3944" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0173" WIDTH="826" HEIGHT="49" HPOS="2132" VPOS="3995">
+            <a:String CONTENT="tes," HEIGHT="44" WIDTH="81" HPOS="2132" VPOS="3995" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="2232" VPOS="4005" />
+            <a:String CONTENT="propios" HEIGHT="47" WIDTH="183" HPOS="2232" VPOS="3995" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="2434" VPOS="3996" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="2434" VPOS="3996" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="2507" VPOS="3995" />
+            <a:String CONTENT="&quot;concejo" HEIGHT="49" WIDTH="211" HPOS="2507" VPOS="3995" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="2760" VPOS="4008" />
+            <a:String CONTENT="abierto&quot;" HEIGHT="39" WIDTH="198" HPOS="2760" VPOS="3998" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0174" WIDTH="825" HEIGHT="48" HPOS="2136" VPOS="4048">
+            <a:String CONTENT="los" HEIGHT="38" WIDTH="65" HPOS="2136" VPOS="4048" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2238" VPOS="4058" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="84" HPOS="2238" VPOS="4058" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2358" VPOS="4057" />
+            <a:String CONTENT="se" HEIGHT="32" WIDTH="47" HPOS="2358" VPOS="4057" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2441" VPOS="4059" />
+            <a:String CONTENT="oyen," HEIGHT="38" WIDTH="125" HPOS="2441" VPOS="4058" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2603" VPOS="4060" />
+            <a:String CONTENT="sobre" HEIGHT="39" WIDTH="131" HPOS="2603" VPOS="4050" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2768" VPOS="4061" />
+            <a:String CONTENT="materia" HEIGHT="40" WIDTH="193" HPOS="2768" VPOS="4051" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0175" WIDTH="824" HEIGHT="51" HPOS="2135" VPOS="4102">
+            <a:String CONTENT="comuna^" HEIGHT="51" WIDTH="218" HPOS="2135" VPOS="4102" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2390" VPOS="4112" />
+            <a:String CONTENT="en" HEIGHT="30" WIDTH="55" HPOS="2390" VPOS="4112" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2481" VPOS="4104" />
+            <a:String CONTENT="la" HEIGHT="36" WIDTH="41" HPOS="2481" VPOS="4104" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2557" VPOS="4114" />
+            <a:String CONTENT="reuniÃ³n" HEIGHT="43" WIDTH="192" HPOS="2557" VPOS="4104" WC="0.86" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2783" VPOS="4105" />
+            <a:String CONTENT="dominÂ¬" HEIGHT="39" WIDTH="176" HPOS="2783" VPOS="4105" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="dominguera," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0176" WIDTH="825" HEIGHT="49" HPOS="2135" VPOS="4156">
+            <a:String CONTENT="guera," HEIGHT="39" WIDTH="150" HPOS="2135" VPOS="4166" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="35" HPOS="2320" VPOS="4167" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="54" HPOS="2320" VPOS="4167" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2406" VPOS="4167" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="38" HPOS="2406" VPOS="4156" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2483" VPOS="4157" />
+            <a:String CONTENT="&quot;adro&quot;," HEIGHT="46" WIDTH="173" HPOS="2483" VPOS="4157" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2690" VPOS="4168" />
+            <a:String CONTENT="al" HEIGHT="38" WIDTH="42" HPOS="2690" VPOS="4158" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2765" VPOS="4168" />
+            <a:String CONTENT="salir" HEIGHT="39" WIDTH="112" HPOS="2765" VPOS="4158" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2909" VPOS="4160" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="51" HPOS="2909" VPOS="4160" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0177" WIDTH="827" HEIGHT="48" HPOS="2135" VPOS="4209">
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="41" HPOS="2135" VPOS="4209" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2217" VPOS="4219" />
+            <a:String CONTENT="misa" HEIGHT="37" WIDTH="117" HPOS="2217" VPOS="4210" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2373" VPOS="4220" />
+            <a:String CONTENT="parroquial." HEIGHT="46" WIDTH="277" HPOS="2373" VPOS="4211" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2690" VPOS="4212" />
+            <a:String CONTENT="Varios" HEIGHT="43" WIDTH="159" HPOS="2690" VPOS="4212" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="2891" VPOS="4212" />
+            <a:String CONTENT="luÂ¬" HEIGHT="40" WIDTH="71" HPOS="2891" VPOS="4212" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="lugares" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0178" WIDTH="824" HEIGHT="52" HPOS="2138" VPOS="4262">
+            <a:String CONTENT="gares" HEIGHT="38" WIDTH="131" HPOS="2138" VPOS="4271" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="3" HPOS="2272" VPOS="4285" />
+            <a:String CONTENT="â€”" HEIGHT="6" WIDTH="59" HPOS="2272" VPOS="4285" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="2333" VPOS="4272" />
+            <a:String CONTENT="caserÃ­os" HEIGHT="41" WIDTH="200" HPOS="2333" VPOS="4262" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="2535" VPOS="4286" />
+            <a:String CONTENT="â€”" HEIGHT="9" WIDTH="55" HPOS="2535" VPOS="4286" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="1" HPOS="2591" VPOS="4293" />
+            <a:String CONTENT="," HEIGHT="16" WIDTH="9" HPOS="2591" VPOS="4293" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="75" HPOS="2675" VPOS="4275" />
+            <a:String CONTENT="constituyen" HEIGHT="49" WIDTH="287" HPOS="2675" VPOS="4265" WC="0.78" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0179" WIDTH="826" HEIGHT="48" HPOS="2135" VPOS="4317">
+            <a:String CONTENT="la" HEIGHT="36" WIDTH="41" HPOS="2135" VPOS="4317" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2213" VPOS="4317" />
+            <a:String CONTENT="Parroquia" HEIGHT="46" WIDTH="248" HPOS="2213" VPOS="4317" WC="0.8" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2498" VPOS="4328" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="26" HPOS="2498" VPOS="4328" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2560" VPOS="4328" />
+            <a:String CONTENT="en" HEIGHT="30" WIDTH="56" HPOS="2560" VPOS="4328" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2654" VPOS="4329" />
+            <a:String CONTENT="ella" HEIGHT="38" WIDTH="86" HPOS="2654" VPOS="4318" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2778" VPOS="4320" />
+            <a:String CONTENT="forman" HEIGHT="39" WIDTH="183" HPOS="2778" VPOS="4320" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0180" WIDTH="835" HEIGHT="51" HPOS="2133" VPOS="4370">
+            <a:String CONTENT="verdadero" HEIGHT="40" WIDTH="243" HPOS="2133" VPOS="4370" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2416" VPOS="4382" />
+            <a:String CONTENT="nÃºcleo" HEIGHT="40" WIDTH="161" HPOS="2416" VPOS="4370" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="55" HPOS="2632" VPOS="4372" />
+            <a:String CONTENT="de" HEIGHT="40" WIDTH="51" HPOS="2632" VPOS="4372" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="55" HPOS="2738" VPOS="4382" />
+            <a:String CONTENT="actividad," HEIGHT="48" WIDTH="230" HPOS="2738" VPOS="4373" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0181" WIDTH="846" HEIGHT="51" HPOS="2113" VPOS="4424">
+            <a:String CONTENT=",que" HEIGHT="37" WIDTH="104" HPOS="2113" VPOS="4433" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2246" VPOS="4424" />
+            <a:String CONTENT="ha" HEIGHT="37" WIDTH="57" HPOS="2246" VPOS="4424" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2332" VPOS="4424" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="2332" VPOS="4424" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2412" VPOS="4435" />
+            <a:String CONTENT="recoger" HEIGHT="37" WIDTH="185" HPOS="2412" VPOS="4434" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2626" VPOS="4435" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="41" HPOS="2626" VPOS="4427" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2694" VPOS="4426" />
+            <a:String CONTENT="Municipio;" HEIGHT="49" WIDTH="265" HPOS="2694" VPOS="4426" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0182" WIDTH="824" HEIGHT="53" HPOS="2135" VPOS="4477">
+            <a:String CONTENT="fomentÃ¡ndola," HEIGHT="51" WIDTH="349" HPOS="2135" VPOS="4477" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2511" VPOS="4479" />
+            <a:String CONTENT="hallarÃ¡" HEIGHT="40" WIDTH="177" HPOS="2511" VPOS="4478" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2711" VPOS="4491" />
+            <a:String CONTENT="como" HEIGHT="29" WIDTH="129" HPOS="2711" VPOS="4491" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2867" VPOS="4492" />
+            <a:String CONTENT="asis" HEIGHT="47" WIDTH="92" HPOS="2867" VPOS="4483" WC="0.59" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0183" WIDTH="824" HEIGHT="49" HPOS="2135" VPOS="4531">
+            <a:String CONTENT="tencias," HEIGHT="48" WIDTH="184" HPOS="2135" VPOS="4531" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2348" VPOS="4541" />
+            <a:String CONTENT="prosperidades," HEIGHT="48" WIDTH="361" HPOS="2348" VPOS="4532" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2738" VPOS="4544" />
+            <a:String CONTENT="en" HEIGHT="30" WIDTH="56" HPOS="2738" VPOS="4544" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2823" VPOS="4546" />
+            <a:String CONTENT="realiÂ¬" HEIGHT="39" WIDTH="136" HPOS="2823" VPOS="4535" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="realidad" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0184" WIDTH="826" HEIGHT="45" HPOS="2134" VPOS="4584">
+            <a:String CONTENT="dad" HEIGHT="38" WIDTH="82" HPOS="2134" VPOS="4584" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="34" HPOS="2250" VPOS="4585" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="52" HPOS="2250" VPOS="4585" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2335" VPOS="4595" />
+            <a:String CONTENT="vida" HEIGHT="38" WIDTH="100" HPOS="2335" VPOS="4584" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2471" VPOS="4596" />
+            <a:String CONTENT="autonÃ³mica." HEIGHT="44" WIDTH="302" HPOS="2471" VPOS="4585" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2807" VPOS="4589" />
+            <a:String CONTENT="No" HEIGHT="39" WIDTH="64" HPOS="2807" VPOS="4589" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2906" VPOS="4599" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="54" HPOS="2906" VPOS="4599" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0185" WIDTH="829" HEIGHT="52" HPOS="2134" VPOS="4638">
+            <a:String CONTENT="un" HEIGHT="28" WIDTH="60" HPOS="2134" VPOS="4648" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2224" VPOS="4648" />
+            <a:String CONTENT="momento" HEIGHT="39" WIDTH="225" HPOS="2224" VPOS="4638" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2481" VPOS="4649" />
+            <a:String CONTENT="se" HEIGHT="29" WIDTH="47" HPOS="2481" VPOS="4649" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2560" VPOS="4651" />
+            <a:String CONTENT="alcanza." HEIGHT="42" WIDTH="198" HPOS="2560" VPOS="4639" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2788" VPOS="4643" />
+            <a:String CONTENT="ImproÂ¬" HEIGHT="47" WIDTH="175" HPOS="2788" VPOS="4643" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="Improvisarla," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0186" WIDTH="826" HEIGHT="51" HPOS="2133" VPOS="4691">
+            <a:String CONTENT="visarla," HEIGHT="46" WIDTH="179" HPOS="2133" VPOS="4691" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="29" HPOS="2341" VPOS="4702" />
+            <a:String CONTENT="valdrÃ­a" HEIGHT="39" WIDTH="174" HPOS="2341" VPOS="4692" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2544" VPOS="4705" />
+            <a:String CONTENT="por" HEIGHT="39" WIDTH="83" HPOS="2544" VPOS="4703" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2658" VPOS="4704" />
+            <a:String CONTENT="perderla." HEIGHT="46" WIDTH="220" HPOS="2658" VPOS="4695" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2909" VPOS="4698" />
+            <a:String CONTENT="El" HEIGHT="39" WIDTH="50" HPOS="2909" VPOS="4697" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0187" WIDTH="825" HEIGHT="48" HPOS="2135" VPOS="4745">
+            <a:String CONTENT="principio" HEIGHT="48" WIDTH="219" HPOS="2135" VPOS="4745" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2387" VPOS="4746" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="2387" VPOS="4746" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2472" VPOS="4757" />
+            <a:String CONTENT="autonomiai" HEIGHT="47" WIDTH="272" HPOS="2472" VPOS="4746" WC="0" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2776" VPOS="4750" />
+            <a:String CONTENT="fÃ¡cil" HEIGHT="38" WIDTH="110" HPOS="2776" VPOS="4750" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2919" VPOS="4753" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="41" HPOS="2919" VPOS="4753" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0188" WIDTH="828" HEIGHT="50" HPOS="2136" VPOS="4799">
+            <a:String CONTENT="enunciaciÃ³n," HEIGHT="50" WIDTH="307" HPOS="2136" VPOS="4799" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2479" VPOS="4810" />
+            <a:String CONTENT="no" HEIGHT="28" WIDTH="59" HPOS="2479" VPOS="4810" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="52" HPOS="2590" VPOS="4811" />
+            <a:String CONTENT="es" HEIGHT="29" WIDTH="47" HPOS="2590" VPOS="4810" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="51" HPOS="2688" VPOS="4813" />
+            <a:String CONTENT="verdadera-," HEIGHT="39" WIDTH="276" HPOS="2688" VPOS="4804" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0189" WIDTH="825" HEIGHT="52" HPOS="2136" VPOS="4853">
+            <a:String CONTENT="mente" HEIGHT="37" WIDTH="146" HPOS="2136" VPOS="4853" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2311" VPOS="4863" />
+            <a:String CONTENT="sentido" HEIGHT="39" WIDTH="174" HPOS="2311" VPOS="4854" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2513" VPOS="4864" />
+            <a:String CONTENT="por" HEIGHT="39" WIDTH="81" HPOS="2513" VPOS="4863" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2620" VPOS="4856" />
+            <a:String CONTENT="todos" HEIGHT="39" WIDTH="130" HPOS="2620" VPOS="4856" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2779" VPOS="4859" />
+            <a:String CONTENT="los" HEIGHT="37" WIDTH="68" HPOS="2779" VPOS="4859" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2877" VPOS="4868" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="84" HPOS="2877" VPOS="4868" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0190" WIDTH="824" HEIGHT="48" HPOS="2137" VPOS="4907">
+            <a:String CONTENT="lo" HEIGHT="41" WIDTH="40" HPOS="2137" VPOS="4907" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2201" VPOS="4917" />
+            <a:String CONTENT="reconocen" HEIGHT="31" WIDTH="248" HPOS="2201" VPOS="4917" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="2471" VPOS="4918" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="28" HPOS="2471" VPOS="4918" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="2520" VPOS="4919" />
+            <a:String CONTENT="proclaman." HEIGHT="47" WIDTH="276" HPOS="2520" VPOS="4908" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="2818" VPOS="4911" />
+            <a:String CONTENT="Y" HEIGHT="37" WIDTH="35" HPOS="2818" VPOS="4911" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2876" VPOS="4922" />
+            <a:String CONTENT="ello" HEIGHT="39" WIDTH="85" HPOS="2876" VPOS="4912" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0191" WIDTH="825" HEIGHT="51" HPOS="2138" VPOS="4961">
+            <a:String CONTENT="es" HEIGHT="27" WIDTH="46" HPOS="2138" VPOS="4971" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2212" VPOS="4971" />
+            <a:String CONTENT="muy" HEIGHT="36" WIDTH="103" HPOS="2212" VPOS="4971" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2340" VPOS="4961" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="49" HPOS="2340" VPOS="4961" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2418" VPOS="4971" />
+            <a:String CONTENT="considerar," HEIGHT="50" WIDTH="276" HPOS="2418" VPOS="4961" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2721" VPOS="4974" />
+            <a:String CONTENT="porque" HEIGHT="38" WIDTH="172" HPOS="2721" VPOS="4974" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2921" VPOS="4965" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="42" HPOS="2921" VPOS="4965" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0192" WIDTH="824" HEIGHT="49" HPOS="2138" VPOS="5015">
+            <a:String CONTENT="obra," HEIGHT="49" WIDTH="119" HPOS="2138" VPOS="5015" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2298" VPOS="5015" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="50" HPOS="2298" VPOS="5015" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2386" VPOS="5025" />
+            <a:String CONTENT="muchas" HEIGHT="37" WIDTH="188" HPOS="2386" VPOS="5017" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2613" VPOS="5026" />
+            <a:String CONTENT="cooperaciones" HEIGHT="45" WIDTH="349" HPOS="2613" VPOS="5019" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0193" WIDTH="826" HEIGHT="50" HPOS="2140" VPOS="5068">
+            <a:String CONTENT="necesita," HEIGHT="50" WIDTH="194" HPOS="2140" VPOS="5068" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2365" VPOS="5078" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="49" HPOS="2365" VPOS="5078" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2446" VPOS="5078" />
+            <a:String CONTENT="concierto" HEIGHT="39" WIDTH="211" HPOS="2446" VPOS="5069" WC="0.89" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2688" VPOS="5070" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="49" HPOS="2688" VPOS="5070" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2768" VPOS="5081" />
+            <a:String CONTENT="voluntaÂ¬" HEIGHT="37" WIDTH="198" HPOS="2768" VPOS="5072" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="voluntades," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0194" WIDTH="827" HEIGHT="51" HPOS="2140" VPOS="5121">
+            <a:String CONTENT="des," HEIGHT="47" WIDTH="89" HPOS="2140" VPOS="5122" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="2260" VPOS="5125" />
+            <a:String CONTENT="tanto" HEIGHT="38" WIDTH="127" HPOS="2260" VPOS="5123" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2419" VPOS="5121" />
+            <a:String CONTENT="las" HEIGHT="39" WIDTH="67" HPOS="2419" VPOS="5121" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2519" VPOS="5123" />
+            <a:String CONTENT="dispersas" HEIGHT="47" WIDTH="229" HPOS="2519" VPOS="5123" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2779" VPOS="5135" />
+            <a:String CONTENT="y" HEIGHT="36" WIDTH="27" HPOS="2779" VPOS="5135" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2838" VPOS="5135" />
+            <a:String CONTENT="prin-," HEIGHT="47" WIDTH="129" HPOS="2838" VPOS="5125" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0195" WIDTH="827" HEIGHT="49" HPOS="2140" VPOS="5176">
+            <a:String CONTENT="cipales," HEIGHT="46" WIDTH="181" HPOS="2140" VPOS="5176" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2360" VPOS="5176" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="65" HPOS="2360" VPOS="5176" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2464" VPOS="5187" />
+            <a:String CONTENT="extraÃ±adas" HEIGHT="39" WIDTH="269" HPOS="2464" VPOS="5177" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2770" VPOS="5188" />
+            <a:String CONTENT="y" HEIGHT="36" WIDTH="27" HPOS="2770" VPOS="5188" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2833" VPOS="5188" />
+            <a:String CONTENT="pros-," HEIGHT="39" WIDTH="134" HPOS="2833" VPOS="5186" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0196" WIDTH="824" HEIGHT="45" HPOS="2141" VPOS="5230">
+            <a:String CONTENT="critas," HEIGHT="45" WIDTH="151" HPOS="2141" VPOS="5230" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2318" VPOS="5240" />
+            <a:String CONTENT="valdrÃ¡n" HEIGHT="38" WIDTH="187" HPOS="2318" VPOS="5230" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2533" VPOS="5239" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="57" HPOS="2533" VPOS="5239" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2619" VPOS="5241" />
+            <a:String CONTENT="sus" HEIGHT="28" WIDTH="78" HPOS="2619" VPOS="5241" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2727" VPOS="5241" />
+            <a:String CONTENT="ansias" HEIGHT="35" WIDTH="157" HPOS="2727" VPOS="5233" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2914" VPOS="5232" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="2914" VPOS="5232" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0197" WIDTH="826" HEIGHT="48" HPOS="2140" VPOS="5283">
+            <a:String CONTENT="reivindicaciÃ³n" HEIGHT="39" WIDTH="346" HPOS="2140" VPOS="5283" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="1" HPOS="2487" VPOS="5308" />
+            <a:String CONTENT="â€”" HEIGHT="8" WIDTH="54" HPOS="2487" VPOS="5308" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="0" HPOS="2541" VPOS="5295" />
+            <a:String CONTENT="no" HEIGHT="30" WIDTH="60" HPOS="2541" VPOS="5294" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2631" VPOS="5284" />
+            <a:String CONTENT="desquite" HEIGHT="47" WIDTH="206" HPOS="2631" VPOS="5284" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="2839" VPOS="5307" />
+            <a:String CONTENT="â€”" HEIGHT="8" WIDTH="59" HPOS="2839" VPOS="5307" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2928" VPOS="5294" />
+            <a:String CONTENT="si" HEIGHT="36" WIDTH="38" HPOS="2928" VPOS="5286" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0198" WIDTH="824" HEIGHT="50" HPOS="2143" VPOS="5337">
+            <a:String CONTENT="aciertan" HEIGHT="38" WIDTH="200" HPOS="2143" VPOS="5338" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="47" HPOS="2390" VPOS="5348" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="24" HPOS="2390" VPOS="5348" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2447" VPOS="5337" />
+            <a:String CONTENT="dominar" HEIGHT="39" WIDTH="205" HPOS="2447" VPOS="5337" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="2698" VPOS="5339" />
+            <a:String CONTENT="la" HEIGHT="48" WIDTH="43" HPOS="2698" VPOS="5339" WC="0.55" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="2784" VPOS="5347" />
+            <a:String CONTENT="natural" HEIGHT="41" WIDTH="183" HPOS="2784" VPOS="5337" WC="0.82" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0199" WIDTH="827" HEIGHT="48" HPOS="2142" VPOS="5390">
+            <a:String CONTENT="violencia," HEIGHT="45" WIDTH="230" HPOS="2142" VPOS="5391" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2413" VPOS="5401" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="85" HPOS="2413" VPOS="5401" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="57" HPOS="2555" VPOS="5401" />
+            <a:String CONTENT="aprovecha" HEIGHT="48" WIDTH="250" HPOS="2555" VPOS="5390" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="54" HPOS="2859" VPOS="5401" />
+            <a:String CONTENT="para" HEIGHT="38" WIDTH="110" HPOS="2859" VPOS="5399" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0200" WIDTH="826" HEIGHT="55" HPOS="2145" VPOS="5443">
+            <a:String CONTENT="destruir," HEIGHT="52" WIDTH="207" HPOS="2145" VPOS="5446" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2381" VPOS="5456" />
+            <a:String CONTENT="pero" HEIGHT="38" WIDTH="107" HPOS="2381" VPOS="5454" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2515" VPOS="5455" />
+            <a:String CONTENT="no" HEIGHT="30" WIDTH="59" HPOS="2515" VPOS="5455" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2603" VPOS="5454" />
+            <a:String CONTENT="sirve" HEIGHT="38" WIDTH="117" HPOS="2603" VPOS="5444" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2748" VPOS="5455" />
+            <a:String CONTENT="para" HEIGHT="39" WIDTH="113" HPOS="2748" VPOS="5452" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2887" VPOS="5443" />
+            <a:String CONTENT="fun" HEIGHT="37" WIDTH="84" HPOS="2887" VPOS="5443" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0201" WIDTH="92" HEIGHT="38" HPOS="2145" VPOS="5499">
+            <a:String CONTENT="dar." HEIGHT="38" WIDTH="92" HPOS="2145" VPOS="5499" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0032" HEIGHT="575" WIDTH="829" HPOS="2146" VPOS="5550" STYLEREFS="PARSTYLE0016">
+          <a:TextLine ID="PAG001LIN0202" WIDTH="773" HEIGHT="49" HPOS="2196" VPOS="5550">
+            <a:String CONTENT="Desconfiemos" HEIGHT="47" WIDTH="342" HPOS="2196" VPOS="5552" WC="0.48" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2577" VPOS="5557" />
+            <a:String CONTENT="de" HEIGHT="33" WIDTH="51" HPOS="2577" VPOS="5557" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="2669" VPOS="5560" />
+            <a:String CONTENT="quienes" HEIGHT="47" WIDTH="186" HPOS="2669" VPOS="5550" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="2897" VPOS="5559" />
+            <a:String CONTENT="es-" HEIGHT="29" WIDTH="72" HPOS="2897" VPOS="5558" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="estreman" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0203" WIDTH="824" HEIGHT="51" HPOS="2146" VPOS="5602">
+            <a:String CONTENT="treman" HEIGHT="36" WIDTH="173" HPOS="2146" VPOS="5609" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="35" HPOS="2354" VPOS="5606" />
+            <a:String CONTENT="los" HEIGHT="38" WIDTH="65" HPOS="2354" VPOS="5606" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2452" VPOS="5616" />
+            <a:String CONTENT="programas" HEIGHT="40" WIDTH="267" HPOS="2452" VPOS="5613" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2753" VPOS="5602" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="2753" VPOS="5602" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2839" VPOS="5612" />
+            <a:String CONTENT="autoÂ¬" HEIGHT="38" WIDTH="131" HPOS="2839" VPOS="5602" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="autonomÃ­a," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0204" WIDTH="824" HEIGHT="50" HPOS="2146" VPOS="5655">
+            <a:String CONTENT="nomÃ­a," HEIGHT="43" WIDTH="161" HPOS="2146" VPOS="5661" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="36" HPOS="2343" VPOS="5659" />
+            <a:String CONTENT="de" HEIGHT="42" WIDTH="51" HPOS="2343" VPOS="5659" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2434" VPOS="5668" />
+            <a:String CONTENT="quienes" HEIGHT="47" WIDTH="185" HPOS="2434" VPOS="5658" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2658" VPOS="5667" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="54" HPOS="2658" VPOS="5667" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2751" VPOS="5656" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="42" HPOS="2751" VPOS="5656" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="2837" VPOS="5655" />
+            <a:String CONTENT="&quot;conÂ¬" HEIGHT="38" WIDTH="133" HPOS="2837" VPOS="5655" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="&quot;concesiÃ³n&quot;" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0205" WIDTH="837" HEIGHT="47" HPOS="2147" VPOS="5709">
+            <a:String CONTENT="cesiÃ³n&quot;" HEIGHT="41" WIDTH="176" HPOS="2147" VPOS="5712" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="42" HPOS="2365" VPOS="5723" />
+            <a:String CONTENT="muestran" HEIGHT="38" WIDTH="233" HPOS="2365" VPOS="5712" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="2638" VPOS="5720" />
+            <a:String CONTENT="amplitudes" HEIGHT="47" WIDTH="270" HPOS="2638" VPOS="5709" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2946" VPOS="5718" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="26" HPOS="2946" VPOS="5718" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0206" WIDTH="821" HEIGHT="55" HPOS="2148" VPOS="5761">
+            <a:String CONTENT="larguezas." HEIGHT="45" WIDTH="245" HPOS="2148" VPOS="5768" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2428" VPOS="5765" />
+            <a:String CONTENT="Hay" HEIGHT="51" WIDTH="93" HPOS="2428" VPOS="5765" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2552" VPOS="5773" />
+            <a:String CONTENT="ejemplos" HEIGHT="48" WIDTH="220" HPOS="2552" VPOS="5762" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2802" VPOS="5772" />
+            <a:String CONTENT="varios," HEIGHT="43" WIDTH="167" HPOS="2802" VPOS="5761" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0207" WIDTH="823" HEIGHT="48" HPOS="2149" VPOS="5814">
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="51" HPOS="2149" VPOS="5820" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="2242" VPOS="5830" />
+            <a:String CONTENT="recordaciÃ³n" HEIGHT="40" WIDTH="290" HPOS="2242" VPOS="5817" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="2575" VPOS="5826" />
+            <a:String CONTENT="muy" HEIGHT="37" WIDTH="106" HPOS="2575" VPOS="5825" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="53" HPOS="2734" VPOS="5824" />
+            <a:String CONTENT="oportuna," HEIGHT="48" WIDTH="238" HPOS="2734" VPOS="5814" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0208" WIDTH="824" HEIGHT="45" HPOS="2150" VPOS="5867">
+            <a:String CONTENT="concesiones" HEIGHT="39" WIDTH="290" HPOS="2150" VPOS="5873" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2471" VPOS="5870" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="2471" VPOS="5870" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2554" VPOS="5880" />
+            <a:String CONTENT="autonomÃ­a" HEIGHT="38" WIDTH="260" HPOS="2554" VPOS="5868" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2846" VPOS="5878" />
+            <a:String CONTENT="a" HEIGHT="27" WIDTH="25" HPOS="2846" VPOS="5878" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2902" VPOS="5867" />
+            <a:String CONTENT="Ã³rÂ¬" HEIGHT="38" WIDTH="72" HPOS="2902" VPOS="5867" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="Ã³rganos" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0209" WIDTH="824" HEIGHT="54" HPOS="2149" VPOS="5920">
+            <a:String CONTENT="ganos" HEIGHT="39" WIDTH="140" HPOS="2149" VPOS="5935" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="27" HPOS="2316" VPOS="5936" />
+            <a:String CONTENT="anteriormente" HEIGHT="42" WIDTH="348" HPOS="2316" VPOS="5921" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2691" VPOS="5931" />
+            <a:String CONTENT="creados," HEIGHT="50" WIDTH="202" HPOS="2691" VPOS="5920" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2919" VPOS="5920" />
+            <a:String CONTENT="lÃ­e" HEIGHT="37" WIDTH="54" HPOS="2919" VPOS="5920" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0210" WIDTH="822" HEIGHT="52" HPOS="2150" VPOS="5972">
+            <a:String CONTENT="churas" HEIGHT="36" WIDTH="163" HPOS="2150" VPOS="5981" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2345" VPOS="5977" />
+            <a:String CONTENT="del" HEIGHT="37" WIDTH="68" HPOS="2345" VPOS="5977" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2443" VPOS="5988" />
+            <a:String CONTENT="poder" HEIGHT="49" WIDTH="137" HPOS="2443" VPOS="5975" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2611" VPOS="5985" />
+            <a:String CONTENT="central," HEIGHT="45" WIDTH="185" HPOS="2611" VPOS="5973" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2829" VPOS="5972" />
+            <a:String CONTENT="llenas" HEIGHT="38" WIDTH="143" HPOS="2829" VPOS="5972" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0211" WIDTH="821" HEIGHT="51" HPOS="2151" VPOS="6026">
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="66" HPOS="2151" VPOS="6033" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2251" VPOS="6042" />
+            <a:String CONTENT="espÃ­ritu" HEIGHT="48" WIDTH="187" HPOS="2251" VPOS="6029" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="2473" VPOS="6038" />
+            <a:String CONTENT="que" HEIGHT="39" WIDTH="83" HPOS="2473" VPOS="6036" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2589" VPOS="6027" />
+            <a:String CONTENT="Ã©ste" HEIGHT="39" WIDTH="96" HPOS="2589" VPOS="6026" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2717" VPOS="6026" />
+            <a:String CONTENT="las" HEIGHT="39" WIDTH="67" HPOS="2717" VPOS="6026" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2818" VPOS="6026" />
+            <a:String CONTENT="infunÂ¬" HEIGHT="37" WIDTH="154" HPOS="2818" VPOS="6026" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="infundiÃ³." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0212" WIDTH="85" HEIGHT="40" HPOS="2152" VPOS="6084">
+            <a:String CONTENT="diÃ³." HEIGHT="40" WIDTH="85" HPOS="2152" VPOS="6084" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0033" HEIGHT="323" WIDTH="823" HPOS="2153" VPOS="6132" STYLEREFS="PARSTYLE0017">
+          <a:TextLine ID="PAG001LIN0213" WIDTH="769" HEIGHT="48" HPOS="2203" VPOS="6132">
+            <a:String CONTENT="Reconocido" HEIGHT="40" WIDTH="274" HPOS="2203" VPOS="6135" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2510" VPOS="6134" />
+            <a:String CONTENT="lealmente" HEIGHT="39" WIDTH="237" HPOS="2510" VPOS="6132" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2778" VPOS="6143" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="39" HPOS="2778" VPOS="6132" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2848" VPOS="6142" />
+            <a:String CONTENT="prin-." HEIGHT="48" WIDTH="124" HPOS="2848" VPOS="6132" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0214" WIDTH="821" HEIGHT="55" HPOS="2153" VPOS="6185">
+            <a:String CONTENT="cipio" HEIGHT="49" WIDTH="113" HPOS="2153" VPOS="6191" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2291" VPOS="6190" />
+            <a:String CONTENT="de" HEIGHT="40" WIDTH="51" HPOS="2291" VPOS="6190" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2369" VPOS="6199" />
+            <a:String CONTENT="autonomÃ­a," HEIGHT="43" WIDTH="272" HPOS="2369" VPOS="6188" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2667" VPOS="6197" />
+            <a:String CONTENT="cuanto" HEIGHT="44" WIDTH="164" HPOS="2667" VPOS="6186" WC="0.72" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2858" VPOS="6197" />
+            <a:String CONTENT="a" HEIGHT="27" WIDTH="24" HPOS="2858" VPOS="6197" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2908" VPOS="6185" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="66" HPOS="2908" VPOS="6185" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0215" WIDTH="820" HEIGHT="57" HPOS="2154" VPOS="6236">
+            <a:String CONTENT="aplicaciones," HEIGHT="50" WIDTH="311" HPOS="2154" VPOS="6243" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2490" VPOS="6250" />
+            <a:String CONTENT="modos" HEIGHT="37" WIDTH="155" HPOS="2490" VPOS="6240" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2669" VPOS="6250" />
+            <a:String CONTENT="y" HEIGHT="36" WIDTH="27" HPOS="2669" VPOS="6250" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="2717" VPOS="6249" />
+            <a:String CONTENT="grados" HEIGHT="50" WIDTH="166" HPOS="2717" VPOS="6236" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2907" VPOS="6238" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="67" HPOS="2907" VPOS="6238" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0216" WIDTH="822" HEIGHT="47" HPOS="2153" VPOS="6290">
+            <a:String CONTENT="desenvolvimiento" HEIGHT="44" WIDTH="422" HPOS="2153" VPOS="6293" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2600" VPOS="6293" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="42" HPOS="2600" VPOS="6293" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2668" VPOS="6301" />
+            <a:String CONTENT="sociedad" HEIGHT="39" WIDTH="208" HPOS="2668" VPOS="6291" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2904" VPOS="6290" />
+            <a:String CONTENT="&quot;fa" HEIGHT="42" WIDTH="71" HPOS="2904" VPOS="6290" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0217" WIDTH="819" HEIGHT="49" HPOS="2153" VPOS="6343">
+            <a:String CONTENT="rÃ¡" HEIGHT="39" WIDTH="50" HPOS="2153" VPOS="6351" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2233" VPOS="6350" />
+            <a:String CONTENT="da" HEIGHT="38" WIDTH="53" HPOS="2233" VPOS="6350" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2318" VPOS="6359" />
+            <a:String CONTENT="se&quot;." HEIGHT="39" WIDTH="89" HPOS="2318" VPOS="6347" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2436" VPOS="6348" />
+            <a:String CONTENT="Actividad" HEIGHT="39" WIDTH="229" HPOS="2436" VPOS="6345" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2698" VPOS="6355" />
+            <a:String CONTENT="generadora" HEIGHT="49" WIDTH="274" HPOS="2698" VPOS="6343" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0218" WIDTH="697" HEIGHT="57" HPOS="2154" VPOS="6397">
+            <a:String CONTENT="que" HEIGHT="40" WIDTH="82" HPOS="2154" VPOS="6414" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2260" VPOS="6403" />
+            <a:String CONTENT="del" HEIGHT="39" WIDTH="68" HPOS="2260" VPOS="6402" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2354" VPOS="6411" />
+            <a:String CONTENT="municipio" HEIGHT="46" WIDTH="244" HPOS="2354" VPOS="6400" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2624" VPOS="6410" />
+            <a:String CONTENT="ascienda." HEIGHT="40" WIDTH="227" HPOS="2624" VPOS="6397" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0034" HEIGHT="159" WIDTH="822" HPOS="2154" VPOS="6462" STYLEREFS="PARSTYLE0018">
+          <a:TextLine ID="PAG001LIN0219" WIDTH="768" HEIGHT="52" HPOS="2207" VPOS="6462">
+            <a:String CONTENT="Â¿Como" HEIGHT="46" WIDTH="161" HPOS="2207" VPOS="6468" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2392" VPOS="6465" />
+            <a:String CONTENT="ha" HEIGHT="40" WIDTH="58" HPOS="2392" VPOS="6465" WC="0.9" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2474" VPOS="6463" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="2474" VPOS="6463" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2550" VPOS="6463" />
+            <a:String CONTENT="haber" HEIGHT="37" WIDTH="138" HPOS="2550" VPOS="6463" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2713" VPOS="6471" />
+            <a:String CONTENT="sin" HEIGHT="37" WIDTH="71" HPOS="2713" VPOS="6463" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2808" VPOS="6471" />
+            <a:String CONTENT="autono" HEIGHT="39" WIDTH="167" HPOS="2808" VPOS="6462" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0220" WIDTH="818" HEIGHT="49" HPOS="2154" VPOS="6516">
+            <a:String CONTENT="mia" HEIGHT="40" WIDTH="88" HPOS="2154" VPOS="6522" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2265" VPOS="6521" />
+            <a:String CONTENT="del" HEIGHT="37" WIDTH="67" HPOS="2265" VPOS="6521" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2356" VPOS="6528" />
+            <a:String CONTENT="municipio," HEIGHT="48" WIDTH="258" HPOS="2356" VPOS="6517" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2637" VPOS="6527" />
+            <a:String CONTENT="autonomÃ­a" HEIGHT="42" WIDTH="262" HPOS="2637" VPOS="6516" WC="0.87" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="2922" VPOS="6525" />
+            <a:String CONTENT="en" HEIGHT="31" WIDTH="50" HPOS="2922" VPOS="6525" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0221" WIDTH="231" HEIGHT="49" HPOS="2156" VPOS="6571">
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="38" HPOS="2156" VPOS="6578" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="2216" VPOS="6585" />
+            <a:String CONTENT="regiÃ³n?" HEIGHT="49" WIDTH="171" HPOS="2216" VPOS="6571" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0035" HEIGHT="472" WIDTH="822" HPOS="2157" VPOS="6634" STYLEREFS="PARSTYLE0019">
+          <a:TextLine ID="PAG001LIN0222" WIDTH="769" HEIGHT="47" HPOS="2207" VPOS="6634">
+            <a:String CONTENT="Noble" HEIGHT="41" WIDTH="133" HPOS="2207" VPOS="6636" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2373" VPOS="6636" />
+            <a:String CONTENT="intento" HEIGHT="37" WIDTH="171" HPOS="2373" VPOS="6635" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2573" VPOS="6634" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="51" HPOS="2573" VPOS="6634" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2655" VPOS="6636" />
+            <a:String CONTENT="tiempo" HEIGHT="46" WIDTH="165" HPOS="2655" VPOS="6635" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2853" VPOS="6644" />
+            <a:String CONTENT="atrÃ¡s" HEIGHT="38" WIDTH="123" HPOS="2853" VPOS="6636" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0223" WIDTH="816" HEIGHT="55" HPOS="2157" VPOS="6687">
+            <a:String CONTENT="perseguido" HEIGHT="53" WIDTH="263" HPOS="2157" VPOS="6689" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2451" VPOS="6698" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="25" HPOS="2451" VPOS="6698" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2506" VPOS="6697" />
+            <a:String CONTENT="siempre" HEIGHT="50" WIDTH="193" HPOS="2506" VPOS="6687" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2730" VPOS="6688" />
+            <a:String CONTENT="frustrado," HEIGHT="47" WIDTH="243" HPOS="2730" VPOS="6688" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0224" WIDTH="815" HEIGHT="50" HPOS="2157" VPOS="6741">
+            <a:String CONTENT="el" HEIGHT="40" WIDTH="39" HPOS="2157" VPOS="6748" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2224" VPOS="6746" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="2224" VPOS="6746" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2303" VPOS="6753" />
+            <a:String CONTENT="reforma" HEIGHT="37" WIDTH="199" HPOS="2303" VPOS="6743" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2530" VPOS="6741" />
+            <a:String CONTENT="local" HEIGHT="39" WIDTH="114" HPOS="2530" VPOS="6741" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2675" VPOS="6742" />
+            <a:String CONTENT="llevada" HEIGHT="38" WIDTH="172" HPOS="2675" VPOS="6742" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2877" VPOS="6752" />
+            <a:String CONTENT="preÂ¬" HEIGHT="40" WIDTH="95" HPOS="2877" VPOS="6751" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="preferentemente" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0225" WIDTH="816" HEIGHT="54" HPOS="2157" VPOS="6794">
+            <a:String CONTENT="ferentemente" HEIGHT="45" WIDTH="323" HPOS="2157" VPOS="6794" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="33" HPOS="2513" VPOS="6806" />
+            <a:String CONTENT="al" HEIGHT="37" WIDTH="40" HPOS="2513" VPOS="6795" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2584" VPOS="6806" />
+            <a:String CONTENT="municipio," HEIGHT="52" WIDTH="257" HPOS="2584" VPOS="6796" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2872" VPOS="6806" />
+            <a:String CONTENT="pera" HEIGHT="37" WIDTH="101" HPOS="2872" VPOS="6806" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0226" WIDTH="817" HEIGHT="47" HPOS="2158" VPOS="6848">
+            <a:String CONTENT="desde" HEIGHT="44" WIDTH="123" HPOS="2158" VPOS="6851" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="63" HPOS="2344" VPOS="6848" />
+            <a:String CONTENT="luego" HEIGHT="45" WIDTH="120" HPOS="2344" VPOS="6848" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="58" HPOS="2522" VPOS="6857" />
+            <a:String CONTENT="cambiadas," HEIGHT="44" WIDTH="247" HPOS="2522" VPOS="6848" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="63" HPOS="2832" VPOS="6849" />
+            <a:String CONTENT="desheÂ¬" HEIGHT="39" WIDTH="143" HPOS="2832" VPOS="6849" WC="0.99" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="deshechas" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0227" WIDTH="817" HEIGHT="49" HPOS="2159" VPOS="6902">
+            <a:String CONTENT="chas" HEIGHT="38" WIDTH="106" HPOS="2159" VPOS="6909" WC="0.99" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="38" HPOS="2303" VPOS="6914" />
+            <a:String CONTENT="para" HEIGHT="39" WIDTH="107" HPOS="2303" VPOS="6912" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2446" VPOS="6911" />
+            <a:String CONTENT="conforme" HEIGHT="38" WIDTH="231" HPOS="2446" VPOS="6902" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2714" VPOS="6913" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="24" HPOS="2714" VPOS="6913" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2776" VPOS="6912" />
+            <a:String CONTENT="otro" HEIGHT="37" WIDTH="97" HPOS="2776" VPOS="6904" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2911" VPOS="6915" />
+            <a:String CONTENT="esÂ¬" HEIGHT="28" WIDTH="65" HPOS="2911" VPOS="6915" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="espÃ­ritu" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0228" WIDTH="818" HEIGHT="55" HPOS="2160" VPOS="6954">
+            <a:String CONTENT="pÃ­ritu" HEIGHT="51" WIDTH="136" HPOS="2160" VPOS="6958" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="28" HPOS="2324" VPOS="6966" />
+            <a:String CONTENT="rehacer" HEIGHT="37" WIDTH="185" HPOS="2324" VPOS="6956" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2540" VPOS="6954" />
+            <a:String CONTENT="las" HEIGHT="39" WIDTH="67" HPOS="2540" VPOS="6954" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2638" VPOS="6956" />
+            <a:String CONTENT="demÃ¡s" HEIGHT="39" WIDTH="152" HPOS="2638" VPOS="6955" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2822" VPOS="6968" />
+            <a:String CONTENT="organi" HEIGHT="47" WIDTH="156" HPOS="2822" VPOS="6958" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0229" WIDTH="816" HEIGHT="52" HPOS="2161" VPOS="7008">
+            <a:String CONTENT="zaciones," HEIGHT="46" WIDTH="219" HPOS="2161" VPOS="7013" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2416" VPOS="7008" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="42" HPOS="2416" VPOS="7008" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2492" VPOS="7017" />
+            <a:String CONTENT="superior," HEIGHT="45" WIDTH="222" HPOS="2492" VPOS="7011" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2746" VPOS="7020" />
+            <a:String CONTENT="y" HEIGHT="40" WIDTH="29" HPOS="2746" VPOS="7020" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2809" VPOS="7010" />
+            <a:String CONTENT="las" HEIGHT="45" WIDTH="67" HPOS="2809" VPOS="7010" WC="0.78" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2913" VPOS="7013" />
+            <a:String CONTENT="inÂ¬" HEIGHT="37" WIDTH="64" HPOS="2913" VPOS="7013" WC="0.9" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="intermedias." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0230" WIDTH="253" HEIGHT="41" HPOS="2161" VPOS="7064">
+            <a:String CONTENT="termedias." HEIGHT="41" WIDTH="253" HPOS="2161" VPOS="7064" WC="0.9" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0036" HEIGHT="322" WIDTH="829" HPOS="2162" VPOS="7125" STYLEREFS="PARSTYLE0020">
+          <a:TextLine ID="PAG001LIN0231" WIDTH="769" HEIGHT="54" HPOS="2212" VPOS="7125">
+            <a:String CONTENT="Si" HEIGHT="38" WIDTH="43" HPOS="2212" VPOS="7132" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2283" VPOS="7141" />
+            <a:String CONTENT="a" HEIGHT="27" WIDTH="25" HPOS="2283" VPOS="7141" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2333" VPOS="7127" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="42" HPOS="2333" VPOS="7127" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2400" VPOS="7136" />
+            <a:String CONTENT="reforma" HEIGHT="41" WIDTH="200" HPOS="2400" VPOS="7125" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="2624" VPOS="7139" />
+            <a:String CONTENT="no" HEIGHT="28" WIDTH="58" HPOS="2624" VPOS="7139" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2710" VPOS="7143" />
+            <a:String CONTENT="acompaÃ±aÂ¬" HEIGHT="47" WIDTH="271" HPOS="2710" VPOS="7132" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="acompaÃ±ara" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0232" WIDTH="827" HEIGHT="52" HPOS="2163" VPOS="7172">
+            <a:String CONTENT="ra" HEIGHT="26" WIDTH="49" HPOS="2163" VPOS="7198" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="27" HPOS="2239" VPOS="7195" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="37" HPOS="2239" VPOS="7185" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2306" VPOS="7193" />
+            <a:String CONTENT="acierto," HEIGHT="44" WIDTH="180" HPOS="2306" VPOS="7179" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="2517" VPOS="7190" />
+            <a:String CONTENT="sino" HEIGHT="41" WIDTH="100" HPOS="2517" VPOS="7179" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="2646" VPOS="7182" />
+            <a:String CONTENT="lo" HEIGHT="39" WIDTH="41" HPOS="2646" VPOS="7182" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2713" VPOS="7183" />
+            <a:String CONTENT="hubiera" HEIGHT="40" WIDTH="186" HPOS="2713" VPOS="7183" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2927" VPOS="7194" />
+            <a:String CONTENT="efÃ­i" HEIGHT="51" WIDTH="63" HPOS="2927" VPOS="7172" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0233" WIDTH="813" HEIGHT="48" HPOS="2163" VPOS="7234">
+            <a:String CONTENT="cuantos" HEIGHT="41" WIDTH="187" HPOS="2163" VPOS="7237" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2387" VPOS="7235" />
+            <a:String CONTENT="han" HEIGHT="39" WIDTH="86" HPOS="2387" VPOS="7235" WC="0.8" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2510" VPOS="7234" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="50" HPOS="2510" VPOS="7234" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2597" VPOS="7245" />
+            <a:String CONTENT="contribuir" HEIGHT="39" WIDTH="250" HPOS="2597" VPOS="7237" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2883" VPOS="7255" />
+            <a:String CONTENT="a" HEIGHT="27" WIDTH="24" HPOS="2883" VPOS="7255" WC="0.85" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2937" VPOS="7240" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="39" HPOS="2937" VPOS="7240" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0234" WIDTH="816" HEIGHT="50" HPOS="2162" VPOS="7286">
+            <a:String CONTENT="vida" HEIGHT="36" WIDTH="97" HPOS="2162" VPOS="7292" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2296" VPOS="7298" />
+            <a:String CONTENT="municipal," HEIGHT="50" WIDTH="257" HPOS="2296" VPOS="7286" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="2592" VPOS="7298" />
+            <a:String CONTENT="a" HEIGHT="27" WIDTH="24" HPOS="2592" VPOS="7298" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="2653" VPOS="7288" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="43" HPOS="2653" VPOS="7288" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="2729" VPOS="7301" />
+            <a:String CONTENT="nueva" HEIGHT="28" WIDTH="145" HPOS="2729" VPOS="7301" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="2912" VPOS="7304" />
+            <a:String CONTENT="ao^" HEIGHT="27" WIDTH="66" HPOS="2912" VPOS="7304" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0235" WIDTH="815" HEIGHT="54" HPOS="2163" VPOS="7340">
+            <a:String CONTENT="tuaciÃ³n," HEIGHT="47" WIDTH="191" HPOS="2163" VPOS="7341" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="2356" VPOS="7363" />
+            <a:String CONTENT="â€”" HEIGHT="7" WIDTH="53" HPOS="2356" VPOS="7363" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="4" HPOS="2413" VPOS="7348" />
+            <a:String CONTENT="sana" HEIGHT="30" WIDTH="110" HPOS="2413" VPOS="7348" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="2551" VPOS="7349" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="24" HPOS="2551" VPOS="7349" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="2600" VPOS="7340" />
+            <a:String CONTENT="libre" HEIGHT="40" WIDTH="110" HPOS="2600" VPOS="7340" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="2712" VPOS="7366" />
+            <a:String CONTENT="â€”" HEIGHT="7" WIDTH="53" HPOS="2712" VPOS="7366" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="1" HPOS="2766" VPOS="7373" />
+            <a:String CONTENT="," HEIGHT="16" WIDTH="8" HPOS="2766" VPOS="7373" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="2800" VPOS="7345" />
+            <a:String CONTENT="todo" HEIGHT="41" WIDTH="103" HPOS="2800" VPOS="7345" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="2930" VPOS="7360" />
+            <a:String CONTENT="]" HEIGHT="34" WIDTH="9" HPOS="2930" VPOS="7360" WC="0.8" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="2958" VPOS="7358" />
+            <a:String CONTENT="0" HEIGHT="26" WIDTH="20" HPOS="2958" VPOS="7358" WC="0.8" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0236" WIDTH="767" HEIGHT="50" HPOS="2164" VPOS="7396">
+            <a:String CONTENT="drÃ­a" HEIGHT="43" WIDTH="92" HPOS="2164" VPOS="7396" WC="0.88" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2290" VPOS="7405" />
+            <a:String CONTENT="parar" HEIGHT="42" WIDTH="133" HPOS="2290" VPOS="7402" WC="0.89" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="2455" VPOS="7402" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="51" HPOS="2455" VPOS="7402" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="2542" VPOS="7403" />
+            <a:String CONTENT="un" HEIGHT="34" WIDTH="60" HPOS="2542" VPOS="7403" WC="0.87" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="2632" VPOS="7404" />
+            <a:String CONTENT="nuevo" HEIGHT="32" WIDTH="142" HPOS="2632" VPOS="7404" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="2808" VPOS="7399" />
+            <a:String CONTENT="despi" HEIGHT="47" WIDTH="123" HPOS="2808" VPOS="7399" WC="0.82" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:ComposedBlock ID="PAG001BLK0037" HEIGHT="2029" WIDTH="863" HPOS="3024" VPOS="1452" />
+        <a:TextBlock ID="PAG001BLK0038" HEIGHT="167" WIDTH="829" HPOS="3032" VPOS="1464" STYLEREFS="PARSTYLE0021">
+          <a:TextLine ID="PAG001LIN0237" WIDTH="824" HEIGHT="55" HPOS="3036" VPOS="1464">
+            <a:String CONTENT="z" HEIGHT="27" WIDTH="20" HPOS="3036" VPOS="1486" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="7" HPOS="3063" VPOS="1487" />
+            <a:String CONTENT="amiento" HEIGHT="39" WIDTH="195" HPOS="3063" VPOS="1475" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="3301" VPOS="1472" />
+            <a:String CONTENT="del" HEIGHT="42" WIDTH="69" HPOS="3301" VPOS="1472" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="3411" VPOS="1480" />
+            <a:String CONTENT="poder" HEIGHT="51" WIDTH="138" HPOS="3411" VPOS="1468" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="3592" VPOS="1477" />
+            <a:String CONTENT="centraliza-" HEIGHT="42" WIDTH="268" HPOS="3592" VPOS="1464" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="centralizador;" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0238" WIDTH="824" HEIGHT="58" HPOS="3033" VPOS="1518">
+            <a:String CONTENT="dor;" HEIGHT="46" WIDTH="101" HPOS="3033" VPOS="1530" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="33" HPOS="3167" VPOS="1539" />
+            <a:String CONTENT="no" HEIGHT="30" WIDTH="59" HPOS="3167" VPOS="1539" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3260" VPOS="1538" />
+            <a:String CONTENT="sÃ©" HEIGHT="39" WIDTH="47" HPOS="3260" VPOS="1527" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="3342" VPOS="1535" />
+            <a:String CONTENT="si" HEIGHT="38" WIDTH="39" HPOS="3342" VPOS="1526" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="3414" VPOS="1534" />
+            <a:String CONTENT="menos" HEIGHT="32" WIDTH="155" HPOS="3414" VPOS="1530" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="3604" VPOS="1521" />
+            <a:String CONTENT="daÃ±ino," HEIGHT="48" WIDTH="179" HPOS="3604" VPOS="1520" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="3816" VPOS="1555" />
+            <a:String CONTENT=".el" HEIGHT="43" WIDTH="41" HPOS="3816" VPOS="1518" WC="0.93" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0239" WIDTH="324" HEIGHT="49" HPOS="3032" VPOS="1581">
+            <a:String CONTENT="mÃ¡s" HEIGHT="38" WIDTH="89" HPOS="3032" VPOS="1583" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="3151" VPOS="1593" />
+            <a:String CONTENT="prÃ³ximo." HEIGHT="49" WIDTH="205" HPOS="3151" VPOS="1581" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0039" HEIGHT="1294" WIDTH="838" HPOS="3032" VPOS="1627" STYLEREFS="PARSTYLE0022">
+          <a:TextLine ID="PAG001LIN0240" WIDTH="774" HEIGHT="52" HPOS="3086" VPOS="1627">
+            <a:String CONTENT="Galicia" HEIGHT="38" WIDTH="173" HPOS="3086" VPOS="1637" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="3289" VPOS="1646" />
+            <a:String CONTENT="calla;" HEIGHT="47" WIDTH="137" HPOS="3289" VPOS="1632" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3457" VPOS="1641" />
+            <a:String CONTENT="sernos" HEIGHT="32" WIDTH="149" HPOS="3457" VPOS="1638" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3635" VPOS="1627" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="51" HPOS="3635" VPOS="1627" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3718" VPOS="1628" />
+            <a:String CONTENT="interÂ¬" HEIGHT="38" WIDTH="142" HPOS="3718" VPOS="1627" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="interpretar," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0241" WIDTH="830" HEIGHT="60" HPOS="3032" VPOS="1681">
+            <a:String CONTENT="pretar," HEIGHT="50" WIDTH="156" HPOS="3032" VPOS="1691" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="30" HPOS="3218" VPOS="1691" />
+            <a:String CONTENT="favorablemente" HEIGHT="43" WIDTH="380" HPOS="3218" VPOS="1685" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="3631" VPOS="1694" />
+            <a:String CONTENT="su" HEIGHT="32" WIDTH="55" HPOS="3631" VPOS="1694" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="3719" VPOS="1692" />
+            <a:String CONTENT="silenÂ¬" HEIGHT="39" WIDTH="143" HPOS="3719" VPOS="1681" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="silencio" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0242" WIDTH="825" HEIGHT="60" HPOS="3035" VPOS="1735">
+            <a:String CONTENT="cio" HEIGHT="40" WIDTH="72" HPOS="3035" VPOS="1745" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="21" HPOS="3128" VPOS="1756" />
+            <a:String CONTENT="que" HEIGHT="40" WIDTH="87" HPOS="3128" VPOS="1755" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3240" VPOS="1744" />
+            <a:String CONTENT="bien" HEIGHT="39" WIDTH="103" HPOS="3240" VPOS="1744" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3367" VPOS="1753" />
+            <a:String CONTENT="puede" HEIGHT="50" WIDTH="141" HPOS="3367" VPOS="1741" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3535" VPOS="1749" />
+            <a:String CONTENT="ser" HEIGHT="29" WIDTH="73" HPOS="3535" VPOS="1749" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3634" VPOS="1748" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="39" HPOS="3634" VPOS="1739" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3700" VPOS="1747" />
+            <a:String CONTENT="propio" HEIGHT="51" WIDTH="160" HPOS="3700" VPOS="1735" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0243" WIDTH="827" HEIGHT="60" HPOS="3034" VPOS="1786">
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="53" HPOS="3034" VPOS="1800" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3114" VPOS="1786" />
+            <a:String CONTENT="Ãºna" HEIGHT="52" WIDTH="89" HPOS="3114" VPOS="1786" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3228" VPOS="1808" />
+            <a:String CONTENT="germinaciÃ³n" HEIGHT="50" WIDTH="308" HPOS="3228" VPOS="1796" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3563" VPOS="1794" />
+            <a:String CONTENT="fecunda." HEIGHT="41" WIDTH="208" HPOS="3563" VPOS="1791" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3796" VPOS="1790" />
+            <a:String CONTENT="Na" HEIGHT="38" WIDTH="65" HPOS="3796" VPOS="1790" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0244" WIDTH="826" HEIGHT="55" HPOS="3036" VPOS="1844">
+            <a:String CONTENT="da" HEIGHT="39" WIDTH="56" HPOS="3036" VPOS="1854" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3121" VPOS="1864" />
+            <a:String CONTENT="en" HEIGHT="30" WIDTH="55" HPOS="3121" VPOS="1863" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3205" VPOS="1853" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="43" HPOS="3205" VPOS="1853" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="3278" VPOS="1863" />
+            <a:String CONTENT="agitaciÃ³n" HEIGHT="48" WIDTH="228" HPOS="3278" VPOS="1851" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3533" VPOS="1850" />
+            <a:String CONTENT="tan" HEIGHT="36" WIDTH="79" HPOS="3533" VPOS="1850" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3643" VPOS="1856" />
+            <a:String CONTENT="pronto" HEIGHT="51" WIDTH="164" HPOS="3643" VPOS="1844" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3834" VPOS="1854" />
+            <a:String CONTENT="y" HEIGHT="40" WIDTH="28" HPOS="3834" VPOS="1854" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0245" WIDTH="826" HEIGHT="44" HPOS="3035" VPOS="1902">
+            <a:String CONTENT="tan" HEIGHT="38" WIDTH="79" HPOS="3035" VPOS="1908" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="15" HPOS="3129" VPOS="1908" />
+            <a:String CONTENT="fÃ¡cilmente" HEIGHT="40" WIDTH="259" HPOS="3129" VPOS="1906" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="3416" VPOS="1915" />
+            <a:String CONTENT="se" HEIGHT="28" WIDTH="47" HPOS="3416" VPOS="1915" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3489" VPOS="1913" />
+            <a:String CONTENT="muestra," HEIGHT="44" WIDTH="215" HPOS="3489" VPOS="1902" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="3732" VPOS="1910" />
+            <a:String CONTENT="como" HEIGHT="31" WIDTH="129" HPOS="3732" VPOS="1907" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0246" WIDTH="824" HEIGHT="56" HPOS="3037" VPOS="1953">
+            <a:String CONTENT="lo" HEIGHT="39" WIDTH="45" HPOS="3037" VPOS="1962" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3105" VPOS="1972" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="86" HPOS="3105" VPOS="1971" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="3219" VPOS="1971" />
+            <a:String CONTENT="estÃ¡" HEIGHT="40" WIDTH="99" HPOS="3219" VPOS="1960" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3344" VPOS="1969" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="54" HPOS="3344" VPOS="1969" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3425" VPOS="1960" />
+            <a:String CONTENT="la" HEIGHT="46" WIDTH="42" HPOS="3425" VPOS="1960" WC="0.73" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3494" VPOS="1967" />
+            <a:String CONTENT="superficie." HEIGHT="52" WIDTH="258" HPOS="3494" VPOS="1955" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3779" VPOS="1953" />
+            <a:String CONTENT="Tie" HEIGHT="42" WIDTH="82" HPOS="3779" VPOS="1953" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0247" WIDTH="826" HEIGHT="52" HPOS="3036" VPOS="2009">
+            <a:String CONTENT="nen" HEIGHT="33" WIDTH="88" HPOS="3036" VPOS="2026" WC="0.87" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3155" VPOS="2016" />
+            <a:String CONTENT="los" HEIGHT="38" WIDTH="68" HPOS="3155" VPOS="2016" WC="0.88" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="3259" VPOS="2024" />
+            <a:String CONTENT="sentires" HEIGHT="38" WIDTH="193" HPOS="3259" VPOS="2014" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="3485" VPOS="2022" />
+            <a:String CONTENT="profundos," HEIGHT="52" WIDTH="266" HPOS="3485" VPOS="2009" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="3786" VPOS="2018" />
+            <a:String CONTENT="exÂ¬" HEIGHT="29" WIDTH="76" HPOS="3786" VPOS="2017" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="expresiones" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0248" WIDTH="824" HEIGHT="58" HPOS="3038" VPOS="2060">
+            <a:String CONTENT="presiones" HEIGHT="48" WIDTH="234" HPOS="3038" VPOS="2070" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="33" HPOS="3305" VPOS="2067" />
+            <a:String CONTENT="tardÃ­as.-" HEIGHT="39" WIDTH="197" HPOS="3305" VPOS="2067" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3526" VPOS="2066" />
+            <a:String CONTENT="Han" HEIGHT="39" WIDTH="98" HPOS="3526" VPOS="2066" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3656" VPOS="2064" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="3656" VPOS="2064" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3742" VPOS="2073" />
+            <a:String CONTENT="serlo" HEIGHT="42" WIDTH="120" HPOS="3742" VPOS="2060" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0249" WIDTH="824" HEIGHT="52" HPOS="3040" VPOS="2116">
+            <a:String CONTENT="sobre" HEIGHT="38" WIDTH="130" HPOS="3040" VPOS="2124" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="3205" VPOS="2123" />
+            <a:String CONTENT="todo" HEIGHT="42" WIDTH="105" HPOS="3205" VPOS="2121" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3344" VPOS="2121" />
+            <a:String CONTENT="las" HEIGHT="40" WIDTH="69" HPOS="3344" VPOS="2121" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="3449" VPOS="2122" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="3449" VPOS="2122" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="3537" VPOS="2129" />
+            <a:String CONTENT="quienes," HEIGHT="49" WIDTH="198" HPOS="3537" VPOS="2119" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="3770" VPOS="2127" />
+            <a:String CONTENT="priÂ¬" HEIGHT="49" WIDTH="94" HPOS="3770" VPOS="2116" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="privados" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0250" WIDTH="826" HEIGHT="54" HPOS="3037" VPOS="2170">
+            <a:String CONTENT="vados" HEIGHT="39" WIDTH="137" HPOS="3037" VPOS="2176" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="30" HPOS="3204" VPOS="2187" />
+            <a:String CONTENT="mucho" HEIGHT="40" WIDTH="162" HPOS="3204" VPOS="2174" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="3394" VPOS="2176" />
+            <a:String CONTENT="tiempo" HEIGHT="48" WIDTH="168" HPOS="3394" VPOS="2176" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="3592" VPOS="2174" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="3592" VPOS="2174" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3673" VPOS="2174" />
+            <a:String CONTENT="libertad" HEIGHT="40" WIDTH="190" HPOS="3673" VPOS="2170" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0251" WIDTH="825" HEIGHT="51" HPOS="3040" VPOS="2227">
+            <a:String CONTENT="anhelan" HEIGHT="39" WIDTH="193" HPOS="3040" VPOS="2229" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3259" VPOS="2241" />
+            <a:String CONTENT="prÃ¡cticas" HEIGHT="49" WIDTH="226" HPOS="3259" VPOS="2229" WC="0.86" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3514" VPOS="2228" />
+            <a:String CONTENT="libertades," HEIGHT="45" WIDTH="254" HPOS="3514" VPOS="2227" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3793" VPOS="2232" />
+            <a:String CONTENT="reÂ¬" HEIGHT="31" WIDTH="72" HPOS="3793" VPOS="2232" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="recelan" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0252" WIDTH="823" HEIGHT="52" HPOS="3040" VPOS="2279">
+            <a:String CONTENT="celan" HEIGHT="39" WIDTH="128" HPOS="3040" VPOS="2283" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="23" HPOS="3191" VPOS="2279" />
+            <a:String CONTENT="de" HEIGHT="43" WIDTH="51" HPOS="3191" VPOS="2279" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3269" VPOS="2283" />
+            <a:String CONTENT="los" HEIGHT="39" WIDTH="67" HPOS="3269" VPOS="2283" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3363" VPOS="2293" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="83" HPOS="3363" VPOS="2293" WC="0.91" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3472" VPOS="2283" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="67" HPOS="3472" VPOS="2283" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3565" VPOS="2283" />
+            <a:String CONTENT="teorizan." HEIGHT="38" WIDTH="213" HPOS="3565" VPOS="2282" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3802" VPOS="2279" />
+            <a:String CONTENT="Es" HEIGHT="39" WIDTH="61" HPOS="3802" VPOS="2279" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0253" WIDTH="826" HEIGHT="55" HPOS="3040" VPOS="2336">
+            <a:String CONTENT="cantinela" HEIGHT="40" WIDTH="226" HPOS="3040" VPOS="2337" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3291" VPOS="2347" />
+            <a:String CONTENT="muy" HEIGHT="38" WIDTH="104" HPOS="3291" VPOS="2347" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3419" VPOS="2346" />
+            <a:String CONTENT="oÃ­da," HEIGHT="55" WIDTH="113" HPOS="3419" VPOS="2336" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3559" VPOS="2337" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="43" HPOS="3559" VPOS="2337" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3626" VPOS="2345" />
+            <a:String CONTENT="encarece-," HEIGHT="30" WIDTH="240" HPOS="3626" VPOS="2343" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0254" WIDTH="837" HEIGHT="49" HPOS="3032" VPOS="2388">
+            <a:String CONTENT="dora" HEIGHT="38" WIDTH="109" HPOS="3032" VPOS="2390" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="3174" VPOS="2390" />
+            <a:String CONTENT="de-" HEIGHT="38" WIDTH="68" HPOS="3174" VPOS="2390" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="3261" VPOS="2389" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="43" HPOS="3261" VPOS="2389" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="49" HPOS="3353" VPOS="2389" />
+            <a:String CONTENT="libertad" HEIGHT="39" WIDTH="190" HPOS="3353" VPOS="2389" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="48" HPOS="3591" VPOS="2399" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="29" HPOS="3591" VPOS="2399" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3652" VPOS="2388" />
+            <a:String CONTENT="denostaÂ¬" HEIGHT="38" WIDTH="217" HPOS="3652" VPOS="2388" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="denostadora" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0255" WIDTH="826" HEIGHT="49" HPOS="3040" VPOS="2444">
+            <a:String CONTENT="dora" HEIGHT="39" WIDTH="109" HPOS="3040" VPOS="2444" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="27" HPOS="3176" VPOS="2444" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="3176" VPOS="2444" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3254" VPOS="2444" />
+            <a:String CONTENT="la" HEIGHT="46" WIDTH="43" HPOS="3254" VPOS="2444" WC="0.74" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3323" VPOS="2455" />
+            <a:String CONTENT="centralizaciÃ³n," HEIGHT="49" WIDTH="361" HPOS="3323" VPOS="2444" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="3712" VPOS="2453" />
+            <a:String CONTENT="su" HEIGHT="28" WIDTH="53" HPOS="3712" VPOS="2453" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3791" VPOS="2452" />
+            <a:String CONTENT="ma" HEIGHT="28" WIDTH="75" HPOS="3791" VPOS="2452" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0256" WIDTH="825" HEIGHT="48" HPOS="3041" VPOS="2497">
+            <a:String CONTENT="yor" HEIGHT="38" WIDTH="78" HPOS="3041" VPOS="2507" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3148" VPOS="2507" />
+            <a:String CONTENT="enemiga." HEIGHT="47" WIDTH="216" HPOS="3148" VPOS="2498" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3393" VPOS="2498" />
+            <a:String CONTENT="No" HEIGHT="39" WIDTH="64" HPOS="3393" VPOS="2498" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="3487" VPOS="2508" />
+            <a:String CONTENT="cesaron" HEIGHT="32" WIDTH="190" HPOS="3487" VPOS="2507" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="3707" VPOS="2497" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="67" HPOS="3707" VPOS="2497" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3806" VPOS="2498" />
+            <a:String CONTENT="im" HEIGHT="35" WIDTH="60" HPOS="3806" VPOS="2498" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0257" WIDTH="824" HEIGHT="50" HPOS="3041" VPOS="2549">
+            <a:String CONTENT="posiciones" HEIGHT="47" WIDTH="256" HPOS="3041" VPOS="2552" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="3337" VPOS="2552" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="52" HPOS="3337" VPOS="2552" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="3428" VPOS="2551" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="42" HPOS="3428" VPOS="2551" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="3510" VPOS="2552" />
+            <a:String CONTENT="fuerza" HEIGHT="42" WIDTH="153" HPOS="3510" VPOS="2552" WC="0.83" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="3702" VPOS="2561" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="27" HPOS="3702" VPOS="2561" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="3766" VPOS="2560" />
+            <a:String CONTENT="mÃ¡s" HEIGHT="39" WIDTH="99" HPOS="3766" VPOS="2549" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0258" WIDTH="823" HEIGHT="47" HPOS="3044" VPOS="2605">
+            <a:String CONTENT="fuerza" HEIGHT="38" WIDTH="155" HPOS="3044" VPOS="2605" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="3239" VPOS="2615" />
+            <a:String CONTENT="representan" HEIGHT="40" WIDTH="297" HPOS="3239" VPOS="2612" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="3580" VPOS="2607" />
+            <a:String CONTENT="las" HEIGHT="36" WIDTH="65" HPOS="3580" VPOS="2607" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="3689" VPOS="2616" />
+            <a:String CONTENT="ocasioÂ¬" HEIGHT="38" WIDTH="178" HPOS="3689" VPOS="2605" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="ocasionales" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0259" WIDTH="827" HEIGHT="49" HPOS="3040" VPOS="2658">
+            <a:String CONTENT="nales" HEIGHT="38" WIDTH="128" HPOS="3040" VPOS="2659" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="26" HPOS="3194" VPOS="2668" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="54" HPOS="3194" VPOS="2668" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3275" VPOS="2669" />
+            <a:String CONTENT="su" HEIGHT="28" WIDTH="52" HPOS="3275" VPOS="2669" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="3355" VPOS="2659" />
+            <a:String CONTENT="intervenciÃ³n" HEIGHT="40" WIDTH="306" HPOS="3355" VPOS="2659" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3685" VPOS="2669" />
+            <a:String CONTENT="pasajeÂ¬" HEIGHT="49" WIDTH="182" HPOS="3685" VPOS="2658" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="pasajera" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0260" WIDTH="826" HEIGHT="49" HPOS="3040" VPOS="2712">
+            <a:String CONTENT="ra" HEIGHT="29" WIDTH="52" HPOS="3040" VPOS="2722" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="25" HPOS="3117" VPOS="2722" />
+            <a:String CONTENT="que," HEIGHT="39" WIDTH="97" HPOS="3117" VPOS="2722" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3241" VPOS="2722" />
+            <a:String CONTENT="seÃ±alando" HEIGHT="41" WIDTH="244" HPOS="3241" VPOS="2712" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3512" VPOS="2723" />
+            <a:String CONTENT="otros" HEIGHT="38" WIDTH="123" HPOS="3512" VPOS="2713" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3661" VPOS="2713" />
+            <a:String CONTENT="destinos" HEIGHT="40" WIDTH="205" HPOS="3661" VPOS="2712" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0261" WIDTH="824" HEIGHT="48" HPOS="3043" VPOS="2766">
+            <a:String CONTENT="con" HEIGHT="30" WIDTH="84" HPOS="3043" VPOS="2775" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3156" VPOS="2776" />
+            <a:String CONTENT="sui" HEIGHT="37" WIDTH="70" HPOS="3156" VPOS="2767" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="3254" VPOS="2776" />
+            <a:String CONTENT="mpulso" HEIGHT="47" WIDTH="178" HPOS="3254" VPOS="2766" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3461" VPOS="2777" />
+            <a:String CONTENT="prepara" HEIGHT="38" WIDTH="191" HPOS="3461" VPOS="2776" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3684" VPOS="2767" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="67" HPOS="3684" VPOS="2767" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3782" VPOS="2776" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="85" HPOS="3782" VPOS="2776" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0262" WIDTH="824" HEIGHT="48" HPOS="3044" VPOS="2819">
+            <a:String CONTENT="sin" HEIGHT="38" WIDTH="71" HPOS="3044" VPOS="2821" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3138" VPOS="2830" />
+            <a:String CONTENT="otros" HEIGHT="39" WIDTH="122" HPOS="3138" VPOS="2820" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3285" VPOS="2820" />
+            <a:String CONTENT="impulsos" HEIGHT="48" WIDTH="219" HPOS="3285" VPOS="2819" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3528" VPOS="2821" />
+            <a:String CONTENT="habrÃ¡n" HEIGHT="38" WIDTH="171" HPOS="3528" VPOS="2820" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3721" VPOS="2820" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="3721" VPOS="2820" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3795" VPOS="2829" />
+            <a:String CONTENT="ma" HEIGHT="31" WIDTH="73" HPOS="3795" VPOS="2829" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0263" WIDTH="218" HEIGHT="48" HPOS="3044" VPOS="2872">
+            <a:String CONTENT="lograrse." HEIGHT="48" WIDTH="218" HPOS="3044" VPOS="2872" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0040" HEIGHT="151" WIDTH="828" HPOS="3042" VPOS="2926" STYLEREFS="PARSTYLE0023">
+          <a:TextLine ID="PAG001LIN0264" WIDTH="771" HEIGHT="48" HPOS="3098" VPOS="2926">
+            <a:String CONTENT="Vigila" HEIGHT="48" WIDTH="145" HPOS="3098" VPOS="2926" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="3285" VPOS="2936" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="39" HPOS="3285" VPOS="2926" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="3367" VPOS="2937" />
+            <a:String CONTENT="espÃ­ritu" HEIGHT="47" WIDTH="192" HPOS="3367" VPOS="2927" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="3602" VPOS="2938" />
+            <a:String CONTENT="centraliza-" HEIGHT="40" WIDTH="267" HPOS="3602" VPOS="2927" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="centralizaÃ­Jor," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0265" WIDTH="826" HEIGHT="52" HPOS="3042" VPOS="2978">
+            <a:String CONTENT="Ã­Jor," HEIGHT="52" WIDTH="95" HPOS="3042" VPOS="2978" WC="0.94" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="3168" VPOS="2989" />
+            <a:String CONTENT="y" HEIGHT="39" WIDTH="28" HPOS="3168" VPOS="2989" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3227" VPOS="2989" />
+            <a:String CONTENT="aun" HEIGHT="30" WIDTH="89" HPOS="3227" VPOS="2989" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3345" VPOS="2988" />
+            <a:String CONTENT="pudiera" HEIGHT="47" WIDTH="187" HPOS="3345" VPOS="2981" WC="0.85" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3564" VPOS="2991" />
+            <a:String CONTENT="suceder" HEIGHT="37" WIDTH="186" HPOS="3564" VPOS="2983" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3784" VPOS="2993" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="84" HPOS="3784" VPOS="2992" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0266" WIDTH="823" HEIGHT="41" HPOS="3045" VPOS="3035">
+            <a:String CONTENT="se" HEIGHT="29" WIDTH="48" HPOS="3045" VPOS="3042" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="3112" VPOS="3045" />
+            <a:String CONTENT="encaramase" HEIGHT="30" WIDTH="291" HPOS="3112" VPOS="3043" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3425" VPOS="3044" />
+            <a:String CONTENT="sobre" HEIGHT="39" WIDTH="130" HPOS="3425" VPOS="3035" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3578" VPOS="3037" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="66" HPOS="3578" VPOS="3037" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3666" VPOS="3047" />
+            <a:String CONTENT="ruinas..." HEIGHT="38" WIDTH="202" HPOS="3666" VPOS="3038" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0041" HEIGHT="312" WIDTH="837" HPOS="3037" VPOS="3086" STYLEREFS="PARSTYLE0024">
+          <a:TextLine ID="PAG001LIN0267" WIDTH="772" HEIGHT="52" HPOS="3097" VPOS="3086">
+            <a:String CONTENT="Si" HEIGHT="39" WIDTH="44" HPOS="3097" VPOS="3086" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3167" VPOS="3098" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="39" HPOS="3167" VPOS="3087" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3233" VPOS="3096" />
+            <a:String CONTENT="silencio" HEIGHT="40" WIDTH="185" HPOS="3233" VPOS="3087" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3444" VPOS="3088" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="69" HPOS="3444" VPOS="3088" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3539" VPOS="3100" />
+            <a:String CONTENT="pueblo" HEIGHT="46" WIDTH="160" HPOS="3539" VPOS="3090" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3726" VPOS="3101" />
+            <a:String CONTENT="galleÂ¬" HEIGHT="48" WIDTH="143" HPOS="3726" VPOS="3090" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="gallego" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0268" WIDTH="819" HEIGHT="48" HPOS="3051" VPOS="3140">
+            <a:String CONTENT="go" HEIGHT="39" WIDTH="55" HPOS="3051" VPOS="3149" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="44" HPOS="3150" VPOS="3150" />
+            <a:String CONTENT="significase" HEIGHT="48" WIDTH="265" HPOS="3150" VPOS="3140" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="3461" VPOS="3143" />
+            <a:String CONTENT="indiferencia," HEIGHT="45" WIDTH="309" HPOS="3461" VPOS="3143" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="45" HPOS="3815" VPOS="3154" />
+            <a:String CONTENT="en" HEIGHT="27" WIDTH="55" HPOS="3815" VPOS="3154" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0269" WIDTH="822" HEIGHT="49" HPOS="3047" VPOS="3194">
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="84" HPOS="3047" VPOS="3203" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3165" VPOS="3204" />
+            <a:String CONTENT="nuevamente" HEIGHT="40" WIDTH="295" HPOS="3165" VPOS="3194" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3494" VPOS="3205" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="28" HPOS="3494" VPOS="3205" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3556" VPOS="3207" />
+            <a:String CONTENT="como" HEIGHT="35" WIDTH="125" HPOS="3556" VPOS="3206" WC="0.68" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="3716" VPOS="3208" />
+            <a:String CONTENT="venciÃ³-" HEIGHT="42" WIDTH="153" HPOS="3716" VPOS="3198" WC="0.87" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="venciÃ³do" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0270" WIDTH="836" HEIGHT="52" HPOS="3037" VPOS="3246">
+            <a:String CONTENT="do" HEIGHT="38" WIDTH="55" HPOS="3037" VPOS="3246" WC="0.87" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="3123" VPOS="3255" />
+            <a:String CONTENT="se" HEIGHT="30" WIDTH="47" HPOS="3123" VPOS="3255" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="3200" VPOS="3256" />
+            <a:String CONTENT="entregase," HEIGHT="47" WIDTH="254" HPOS="3200" VPOS="3247" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3486" VPOS="3256" />
+            <a:String CONTENT="i" HEIGHT="36" WIDTH="11" HPOS="3486" VPOS="3256" WC="0.9" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="10" HPOS="3507" VPOS="3259" />
+            <a:String CONTENT="cuÃ¡ntas" HEIGHT="38" WIDTH="190" HPOS="3507" VPOS="3249" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3728" VPOS="3261" />
+            <a:String CONTENT="y" HEIGHT="36" WIDTH="28" HPOS="3728" VPOS="3261" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3787" VPOS="3261" />
+            <a:String CONTENT="quÃ©" HEIGHT="47" WIDTH="86" HPOS="3787" VPOS="3251" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0271" WIDTH="816" HEIGHT="49" HPOS="3052" VPOS="3300">
+            <a:String CONTENT="dolorosas" HEIGHT="39" WIDTH="237" HPOS="3052" VPOS="3300" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="3335" VPOS="3302" />
+            <a:String CONTENT="habrÃ­an" HEIGHT="39" WIDTH="190" HPOS="3335" VPOS="3301" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="3567" VPOS="3303" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="53" HPOS="3567" VPOS="3303" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="3666" VPOS="3313" />
+            <a:String CONTENT="ser," HEIGHT="36" WIDTH="85" HPOS="3666" VPOS="3313" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="49" HPOS="3800" VPOS="3305" />
+            <a:String CONTENT="las" HEIGHT="38" WIDTH="68" HPOS="3800" VPOS="3305" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0272" WIDTH="795" HEIGHT="42" HPOS="3046" VPOS="3355">
+            <a:String CONTENT="consecuencias" HEIGHT="37" WIDTH="349" HPOS="3046" VPOS="3355" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3426" VPOS="3356" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="68" HPOS="3426" VPOS="3356" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="3523" VPOS="3367" />
+            <a:String CONTENT="vencimiento!" HEIGHT="39" WIDTH="318" HPOS="3523" VPOS="3358" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0042" HEIGHT="46" WIDTH="685" HPOS="3186" VPOS="3431" STYLEREFS="PARSTYLE0025">
+          <a:TextLine ID="PAG001LIN0273" WIDTH="684" HEIGHT="45" HPOS="3186" VPOS="3431">
+            <a:String CONTENT="El" HEIGHT="35" WIDTH="47" HPOS="3186" VPOS="3431" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="35" HPOS="3268" VPOS="3431" />
+            <a:String CONTENT="MarquÃ©s" HEIGHT="45" WIDTH="210" HPOS="3268" VPOS="3431" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="31" HPOS="3509" VPOS="3433" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="52" HPOS="3509" VPOS="3433" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="34" HPOS="3595" VPOS="3434" />
+            <a:String CONTENT="F1GUEROA" HEIGHT="39" WIDTH="275" HPOS="3595" VPOS="3433" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:ComposedBlock ID="PAG001BLK0043" HEIGHT="1243" WIDTH="897" HPOS="2996" VPOS="3576" />
+        <a:TextBlock ID="PAG001BLK0044" HEIGHT="145" WIDTH="833" HPOS="3044" VPOS="3588" STYLEREFS="PARSTYLE0026">
+          <a:TextLine ID="PAG001LIN0274" WIDTH="832" HEIGHT="144" HPOS="3044" VPOS="3588">
+            <a:String CONTENT="ESTELAS" HEIGHT="144" WIDTH="832" HPOS="3044" VPOS="3588" WC="1" STYLEREFS="TEXTSTYLE0008" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0045" HEIGHT="95" WIDTH="829" HPOS="3048" VPOS="3754" STYLEREFS="PARSTYLE0027">
+          <a:TextLine ID="PAG001LIN0275" WIDTH="828" HEIGHT="44" HPOS="3048" VPOS="3754">
+            <a:String CONTENT="PARABOLA" HEIGHT="39" WIDTH="286" HPOS="3048" VPOS="3754" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="3362" VPOS="3757" />
+            <a:String CONTENT="DE" HEIGHT="35" WIDTH="71" HPOS="3362" VPOS="3757" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="3461" VPOS="3757" />
+            <a:String CONTENT="LA" HEIGHT="37" WIDTH="68" HPOS="3461" VPOS="3757" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="27" HPOS="3556" VPOS="3759" />
+            <a:String CONTENT="PIEDRA" HEIGHT="38" WIDTH="202" HPOS="3556" VPOS="3759" WC="0.98" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="25" HPOS="3783" VPOS="3761" />
+            <a:String CONTENT="SOÂ¬" HEIGHT="37" WIDTH="93" HPOS="3783" VPOS="3761" WC="1" STYLEREFS="TEXTSTYLE0001" SUBS_TYPE="HypPart1" SUBS_CONTENT="SOCAVADA" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0276" WIDTH="214" HEIGHT="38" HPOS="3342" VPOS="3810">
+            <a:String CONTENT="CAVADA" HEIGHT="38" WIDTH="214" HPOS="3342" VPOS="3810" WC="1" STYLEREFS="TEXTSTYLE0001" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0046" HEIGHT="952" WIDTH="863" HPOS="3013" VPOS="3859" STYLEREFS="PARSTYLE0028">
+          <a:TextLine ID="PAG001LIN0277" WIDTH="775" HEIGHT="52" HPOS="3100" VPOS="3859">
+            <a:String CONTENT="El" HEIGHT="37" WIDTH="50" HPOS="3100" VPOS="3859" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="3181" VPOS="3870" />
+            <a:String CONTENT="aÃ±o" HEIGHT="37" WIDTH="84" HPOS="3181" VPOS="3861" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="31" HPOS="3296" VPOS="3872" />
+            <a:String CONTENT="pasado," HEIGHT="44" WIDTH="182" HPOS="3296" VPOS="3864" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="31" HPOS="3509" VPOS="3864" />
+            <a:String CONTENT="despuÃ©s" HEIGHT="47" WIDTH="191" HPOS="3509" VPOS="3864" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3732" VPOS="3867" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="52" HPOS="3732" VPOS="3867" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="3814" VPOS="3877" />
+            <a:String CONTENT="un" HEIGHT="27" WIDTH="61" HPOS="3814" VPOS="3877" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0278" WIDTH="861" HEIGHT="51" HPOS="3013" VPOS="3912">
+            <a:String CONTENT="&lt;" HEIGHT="20" WIDTH="8" HPOS="3013" VPOS="3921" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="3047" VPOS="3920" />
+            <a:String CONTENT="romÃ¡ntico" HEIGHT="39" WIDTH="251" HPOS="3047" VPOS="3912" WC="0.98" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="28" HPOS="3326" VPOS="3921" />
+            <a:String CONTENT="perip:c" HEIGHT="46" WIDTH="169" HPOS="3326" VPOS="3915" WC="0.6" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="3523" VPOS="3921" />
+            <a:String CONTENT="por" HEIGHT="42" WIDTH="80" HPOS="3523" VPOS="3921" WC="0.98" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="29" HPOS="3632" VPOS="3918" />
+            <a:String CONTENT="tierras" HEIGHT="45" WIDTH="164" HPOS="3632" VPOS="3918" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3823" VPOS="3919" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="51" HPOS="3823" VPOS="3919" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0279" WIDTH="827" HEIGHT="50" HPOS="3047" VPOS="3962">
+            <a:String CONTENT="Portugal," HEIGHT="50" WIDTH="228" HPOS="3047" VPOS="3962" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3300" VPOS="3966" />
+            <a:String CONTENT="fui" HEIGHT="38" WIDTH="67" HPOS="3300" VPOS="3966" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3391" VPOS="3978" />
+            <a:String CONTENT="a" HEIGHT="26" WIDTH="24" HPOS="3391" VPOS="3978" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="3438" VPOS="3977" />
+            <a:String CONTENT="remansar" HEIGHT="30" WIDTH="235" HPOS="3438" VPOS="3977" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3697" VPOS="3981" />
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="39" HPOS="3697" VPOS="3971" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3758" VPOS="3981" />
+            <a:String CONTENT="vano" HEIGHT="30" WIDTH="116" HPOS="3758" VPOS="3981" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0280" WIDTH="827" HEIGHT="48" HPOS="3047" VPOS="4017">
+            <a:String CONTENT="arroyo" HEIGHT="39" WIDTH="160" HPOS="3047" VPOS="4026" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3230" VPOS="4017" />
+            <a:String CONTENT="de" HEIGHT="40" WIDTH="51" HPOS="3230" VPOS="4017" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="23" HPOS="3304" VPOS="4028" />
+            <a:String CONTENT="mis" HEIGHT="39" WIDTH="86" HPOS="3304" VPOS="4019" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="22" HPOS="3412" VPOS="4029" />
+            <a:String CONTENT="emociones" HEIGHT="39" WIDTH="254" HPOS="3412" VPOS="4022" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3690" VPOS="4034" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="55" HPOS="3690" VPOS="4034" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="3766" VPOS="4035" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="42" HPOS="3766" VPOS="4025" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="3829" VPOS="4027" />
+            <a:String CONTENT="hi" HEIGHT="37" WIDTH="45" HPOS="3829" VPOS="4026" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0281" WIDTH="826" HEIGHT="48" HPOS="3047" VPOS="4070">
+            <a:String CONTENT="dalgo" HEIGHT="48" WIDTH="132" HPOS="3047" VPOS="4070" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3202" VPOS="4081" />
+            <a:String CONTENT="caserÃ³n" HEIGHT="39" WIDTH="192" HPOS="3202" VPOS="4072" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="20" HPOS="3414" VPOS="4074" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="53" HPOS="3414" VPOS="4074" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3489" VPOS="4084" />
+            <a:String CONTENT="mi" HEIGHT="37" WIDTH="61" HPOS="3489" VPOS="4075" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3573" VPOS="4086" />
+            <a:String CONTENT="maestro" HEIGHT="39" WIDTH="199" HPOS="3573" VPOS="4078" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3795" VPOS="4079" />
+            <a:String CONTENT="Tei" HEIGHT="39" WIDTH="78" HPOS="3795" VPOS="4079" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0282" WIDTH="827" HEIGHT="48" HPOS="3047" VPOS="4123">
+            <a:String CONTENT="xeira" HEIGHT="39" WIDTH="122" HPOS="3047" VPOS="4123" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3194" VPOS="4124" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="3194" VPOS="4124" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3272" VPOS="4125" />
+            <a:String CONTENT="Pascoaes." HEIGHT="41" WIDTH="239" HPOS="3272" VPOS="4125" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3537" VPOS="4129" />
+            <a:String CONTENT="Del" HEIGHT="38" WIDTH="78" HPOS="3537" VPOS="4129" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3639" VPOS="4139" />
+            <a:String CONTENT="noble" HEIGHT="38" WIDTH="131" HPOS="3639" VPOS="4131" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3797" VPOS="4142" />
+            <a:String CONTENT="soÂ¬" HEIGHT="29" WIDTH="77" HPOS="3797" VPOS="4142" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="solar" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0283" WIDTH="825" HEIGHT="56" HPOS="3048" VPOS="4176">
+            <a:String CONTENT="lar" HEIGHT="38" WIDTH="68" HPOS="3048" VPOS="4176" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="21" HPOS="3137" VPOS="4177" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="3137" VPOS="4177" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3211" VPOS="4179" />
+            <a:String CONTENT="Amarante," HEIGHT="46" WIDTH="255" HPOS="3211" VPOS="4179" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3489" VPOS="4180" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="3489" VPOS="4180" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3563" VPOS="4192" />
+            <a:String CONTENT="aquel" HEIGHT="47" WIDTH="130" HPOS="3563" VPOS="4183" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3718" VPOS="4194" />
+            <a:String CONTENT="paisaÂ¬" HEIGHT="47" WIDTH="155" HPOS="3718" VPOS="4185" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="paisaje" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0284" WIDTH="827" HEIGHT="56" HPOS="3047" VPOS="4229">
+            <a:String CONTENT="je" HEIGHT="48" WIDTH="44" HPOS="3047" VPOS="4229" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="21" HPOS="3112" VPOS="4230" />
+            <a:String CONTENT="blando," HEIGHT="46" WIDTH="175" HPOS="3112" VPOS="4230" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3311" VPOS="4241" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="83" HPOS="3311" VPOS="4241" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3416" VPOS="4242" />
+            <a:String CONTENT="se" HEIGHT="29" WIDTH="48" HPOS="3416" VPOS="4242" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3487" VPOS="4245" />
+            <a:String CONTENT="agazapa" HEIGHT="39" WIDTH="197" HPOS="3487" VPOS="4244" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="3703" VPOS="4238" />
+            <a:String CONTENT="bajo" HEIGHT="47" WIDTH="106" HPOS="3703" VPOS="4238" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3831" VPOS="4239" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="43" HPOS="3831" VPOS="4239" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0285" WIDTH="833" HEIGHT="57" HPOS="3046" VPOS="4283">
+            <a:String CONTENT="granÃ­tica" HEIGHT="48" WIDTH="223" HPOS="3046" VPOS="4283" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3303" VPOS="4295" />
+            <a:String CONTENT="amenaza" HEIGHT="33" WIDTH="212" HPOS="3303" VPOS="4292" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="3548" VPOS="4288" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="68" HPOS="3548" VPOS="4288" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3650" VPOS="4289" />
+            <a:String CONTENT="Marao," HEIGHT="48" WIDTH="165" HPOS="3650" VPOS="4289" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3847" VPOS="4303" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="26" HPOS="3847" VPOS="4303" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0286" WIDTH="825" HEIGHT="53" HPOS="3047" VPOS="4336">
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="69" HPOS="3047" VPOS="4336" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="3137" VPOS="4347" />
+            <a:String CONTENT="comercio" HEIGHT="38" WIDTH="221" HPOS="3137" VPOS="4339" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3380" VPOS="4350" />
+            <a:String CONTENT="espiritual" HEIGHT="46" WIDTH="235" HPOS="3380" VPOS="4340" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3639" VPOS="4353" />
+            <a:String CONTENT="que" HEIGHT="36" WIDTH="82" HPOS="3639" VPOS="4353" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="3742" VPOS="4354" />
+            <a:String CONTENT="manÂ¬" HEIGHT="28" WIDTH="130" HPOS="3742" VPOS="4354" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="mantuve" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0287" WIDTH="824" HEIGHT="49" HPOS="3046" VPOS="4389">
+            <a:String CONTENT="tuve" HEIGHT="38" WIDTH="101" HPOS="3046" VPOS="4389" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="21" HPOS="3168" VPOS="4401" />
+            <a:String CONTENT="con" HEIGHT="28" WIDTH="83" HPOS="3168" VPOS="4400" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="17" HPOS="3268" VPOS="4401" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="40" HPOS="3268" VPOS="4390" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="3327" VPOS="4401" />
+            <a:String CONTENT="poeta" HEIGHT="46" WIDTH="132" HPOS="3327" VPOS="4392" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="3501" VPOS="4393" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="70" HPOS="3501" VPOS="4393" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="18" HPOS="3589" VPOS="4395" />
+            <a:String CONTENT="REGRESSO" HEIGHT="41" WIDTH="281" HPOS="3589" VPOS="4395" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0288" WIDTH="828" HEIGHT="48" HPOS="3045" VPOS="4442">
+            <a:String CONTENT="AO" HEIGHT="39" WIDTH="71" HPOS="3045" VPOS="4442" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="3138" VPOS="4443" />
+            <a:String CONTENT="PARAISO," HEIGHT="47" WIDTH="244" HPOS="3138" VPOS="4443" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="3403" VPOS="4446" />
+            <a:String CONTENT="durante" HEIGHT="39" WIDTH="189" HPOS="3403" VPOS="4446" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="20" HPOS="3612" VPOS="4459" />
+            <a:String CONTENT="una" HEIGHT="30" WIDTH="89" HPOS="3612" VPOS="4458" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="3722" VPOS="4460" />
+            <a:String CONTENT="semaÂ¬" HEIGHT="29" WIDTH="151" HPOS="3722" VPOS="4460" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="semana" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0289" WIDTH="827" HEIGHT="52" HPOS="3045" VPOS="4496">
+            <a:String CONTENT="na" HEIGHT="29" WIDTH="61" HPOS="3045" VPOS="4505" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="21" HPOS="3127" VPOS="4496" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="52" HPOS="3127" VPOS="4496" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3204" VPOS="4497" />
+            <a:String CONTENT="hipertensiÃ³n" HEIGHT="48" WIDTH="310" HPOS="3204" VPOS="4497" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3539" VPOS="4512" />
+            <a:String CONTENT="anÃ­mica," HEIGHT="47" WIDTH="205" HPOS="3539" VPOS="4501" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3771" VPOS="4514" />
+            <a:String CONTENT="muÂ¬" HEIGHT="28" WIDTH="101" HPOS="3771" VPOS="4514" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="mucho" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0290" WIDTH="822" HEIGHT="53" HPOS="3048" VPOS="4550">
+            <a:String CONTENT="cho" HEIGHT="38" WIDTH="82" HPOS="3048" VPOS="4550" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="23" HPOS="3153" VPOS="4550" />
+            <a:String CONTENT="he" HEIGHT="38" WIDTH="54" HPOS="3153" VPOS="4550" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3233" VPOS="4550" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="3233" VPOS="4550" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="3308" VPOS="4550" />
+            <a:String CONTENT="decir" HEIGHT="40" WIDTH="121" HPOS="3308" VPOS="4550" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3452" VPOS="4562" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="38" HPOS="3452" VPOS="4552" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3516" VPOS="4553" />
+            <a:String CONTENT="dÃ­a" HEIGHT="38" WIDTH="72" HPOS="3516" VPOS="4553" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="3612" VPOS="4564" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="55" HPOS="3612" VPOS="4564" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="3690" VPOS="4565" />
+            <a:String CONTENT="que," HEIGHT="38" WIDTH="97" HPOS="3690" VPOS="4565" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="3814" VPOS="4557" />
+            <a:String CONTENT="liÂ¬" HEIGHT="37" WIDTH="56" HPOS="3814" VPOS="4557" WC="1" STYLEREFS="TEXTSTYLE0001" SUBS_TYPE="HypPart1" SUBS_CONTENT="libre" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0291" WIDTH="833" HEIGHT="56" HPOS="3047" VPOS="4602">
+            <a:String CONTENT="bre" HEIGHT="39" WIDTH="77" HPOS="3047" VPOS="4602" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="32" HPOS="3156" VPOS="4603" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="3156" VPOS="4603" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="3242" VPOS="4603" />
+            <a:String CONTENT="imperativos" HEIGHT="48" WIDTH="291" HPOS="3242" VPOS="4603" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3565" VPOS="4607" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="3565" VPOS="4607" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="3649" VPOS="4608" />
+            <a:String CONTENT="tiempo" HEIGHT="48" WIDTH="165" HPOS="3649" VPOS="4608" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="3847" VPOS="4622" />
+            <a:String CONTENT="y" HEIGHT="36" WIDTH="24" HPOS="3847" VPOS="4622" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0292" WIDTH="822" HEIGHT="48" HPOS="3047" VPOS="4655">
+            <a:String CONTENT="espacio," HEIGHT="48" WIDTH="194" HPOS="3047" VPOS="4655" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="3281" VPOS="4666" />
+            <a:String CONTENT="pueda" HEIGHT="46" WIDTH="143" HPOS="3281" VPOS="4657" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="3464" VPOS="4658" />
+            <a:String CONTENT="tamizar," HEIGHT="43" WIDTH="202" HPOS="3464" VPOS="4658" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="3692" VPOS="4671" />
+            <a:String CONTENT="mi" HEIGHT="36" WIDTH="60" HPOS="3692" VPOS="4663" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="3796" VPOS="4673" />
+            <a:String CONTENT="reÂ¬" HEIGHT="29" WIDTH="73" HPOS="3796" VPOS="4672" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="recuerdo" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0293" WIDTH="822" HEIGHT="50" HPOS="3047" VPOS="4708">
+            <a:String CONTENT="cuerdo" HEIGHT="39" WIDTH="162" HPOS="3047" VPOS="4708" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="33" HPOS="3242" VPOS="4719" />
+            <a:String CONTENT="con" HEIGHT="29" WIDTH="84" HPOS="3242" VPOS="4718" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3358" VPOS="4709" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="43" HPOS="3358" VPOS="4709" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3433" VPOS="4711" />
+            <a:String CONTENT="disposiciÃ³n" HEIGHT="48" WIDTH="272" HPOS="3433" VPOS="4710" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="3742" VPOS="4714" />
+            <a:String CONTENT="lÃ­rica" HEIGHT="41" WIDTH="127" HPOS="3742" VPOS="4714" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0294" WIDTH="589" HEIGHT="50" HPOS="3046" VPOS="4760">
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="25" HPOS="3046" VPOS="4772" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="3103" VPOS="4771" />
+            <a:String CONTENT="el" HEIGHT="40" WIDTH="38" HPOS="3103" VPOS="4760" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3175" VPOS="4771" />
+            <a:String CONTENT="reposo" HEIGHT="40" WIDTH="161" HPOS="3175" VPOS="4770" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="3370" VPOS="4773" />
+            <a:String CONTENT="adecuados." HEIGHT="41" WIDTH="265" HPOS="3370" VPOS="4764" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:ComposedBlock ID="PAG001BLK0047" HEIGHT="3371" WIDTH="869" HPOS="3932" VPOS="1458" />
+        <a:TextBlock ID="PAG001BLK0048" HEIGHT="162" WIDTH="831" HPOS="3942" VPOS="1468" STYLEREFS="PARSTYLE0029">
+          <a:TextLine ID="PAG001LIN0295" WIDTH="771" HEIGHT="50" HPOS="4001" VPOS="1468">
+            <a:String CONTENT="Hoy" HEIGHT="48" WIDTH="95" HPOS="4001" VPOS="1468" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="18" HPOS="4114" VPOS="1479" />
+            <a:String CONTENT="voy" HEIGHT="39" WIDTH="84" HPOS="4114" VPOS="1479" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="4219" VPOS="1480" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="27" HPOS="4219" VPOS="1480" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="22" HPOS="4268" VPOS="1480" />
+            <a:String CONTENT="mentaros" HEIGHT="38" WIDTH="231" HPOS="4268" VPOS="1473" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4523" VPOS="1483" />
+            <a:String CONTENT="una" HEIGHT="28" WIDTH="89" HPOS="4523" VPOS="1482" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4634" VPOS="1482" />
+            <a:String CONTENT="anÃ©cÂ¬" HEIGHT="40" WIDTH="138" HPOS="4634" VPOS="1470" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="anÃ©cdota" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0296" WIDTH="829" HEIGHT="52" HPOS="3943" VPOS="1521">
+            <a:String CONTENT="dota" HEIGHT="39" WIDTH="106" HPOS="3943" VPOS="1521" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="4080" VPOS="1532" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="84" HPOS="4080" VPOS="1532" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="4198" VPOS="1522" />
+            <a:String CONTENT="tiene" HEIGHT="40" WIDTH="120" HPOS="4198" VPOS="1522" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4351" VPOS="1535" />
+            <a:String CONTENT="mucho" HEIGHT="38" WIDTH="162" HPOS="4351" VPOS="1525" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4546" VPOS="1524" />
+            <a:String CONTENT="de" HEIGHT="43" WIDTH="53" HPOS="4546" VPOS="1524" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="4633" VPOS="1534" />
+            <a:String CONTENT="parÃ¡Â¬" HEIGHT="50" WIDTH="139" HPOS="4633" VPOS="1523" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="parÃ¡bola," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0297" WIDTH="829" HEIGHT="55" HPOS="3942" VPOS="1574">
+            <a:String CONTENT="bola," HEIGHT="47" WIDTH="118" HPOS="3942" VPOS="1574" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="22" HPOS="4082" VPOS="1585" />
+            <a:String CONTENT="una" HEIGHT="33" WIDTH="92" HPOS="4082" VPOS="1585" WC="0.91" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4197" VPOS="1586" />
+            <a:String CONTENT="parÃ¡bola" HEIGHT="47" WIDTH="217" HPOS="4197" VPOS="1577" WC="0.9" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="4435" VPOS="1588" />
+            <a:String CONTENT="que" HEIGHT="41" WIDTH="87" HPOS="4435" VPOS="1588" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4547" VPOS="1579" />
+            <a:String CONTENT="tiene" HEIGHT="37" WIDTH="118" HPOS="4547" VPOS="1579" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4688" VPOS="1578" />
+            <a:String CONTENT="bas" HEIGHT="39" WIDTH="83" HPOS="4688" VPOS="1578" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0049" HEIGHT="315" WIDTH="834" HPOS="3941" VPOS="1636" STYLEREFS="PARSTYLE0030">
+          <a:TextLine ID="PAG001LIN0298" WIDTH="101" HEIGHT="33" HPOS="4669" VPOS="1636">
+            <a:String CONTENT="â– 'caÂ¬" HEIGHT="33" WIDTH="101" HPOS="4669" VPOS="1636" WC="0.82" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="â– 'categorÃ­a,," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0299" WIDTH="831" HEIGHT="49" HPOS="3941" VPOS="1684">
+            <a:String CONTENT="tegorÃ­a,," HEIGHT="48" WIDTH="202" HPOS="3941" VPOS="1685" WC="0.82" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="28" HPOS="4171" VPOS="1694" />
+            <a:String CONTENT="en" HEIGHT="30" WIDTH="57" HPOS="4171" VPOS="1693" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4250" VPOS="1684" />
+            <a:String CONTENT="toda" HEIGHT="39" WIDTH="105" HPOS="4250" VPOS="1684" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4378" VPOS="1685" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="44" HPOS="4378" VPOS="1685" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4446" VPOS="1695" />
+            <a:String CONTENT="amplia" HEIGHT="48" WIDTH="169" HPOS="4446" VPOS="1684" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4640" VPOS="1695" />
+            <a:String CONTENT="acepÂ¬" HEIGHT="41" WIDTH="132" HPOS="4640" VPOS="1692" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="acepciÃ³n" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0300" WIDTH="829" HEIGHT="48" HPOS="3944" VPOS="1739">
+            <a:String CONTENT="ciÃ³n" HEIGHT="39" WIDTH="103" HPOS="3944" VPOS="1739" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="18" HPOS="4065" VPOS="1739" />
+            <a:String CONTENT="filosÃ³fica" HEIGHT="39" WIDTH="233" HPOS="4065" VPOS="1739" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="20" HPOS="4318" VPOS="1749" />
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="85" HPOS="4318" VPOS="1749" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4425" VPOS="1739" />
+            <a:String CONTENT="incumbe" HEIGHT="40" WIDTH="205" HPOS="4425" VPOS="1739" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="20" HPOS="4650" VPOS="1749" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="27" HPOS="4650" VPOS="1749" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="20" HPOS="4697" VPOS="1749" />
+            <a:String CONTENT="esÂ¬" HEIGHT="30" WIDTH="76" HPOS="4697" VPOS="1747" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="este" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0301" WIDTH="830" HEIGHT="48" HPOS="3944" VPOS="1792">
+            <a:String CONTENT="te" HEIGHT="37" WIDTH="43" HPOS="3944" VPOS="1794" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="29" HPOS="4016" VPOS="1804" />
+            <a:String CONTENT="vocablo." HEIGHT="40" WIDTH="201" HPOS="4016" VPOS="1792" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="4246" VPOS="1793" />
+            <a:String CONTENT="KiYa" HEIGHT="48" WIDTH="93" HPOS="4246" VPOS="1792" WC="0.79" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4370" VPOS="1802" />
+            <a:String CONTENT="sabemos" HEIGHT="39" WIDTH="210" HPOS="4370" VPOS="1793" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4612" VPOS="1792" />
+            <a:String CONTENT="lo" HEIGHT="39" WIDTH="41" HPOS="4612" VPOS="1792" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="4688" VPOS="1802" />
+            <a:String CONTENT="que" HEIGHT="39" WIDTH="86" HPOS="4688" VPOS="1801" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0302" WIDTH="826" HEIGHT="45" HPOS="3945" VPOS="1845">
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="56" HPOS="3945" VPOS="1858" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4032" VPOS="1857" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="39" HPOS="4032" VPOS="1846" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4104" VPOS="1856" />
+            <a:String CONTENT="ceÃ±ido" HEIGHT="44" WIDTH="156" HPOS="4104" VPOS="1845" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4290" VPOS="1846" />
+            <a:String CONTENT="lÃ©xico" HEIGHT="40" WIDTH="141" HPOS="4290" VPOS="1846" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4461" VPOS="1846" />
+            <a:String CONTENT="de" HEIGHT="40" WIDTH="54" HPOS="4461" VPOS="1846" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="4552" VPOS="1847" />
+            <a:String CONTENT="&quot;Xeniusâ€ž" HEIGHT="43" WIDTH="219" HPOS="4552" VPOS="1847" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0303" WIDTH="259" HEIGHT="50" HPOS="3946" VPOS="1900">
+            <a:String CONTENT="significa)]." HEIGHT="50" WIDTH="259" HPOS="3946" VPOS="1900" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0050" HEIGHT="322" WIDTH="833" HPOS="3944" VPOS="1966" STYLEREFS="PARSTYLE0031">
+          <a:TextLine ID="PAG001LIN0304" WIDTH="771" HEIGHT="48" HPOS="4003" VPOS="1966">
+            <a:String CONTENT="HabÃ­amos" HEIGHT="39" WIDTH="242" HPOS="4003" VPOS="1968" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="4286" VPOS="1972" />
+            <a:String CONTENT="agotado" HEIGHT="48" WIDTH="192" HPOS="4286" VPOS="1966" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="4519" VPOS="1967" />
+            <a:String CONTENT="los" HEIGHT="39" WIDTH="68" HPOS="4519" VPOS="1967" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="4627" VPOS="1967" />
+            <a:String CONTENT="temas" HEIGHT="38" WIDTH="147" HPOS="4627" VPOS="1967" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0305" WIDTH="829" HEIGHT="49" HPOS="3946" VPOS="2020">
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="50" HPOS="3946" VPOS="2025" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4020" VPOS="2033" />
+            <a:String CONTENT="nuestro" HEIGHT="39" WIDTH="189" HPOS="4020" VPOS="2023" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4233" VPOS="2021" />
+            <a:String CONTENT="diÃ¡logo," HEIGHT="48" WIDTH="193" HPOS="4233" VPOS="2021" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4448" VPOS="2031" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="29" HPOS="4448" VPOS="2031" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4499" VPOS="2031" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="39" HPOS="4499" VPOS="2020" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4562" VPOS="2031" />
+            <a:String CONTENT="ritmÃ³" HEIGHT="39" WIDTH="136" HPOS="4562" VPOS="2020" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4722" VPOS="2020" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="53" HPOS="4722" VPOS="2020" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0306" WIDTH="831" HEIGHT="51" HPOS="3944" VPOS="2071">
+            <a:String CONTENT="la" HEIGHT="40" WIDTH="46" HPOS="3944" VPOS="2079" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="4018" VPOS="2088" />
+            <a:String CONTENT="cliarla" HEIGHT="46" WIDTH="157" HPOS="4018" VPOS="2071" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="4203" VPOS="2085" />
+            <a:String CONTENT="esmorecÃ­a" HEIGHT="40" WIDTH="250" HPOS="4203" VPOS="2074" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="4480" VPOS="2074" />
+            <a:String CONTENT="fatigado." HEIGHT="49" WIDTH="219" HPOS="4480" VPOS="2073" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="4727" VPOS="2073" />
+            <a:String CONTENT="Â¡Y," HEIGHT="47" WIDTH="48" HPOS="4727" VPOS="2072" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0307" WIDTH="828" HEIGHT="52" HPOS="3948" VPOS="2127">
+            <a:String CONTENT="con" HEIGHT="30" WIDTH="86" HPOS="3948" VPOS="2142" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="4055" VPOS="2143" />
+            <a:String CONTENT="un" HEIGHT="30" WIDTH="62" HPOS="4055" VPOS="2140" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="4138" VPOS="2131" />
+            <a:String CONTENT="jÃºbilo" HEIGHT="50" WIDTH="143" HPOS="4138" VPOS="2129" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="4307" VPOS="2139" />
+            <a:String CONTENT="colegial" HEIGHT="48" WIDTH="190" HPOS="4307" VPOS="2127" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4521" VPOS="2128" />
+            <a:String CONTENT="bailoteÃ¡n-" HEIGHT="39" WIDTH="255" HPOS="4521" VPOS="2127" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="bailoteÃ¡ndole" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0308" WIDTH="822" HEIGHT="49" HPOS="3948" VPOS="2181">
+            <a:String CONTENT="dole" HEIGHT="40" WIDTH="100" HPOS="3948" VPOS="2186" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="43" HPOS="4091" VPOS="2195" />
+            <a:String CONTENT="en" HEIGHT="30" WIDTH="57" HPOS="4091" VPOS="2194" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="4189" VPOS="2183" />
+            <a:String CONTENT="las" HEIGHT="39" WIDTH="68" HPOS="4189" VPOS="2183" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="4297" VPOS="2188" />
+            <a:String CONTENT="pupilas," HEIGHT="49" WIDTH="198" HPOS="4297" VPOS="2181" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="4539" VPOS="2181" />
+            <a:String CONTENT="Pascoaes" HEIGHT="43" WIDTH="231" HPOS="4539" VPOS="2181" WC="0.91" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0309" WIDTH="210" HEIGHT="48" HPOS="3948" VPOS="2239">
+            <a:String CONTENT="me" HEIGHT="28" WIDTH="70" HPOS="3948" VPOS="2252" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="4045" VPOS="2240" />
+            <a:String CONTENT="dijo:" HEIGHT="48" WIDTH="113" HPOS="4045" VPOS="2239" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0051" HEIGHT="101" WIDTH="828" HPOS="3948" VPOS="2301" STYLEREFS="PARSTYLE0032">
+          <a:TextLine ID="PAG001LIN0310" WIDTH="771" HEIGHT="51" HPOS="4004" VPOS="2301">
+            <a:String CONTENT="aâ€”Venga." HEIGHT="47" WIDTH="225" HPOS="4004" VPOS="2305" WC="0.72" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="55" HPOS="4284" VPOS="2302" />
+            <a:String CONTENT="L'e" HEIGHT="39" WIDTH="58" HPOS="4284" VPOS="2302" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="57" HPOS="4399" VPOS="2311" />
+            <a:String CONTENT="mostrÃ¡is" HEIGHT="42" WIDTH="226" HPOS="4399" VPOS="2301" WC="0.83" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="57" HPOS="4682" VPOS="2309" />
+            <a:String CONTENT="una" HEIGHT="35" WIDTH="93" HPOS="4682" VPOS="2305" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0311" WIDTH="535" HEIGHT="45" HPOS="3948" VPOS="2356">
+            <a:String CONTENT="obra" HEIGHT="40" WIDTH="110" HPOS="3948" VPOS="2361" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4089" VPOS="2359" />
+            <a:String CONTENT="de" HEIGHT="40" WIDTH="53" HPOS="4089" VPOS="2359" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4173" VPOS="2368" />
+            <a:String CONTENT="mi" HEIGHT="39" WIDTH="61" HPOS="4173" VPOS="2357" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="4268" VPOS="2357" />
+            <a:String CONTENT="infancia." HEIGHT="39" WIDTH="215" HPOS="4268" VPOS="2356" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0052" HEIGHT="484" WIDTH="831" HPOS="3949" VPOS="2409" STYLEREFS="PARSTYLE0033">
+          <a:TextLine ID="PAG001LIN0312" WIDTH="770" HEIGHT="44" HPOS="4006" VPOS="2409">
+            <a:String CONTENT="Nos" HEIGHT="38" WIDTH="90" HPOS="4006" VPOS="2415" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="4133" VPOS="2413" />
+            <a:String CONTENT="internamos" HEIGHT="39" WIDTH="279" HPOS="4133" VPOS="2412" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="4450" VPOS="2419" />
+            <a:String CONTENT="en" HEIGHT="30" WIDTH="56" HPOS="4450" VPOS="2418" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4539" VPOS="2419" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="41" HPOS="4539" VPOS="2409" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="4616" VPOS="2419" />
+            <a:String CONTENT="rincÃ³n" HEIGHT="39" WIDTH="160" HPOS="4616" VPOS="2409" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0313" WIDTH="827" HEIGHT="50" HPOS="3949" VPOS="2463">
+            <a:String CONTENT="mÃ¡s" HEIGHT="39" WIDTH="98" HPOS="3949" VPOS="2469" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="4081" VPOS="2477" />
+            <a:String CONTENT="escondido" HEIGHT="41" WIDTH="239" HPOS="4081" VPOS="2465" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="4349" VPOS="2475" />
+            <a:String CONTENT="y" HEIGHT="38" WIDTH="29" HPOS="4349" VPOS="2475" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="4407" VPOS="2473" />
+            <a:String CONTENT="mÃ¡s" HEIGHT="39" WIDTH="99" HPOS="4407" VPOS="2464" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4539" VPOS="2474" />
+            <a:String CONTENT="confidenÂ¬" HEIGHT="40" WIDTH="237" HPOS="4539" VPOS="2463" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="confidencial" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0314" WIDTH="826" HEIGHT="51" HPOS="3950" VPOS="2518">
+            <a:String CONTENT="cial" HEIGHT="40" WIDTH="85" HPOS="3950" VPOS="2522" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="29" HPOS="4064" VPOS="2522" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="69" HPOS="4064" VPOS="2522" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="4162" VPOS="2531" />
+            <a:String CONTENT="parque;" HEIGHT="48" WIDTH="183" HPOS="4162" VPOS="2521" WC="0.83" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="4371" VPOS="2518" />
+            <a:String CONTENT="Eos" HEIGHT="39" WIDTH="88" HPOS="4371" VPOS="2518" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4489" VPOS="2528" />
+            <a:String CONTENT="pinos" HEIGHT="48" WIDTH="130" HPOS="4489" VPOS="2518" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="4647" VPOS="2528" />
+            <a:String CONTENT="rezaÂ¬" HEIGHT="29" WIDTH="129" HPOS="4647" VPOS="2527" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="rezaban" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0315" WIDTH="826" HEIGHT="43" HPOS="3950" VPOS="2572">
+            <a:String CONTENT="ban" HEIGHT="38" WIDTH="90" HPOS="3950" VPOS="2577" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="21" HPOS="4061" VPOS="2585" />
+            <a:String CONTENT="su" HEIGHT="29" WIDTH="54" HPOS="4061" VPOS="2585" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4137" VPOS="2585" />
+            <a:String CONTENT="rosario" HEIGHT="39" WIDTH="176" HPOS="4137" VPOS="2574" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4336" VPOS="2573" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="52" HPOS="4336" VPOS="2573" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4411" VPOS="2582" />
+            <a:String CONTENT="rocÃ­o" HEIGHT="39" WIDTH="124" HPOS="4411" VPOS="2572" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4558" VPOS="2581" />
+            <a:String CONTENT="maÃ±aneÂ¬" HEIGHT="38" WIDTH="218" HPOS="4558" VPOS="2572" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="maÃ±anero" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0316" WIDTH="827" HEIGHT="54" HPOS="3950" VPOS="2625">
+            <a:String CONTENT="ro" HEIGHT="30" WIDTH="51" HPOS="3950" VPOS="2640" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="4032" VPOS="2641" />
+            <a:String CONTENT="y," HEIGHT="38" WIDTH="40" HPOS="4032" VPOS="2641" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="4106" VPOS="2639" />
+            <a:String CONTENT="entre" HEIGHT="38" WIDTH="125" HPOS="4106" VPOS="2629" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="4266" VPOS="2637" />
+            <a:String CONTENT="sÃ¡banas" HEIGHT="43" WIDTH="195" HPOS="4266" VPOS="2627" WC="0.91" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="4495" VPOS="2625" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="4495" VPOS="2625" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4580" VPOS="2635" />
+            <a:String CONTENT="neblina," HEIGHT="46" WIDTH="197" HPOS="4580" VPOS="2626" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0317" WIDTH="828" HEIGHT="45" HPOS="3951" VPOS="2680">
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="40" HPOS="3951" VPOS="2684" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4021" VPOS="2693" />
+            <a:String CONTENT="sol" HEIGHT="39" WIDTH="67" HPOS="4021" VPOS="2683" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4120" VPOS="2693" />
+            <a:String CONTENT="estaba" HEIGHT="43" WIDTH="156" HPOS="4120" VPOS="2682" WC="0.88" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="4304" VPOS="2691" />
+            <a:String CONTENT="enfermo" HEIGHT="38" WIDTH="203" HPOS="4304" VPOS="2681" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4538" VPOS="2680" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="4538" VPOS="2680" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4619" VPOS="2690" />
+            <a:String CONTENT="recuer," HEIGHT="32" WIDTH="160" HPOS="4619" VPOS="2689" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0318" WIDTH="827" HEIGHT="44" HPOS="3951" VPOS="2732">
+            <a:String CONTENT="do." HEIGHT="39" WIDTH="69" HPOS="3951" VPOS="2737" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4043" VPOS="2737" />
+            <a:String CONTENT="Todo" HEIGHT="39" WIDTH="122" HPOS="4043" VPOS="2736" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4189" VPOS="2746" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="40" HPOS="4189" VPOS="2735" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4251" VPOS="2735" />
+            <a:String CONTENT="tedio" HEIGHT="39" WIDTH="119" HPOS="4251" VPOS="2734" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4393" VPOS="2734" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="4393" VPOS="2734" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4469" VPOS="2733" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="44" HPOS="4469" VPOS="2733" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="4534" VPOS="2743" />
+            <a:String CONTENT="verde" HEIGHT="40" WIDTH="132" HPOS="4534" VPOS="2732" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4690" VPOS="2742" />
+            <a:String CONTENT="miÂ¬" HEIGHT="38" WIDTH="88" HPOS="4690" VPOS="2733" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="mirada" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0319" WIDTH="827" HEIGHT="49" HPOS="3951" VPOS="2788">
+            <a:String CONTENT="rada" HEIGHT="39" WIDTH="109" HPOS="3951" VPOS="2791" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="25" HPOS="4085" VPOS="2791" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="68" HPOS="4085" VPOS="2790" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="4180" VPOS="2800" />
+            <a:String CONTENT="campo" HEIGHT="39" WIDTH="156" HPOS="4180" VPOS="2798" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4361" VPOS="2788" />
+            <a:String CONTENT="fluÃ­a" HEIGHT="39" WIDTH="115" HPOS="4361" VPOS="2788" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="4502" VPOS="2797" />
+            <a:String CONTENT="en" HEIGHT="30" WIDTH="56" HPOS="4502" VPOS="2796" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4581" VPOS="2797" />
+            <a:String CONTENT="ei" HEIGHT="38" WIDTH="39" HPOS="4581" VPOS="2788" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4643" VPOS="2797" />
+            <a:String CONTENT="verso" HEIGHT="31" WIDTH="135" HPOS="4643" VPOS="2797" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0320" WIDTH="622" HEIGHT="50" HPOS="3952" VPOS="2842">
+            <a:String CONTENT="elegiaco" HEIGHT="48" WIDTH="198" HPOS="3952" VPOS="2844" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="4188" VPOS="2844" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="51" HPOS="4188" VPOS="2844" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="4277" VPOS="2853" />
+            <a:String CONTENT="una" HEIGHT="29" WIDTH="91" HPOS="4277" VPOS="2852" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="4403" VPOS="2843" />
+            <a:String CONTENT="fuentej" HEIGHT="40" WIDTH="171" HPOS="4403" VPOS="2842" WC="0.61" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0053" HEIGHT="642" WIDTH="829" HPOS="3952" VPOS="2908" STYLEREFS="PARSTYLE0034">
+          <a:TextLine ID="PAG001LIN0321" WIDTH="769" HEIGHT="49" HPOS="4009" VPOS="2908">
+            <a:String CONTENT="El" HEIGHT="38" WIDTH="51" HPOS="4009" VPOS="2909" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4090" VPOS="2919" />
+            <a:String CONTENT="poeta" HEIGHT="49" WIDTH="133" HPOS="4090" VPOS="2908" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4253" VPOS="2917" />
+            <a:String CONTENT="se" HEIGHT="30" WIDTH="48" HPOS="4253" VPOS="2917" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4332" VPOS="2908" />
+            <a:String CONTENT="detuvo" HEIGHT="39" WIDTH="159" HPOS="4332" VPOS="2908" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="4520" VPOS="2918" />
+            <a:String CONTENT="y" HEIGHT="39" WIDTH="26" HPOS="4520" VPOS="2918" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="4574" VPOS="2908" />
+            <a:String CONTENT="Kurgari-" HEIGHT="48" WIDTH="204" HPOS="4574" VPOS="2908" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="Kurgarido" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0322" WIDTH="824" HEIGHT="41" HPOS="3953" VPOS="2962">
+            <a:String CONTENT="do" HEIGHT="39" WIDTH="53" HPOS="3953" VPOS="2964" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="33" HPOS="4039" VPOS="2974" />
+            <a:String CONTENT="con" HEIGHT="30" WIDTH="84" HPOS="4039" VPOS="2972" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4154" VPOS="2973" />
+            <a:String CONTENT="su" HEIGHT="29" WIDTH="53" HPOS="4154" VPOS="2973" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4237" VPOS="2962" />
+            <a:String CONTENT="bÃ¡culo" HEIGHT="39" WIDTH="159" HPOS="4237" VPOS="2962" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4429" VPOS="2973" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="53" HPOS="4429" VPOS="2972" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4514" VPOS="2973" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="39" HPOS="4514" VPOS="2962" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4586" VPOS="2972" />
+            <a:String CONTENT="corazÃ³n" HEIGHT="39" WIDTH="191" HPOS="4586" VPOS="2962" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0323" WIDTH="828" HEIGHT="46" HPOS="3952" VPOS="3016">
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="52" HPOS="3952" VPOS="3017" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="4033" VPOS="3017" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="43" HPOS="4033" VPOS="3017" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="4104" VPOS="3027" />
+            <a:String CONTENT="maleza," HEIGHT="46" WIDTH="184" HPOS="4104" VPOS="3016" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="4317" VPOS="3017" />
+            <a:String CONTENT="descubriÃ³" HEIGHT="39" WIDTH="236" HPOS="4317" VPOS="3016" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4584" VPOS="3026" />
+            <a:String CONTENT="ante" HEIGHT="38" WIDTH="103" HPOS="4584" VPOS="3018" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4717" VPOS="3027" />
+            <a:String CONTENT="mi" HEIGHT="38" WIDTH="63" HPOS="4717" VPOS="3017" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0324" WIDTH="826" HEIGHT="49" HPOS="3952" VPOS="3070">
+            <a:String CONTENT="un" HEIGHT="29" WIDTH="61" HPOS="3952" VPOS="3080" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4038" VPOS="3081" />
+            <a:String CONTENT="peÃ±asco" HEIGHT="48" WIDTH="194" HPOS="4038" VPOS="3071" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4256" VPOS="3081" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="26" HPOS="4256" VPOS="3081" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4307" VPOS="3071" />
+            <a:String CONTENT="flor" HEIGHT="39" WIDTH="87" HPOS="4307" VPOS="3070" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="4420" VPOS="3071" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="4420" VPOS="3071" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4495" VPOS="3071" />
+            <a:String CONTENT="tierra" HEIGHT="39" WIDTH="139" HPOS="4495" VPOS="3071" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4658" VPOS="3081" />
+            <a:String CONTENT="en" HEIGHT="29" WIDTH="56" HPOS="4658" VPOS="3081" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4739" VPOS="3081" />
+            <a:String CONTENT="el" HEIGHT="40" WIDTH="39" HPOS="4739" VPOS="3070" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0325" WIDTH="821" HEIGHT="48" HPOS="3955" VPOS="3124">
+            <a:String CONTENT="que" HEIGHT="38" WIDTH="82" HPOS="3955" VPOS="3134" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4069" VPOS="3134" />
+            <a:String CONTENT="se" HEIGHT="28" WIDTH="47" HPOS="4069" VPOS="3134" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4148" VPOS="3135" />
+            <a:String CONTENT="abrÃ­a" HEIGHT="39" WIDTH="125" HPOS="4148" VPOS="3124" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4303" VPOS="3135" />
+            <a:String CONTENT="una" HEIGHT="29" WIDTH="88" HPOS="4303" VPOS="3134" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4421" VPOS="3125" />
+            <a:String CONTENT="breve" HEIGHT="45" WIDTH="129" HPOS="4421" VPOS="3125" WC="0.75" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4582" VPOS="3126" />
+            <a:String CONTENT="horadaÂ¬" HEIGHT="38" WIDTH="194" HPOS="4582" VPOS="3126" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="horadaciÃ³n." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0326" WIDTH="823" HEIGHT="51" HPOS="3954" VPOS="3178">
+            <a:String CONTENT="ciÃ³n." HEIGHT="38" WIDTH="114" HPOS="3954" VPOS="3178" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="35" HPOS="4103" VPOS="3178" />
+            <a:String CONTENT="Me" HEIGHT="38" WIDTH="66" HPOS="4103" VPOS="3178" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4201" VPOS="3189" />
+            <a:String CONTENT="contÃ³" HEIGHT="39" WIDTH="131" HPOS="4201" VPOS="3178" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="4368" VPOS="3189" />
+            <a:String CONTENT="su" HEIGHT="28" WIDTH="52" HPOS="4368" VPOS="3189" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="4454" VPOS="3180" />
+            <a:String CONTENT="historial" HEIGHT="39" WIDTH="208" HPOS="4454" VPOS="3179" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="4698" VPOS="3191" />
+            <a:String CONTENT="pe-" HEIGHT="39" WIDTH="79" HPOS="4698" VPOS="3190" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="pequeÃ±ito." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0327" WIDTH="825" HEIGHT="48" HPOS="3955" VPOS="3231">
+            <a:String CONTENT="queÃ±ito." HEIGHT="48" WIDTH="196" HPOS="3955" VPOS="3231" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="20" HPOS="4171" VPOS="3233" />
+            <a:String CONTENT="De" HEIGHT="38" WIDTH="62" HPOS="4171" VPOS="3233" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="4252" VPOS="3243" />
+            <a:String CONTENT="niÃ±o," HEIGHT="39" WIDTH="121" HPOS="4252" VPOS="3233" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="20" HPOS="4393" VPOS="3244" />
+            <a:String CONTENT="el" HEIGHT="39" WIDTH="39" HPOS="4393" VPOS="3233" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="4453" VPOS="3234" />
+            <a:String CONTENT="lÃ­rico" HEIGHT="38" WIDTH="127" HPOS="4453" VPOS="3234" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="4601" VPOS="3235" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="4601" VPOS="3235" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="4671" VPOS="3235" />
+            <a:String CONTENT="VER" HEIGHT="38" WIDTH="109" HPOS="4671" VPOS="3235" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0328" WIDTH="826" HEIGHT="51" HPOS="3952" VPOS="3284">
+            <a:String CONTENT="BO" HEIGHT="39" WIDTH="72" HPOS="3952" VPOS="3284" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4057" VPOS="3286" />
+            <a:String CONTENT="ESCURO" HEIGHT="39" WIDTH="209" HPOS="4057" VPOS="3285" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4298" VPOS="3288" />
+            <a:String CONTENT="huÃ­a" HEIGHT="37" WIDTH="106" HPOS="4298" VPOS="3288" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="4439" VPOS="3297" />
+            <a:String CONTENT="sigilosamente" HEIGHT="48" WIDTH="339" HPOS="4439" VPOS="3287" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0329" WIDTH="823" HEIGHT="49" HPOS="3956" VPOS="3339">
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="24" HPOS="3956" VPOS="3348" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4005" VPOS="3348" />
+            <a:String CONTENT="este" HEIGHT="37" WIDTH="94" HPOS="4005" VPOS="3339" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4122" VPOS="3350" />
+            <a:String CONTENT="retiro" HEIGHT="39" WIDTH="138" HPOS="4122" VPOS="3339" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4284" VPOS="3351" />
+            <a:String CONTENT="y," HEIGHT="37" WIDTH="39" HPOS="4284" VPOS="3351" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4348" VPOS="3351" />
+            <a:String CONTENT="a" HEIGHT="28" WIDTH="25" HPOS="4348" VPOS="3351" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4397" VPOS="3352" />
+            <a:String CONTENT="punta" HEIGHT="45" WIDTH="139" HPOS="4397" VPOS="3343" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4561" VPOS="3342" />
+            <a:String CONTENT="dÃ©" HEIGHT="38" WIDTH="51" HPOS="4561" VPOS="3342" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="4638" VPOS="3352" />
+            <a:String CONTENT="cincel" HEIGHT="39" WIDTH="141" HPOS="4638" VPOS="3342" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0330" WIDTH="826" HEIGHT="49" HPOS="3954" VPOS="3392">
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="26" HPOS="3954" VPOS="3402" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="4021" VPOS="3392" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="4021" VPOS="3392" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="4116" VPOS="3403" />
+            <a:String CONTENT="obsesa" HEIGHT="38" WIDTH="162" HPOS="4116" VPOS="3393" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="4319" VPOS="3404" />
+            <a:String CONTENT="voluntad," HEIGHT="47" WIDTH="225" HPOS="4319" VPOS="3394" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="4590" VPOS="3396" />
+            <a:String CONTENT="iba" HEIGHT="38" WIDTH="71" HPOS="4590" VPOS="3396" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="4701" VPOS="3407" />
+            <a:String CONTENT="soÂ¬" HEIGHT="29" WIDTH="79" HPOS="4701" VPOS="3407" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="socavando" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0331" WIDTH="824" HEIGHT="45" HPOS="3956" VPOS="3446">
+            <a:String CONTENT="cavando" HEIGHT="39" WIDTH="196" HPOS="3956" VPOS="3446" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="36" HPOS="4188" VPOS="3457" />
+            <a:String CONTENT="un" HEIGHT="28" WIDTH="60" HPOS="4188" VPOS="3457" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="4283" VPOS="3458" />
+            <a:String CONTENT="nido" HEIGHT="38" WIDTH="102" HPOS="4283" VPOS="3448" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="4422" VPOS="3460" />
+            <a:String CONTENT="en" HEIGHT="27" WIDTH="53" HPOS="4422" VPOS="3460" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="4513" VPOS="3450" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="41" HPOS="4513" VPOS="3450" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="4590" VPOS="3460" />
+            <a:String CONTENT="entraÃ±a" HEIGHT="39" WIDTH="190" HPOS="4590" VPOS="3452" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0332" WIDTH="502" HEIGHT="51" HPOS="3955" VPOS="3498">
+            <a:String CONTENT="hostil" HEIGHT="39" WIDTH="137" HPOS="3955" VPOS="3498" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="34" HPOS="4126" VPOS="3500" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="4126" VPOS="3500" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="4212" VPOS="3501" />
+            <a:String CONTENT="la" HEIGHT="39" WIDTH="42" HPOS="4212" VPOS="3501" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="4289" VPOS="3512" />
+            <a:String CONTENT="piedra." HEIGHT="47" WIDTH="168" HPOS="4289" VPOS="3502" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0054" HEIGHT="472" WIDTH="830" HPOS="3955" VPOS="3566" STYLEREFS="PARSTYLE0035">
+          <a:TextLine ID="PAG001LIN0333" WIDTH="777" HEIGHT="47" HPOS="4005" VPOS="3566">
+            <a:String CONTENT="â€”" HEIGHT="8" WIDTH="54" HPOS="4005" VPOS="3586" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="2" HPOS="4061" VPOS="3566" />
+            <a:String CONTENT="He" HEIGHT="38" WIDTH="58" HPOS="4061" VPOS="3566" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4143" VPOS="3577" />
+            <a:String CONTENT="aquÃ­" HEIGHT="45" WIDTH="97" HPOS="4143" VPOS="3568" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4262" VPOS="3579" />
+            <a:String CONTENT="mi" HEIGHT="35" WIDTH="56" HPOS="4262" VPOS="3570" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="26" HPOS="4344" VPOS="3571" />
+            <a:String CONTENT="labor" HEIGHT="36" WIDTH="115" HPOS="4344" VPOS="3571" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="21" HPOS="4480" VPOS="3571" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="50" HPOS="4480" VPOS="3571" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="25" HPOS="4555" VPOS="3575" />
+            <a:String CONTENT="Irer" HEIGHT="34" WIDTH="80" HPOS="4555" VPOS="3575" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4659" VPOS="3583" />
+            <a:String CONTENT="vacaÂ¬" HEIGHT="33" WIDTH="123" HPOS="4659" VPOS="3579" WC="0.92" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="vacaciones." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0334" WIDTH="829" HEIGHT="52" HPOS="3955" VPOS="3619">
+            <a:String CONTENT="ciones." HEIGHT="37" WIDTH="153" HPOS="3955" VPOS="3619" WC="0.92" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="33" HPOS="4141" VPOS="3620" />
+            <a:String CONTENT="He" HEIGHT="38" WIDTH="58" HPOS="4141" VPOS="3620" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4231" VPOS="3631" />
+            <a:String CONTENT="aquÃ­" HEIGHT="46" WIDTH="98" HPOS="4231" VPOS="3622" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4362" VPOS="3633" />
+            <a:String CONTENT="un" HEIGHT="27" WIDTH="53" HPOS="4362" VPOS="3633" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4447" VPOS="3623" />
+            <a:String CONTENT="juego" HEIGHT="48" WIDTH="126" HPOS="4447" VPOS="3623" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4603" VPOS="3624" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="49" HPOS="4603" VPOS="3624" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4682" VPOS="3636" />
+            <a:String CONTENT="niÃ±o" HEIGHT="38" WIDTH="102" HPOS="4682" VPOS="3627" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0335" WIDTH="827" HEIGHT="45" HPOS="3956" VPOS="3672">
+            <a:String CONTENT="simbolizando" HEIGHT="39" WIDTH="296" HPOS="3956" VPOS="3672" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4276" VPOS="3675" />
+            <a:String CONTENT="toda" HEIGHT="38" WIDTH="96" HPOS="4276" VPOS="3675" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4395" VPOS="3676" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="40" HPOS="4395" VPOS="3676" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4459" VPOS="3687" />
+            <a:String CONTENT="sed" HEIGHT="36" WIDTH="71" HPOS="4459" VPOS="3678" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4552" VPOS="3678" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="49" HPOS="4552" VPOS="3678" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="24" HPOS="4625" VPOS="3689" />
+            <a:String CONTENT="eterniÂ¬" HEIGHT="38" WIDTH="158" HPOS="4625" VPOS="3679" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="eternidad" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0336" WIDTH="823" HEIGHT="55" HPOS="3958" VPOS="3723">
+            <a:String CONTENT="dad" HEIGHT="38" WIDTH="83" HPOS="3958" VPOS="3723" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="43" HPOS="4084" VPOS="3734" />
+            <a:String CONTENT="que" HEIGHT="37" WIDTH="81" HPOS="4084" VPOS="3734" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="4207" VPOS="3735" />
+            <a:String CONTENT="me" HEIGHT="28" WIDTH="69" HPOS="4207" VPOS="3735" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="4319" VPOS="3737" />
+            <a:String CONTENT="ahogarÃ­a" HEIGHT="46" WIDTH="217" HPOS="4319" VPOS="3728" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="4573" VPOS="3729" />
+            <a:String CONTENT="despuÃ©s." HEIGHT="49" WIDTH="208" HPOS="4573" VPOS="3729" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0337" WIDTH="827" HEIGHT="54" HPOS="3956" VPOS="3777">
+            <a:String CONTENT="El" HEIGHT="36" WIDTH="49" HPOS="3956" VPOS="3777" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="4032" VPOS="3778" />
+            <a:String CONTENT="hambre" HEIGHT="39" WIDTH="181" HPOS="4032" VPOS="3778" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="20" HPOS="4233" VPOS="3779" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="50" HPOS="4233" VPOS="3779" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="22" HPOS="4305" VPOS="3782" />
+            <a:String CONTENT="inmortalidad" HEIGHT="39" WIDTH="314" HPOS="4305" VPOS="3782" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="4638" VPOS="3795" />
+            <a:String CONTENT="que" HEIGHT="36" WIDTH="83" HPOS="4638" VPOS="3795" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="19" HPOS="4740" VPOS="3786" />
+            <a:String CONTENT="di" HEIGHT="38" WIDTH="43" HPOS="4740" VPOS="3786" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0338" WIDTH="826" HEIGHT="48" HPOS="3957" VPOS="3830">
+            <a:String CONTENT="rÃ­a" HEIGHT="38" WIDTH="68" HPOS="3957" VPOS="3830" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4055" VPOS="3840" />
+            <a:String CONTENT="vuestro" HEIGHT="38" WIDTH="181" HPOS="4055" VPOS="3832" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4267" VPOS="3834" />
+            <a:String CONTENT="Unamuno." HEIGHT="40" WIDTH="249" HPOS="4267" VPOS="3834" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4548" VPOS="3837" />
+            <a:String CONTENT="En" HEIGHT="38" WIDTH="65" HPOS="4548" VPOS="3837" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4643" VPOS="3848" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="39" HPOS="4643" VPOS="3838" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4713" VPOS="3849" />
+            <a:String CONTENT="alÂ¬" HEIGHT="39" WIDTH="70" HPOS="4713" VPOS="3839" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="alba," />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0339" WIDTH="821" HEIGHT="56" HPOS="3959" VPOS="3883">
+            <a:String CONTENT="ba," HEIGHT="37" WIDTH="54" HPOS="3959" VPOS="3883" WC="0.96" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="31" HPOS="4044" VPOS="3884" />
+            <a:String CONTENT="da" HEIGHT="39" WIDTH="60" HPOS="4044" VPOS="3884" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="23" HPOS="4127" VPOS="3895" />
+            <a:String CONTENT="mi" HEIGHT="36" WIDTH="59" HPOS="4127" VPOS="3885" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4218" VPOS="3895" />
+            <a:String CONTENT="vida" HEIGHT="37" WIDTH="99" HPOS="4218" VPOS="3886" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4350" VPOS="3897" />
+            <a:String CONTENT="ese" HEIGHT="28" WIDTH="73" HPOS="4350" VPOS="3897" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4455" VPOS="3899" />
+            <a:String CONTENT="afÃ¡n" HEIGHT="38" WIDTH="106" HPOS="4455" VPOS="3889" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4593" VPOS="3891" />
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="4593" VPOS="3891" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4676" VPOS="3902" />
+            <a:String CONTENT="perÂ¬" HEIGHT="37" WIDTH="104" HPOS="4676" VPOS="3902" WC="0.95" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="perpetuidad" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0340" WIDTH="822" HEIGHT="50" HPOS="3959" VPOS="3934">
+            <a:String CONTENT="petuidad" HEIGHT="48" WIDTH="205" HPOS="3959" VPOS="3934" WC="0.95" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="34" HPOS="4198" VPOS="3948" />
+            <a:String CONTENT="no" HEIGHT="28" WIDTH="57" HPOS="4198" VPOS="3948" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4287" VPOS="3950" />
+            <a:String CONTENT="rebasaba" HEIGHT="39" WIDTH="219" HPOS="4287" VPOS="3940" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4537" VPOS="3942" />
+            <a:String CONTENT="los" HEIGHT="40" WIDTH="67" HPOS="4537" VPOS="3942" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="4639" VPOS="3944" />
+            <a:String CONTENT="labios" HEIGHT="40" WIDTH="142" HPOS="4639" VPOS="3944" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0341" WIDTH="735" HEIGHT="49" HPOS="3959" VPOS="3988">
+            <a:String CONTENT="de" HEIGHT="38" WIDTH="50" HPOS="3959" VPOS="3988" WC="0.97" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="37" HPOS="4046" VPOS="3999" />
+            <a:String CONTENT="este" HEIGHT="36" WIDTH="93" HPOS="4046" VPOS="3991" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="35" HPOS="4174" VPOS="4000" />
+            <a:String CONTENT="abismo" HEIGHT="40" WIDTH="173" HPOS="4174" VPOS="3991" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="4383" VPOS="4004" />
+            <a:String CONTENT="minÃºsculo.-rs" HEIGHT="43" WIDTH="311" HPOS="4383" VPOS="3994" WC="0.66" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0055" HEIGHT="359" WIDTH="824" HPOS="3959" VPOS="4042" STYLEREFS="PARSTYLE0036">
+          <a:TextLine ID="PAG001LIN0342" WIDTH="765" HEIGHT="57" HPOS="4017" VPOS="4042">
+            <a:String CONTENT="Y" HEIGHT="36" WIDTH="29" HPOS="4017" VPOS="4042" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="12" HPOS="4058" VPOS="4056" />
+            <a:String CONTENT="-" HEIGHT="6" WIDTH="6" HPOS="4058" VPOS="4056" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="15" HPOS="4079" VPOS="4053" />
+            <a:String CONTENT="me" HEIGHT="27" WIDTH="68" HPOS="4079" VPOS="4053" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4180" VPOS="4044" />
+            <a:String CONTENT="indicaba" HEIGHT="46" WIDTH="208" HPOS="4180" VPOS="4044" WC="0.88" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4418" VPOS="4058" />
+            <a:String CONTENT="aquel" HEIGHT="46" WIDTH="128" HPOS="4418" VPOS="4049" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="4582" VPOS="4051" />
+            <a:String CONTENT="hueque-" HEIGHT="48" WIDTH="200" HPOS="4582" VPOS="4051" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="huequecito" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0343" WIDTH="819" HEIGHT="50" HPOS="3962" VPOS="4095">
+            <a:String CONTENT="cito" HEIGHT="38" WIDTH="87" HPOS="3962" VPOS="4095" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="44" HPOS="4093" VPOS="4097" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="4093" VPOS="4097" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="43" HPOS="4187" VPOS="4097" />
+            <a:String CONTENT="dos" HEIGHT="38" WIDTH="80" HPOS="4187" VPOS="4097" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="46" HPOS="4313" VPOS="4108" />
+            <a:String CONTENT="palmos." HEIGHT="45" WIDTH="188" HPOS="4313" VPOS="4100" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="48" HPOS="4549" VPOS="4103" />
+            <a:String CONTENT="Yo" HEIGHT="38" WIDTH="57" HPOS="4549" VPOS="4103" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="4650" VPOS="4115" />
+            <a:String CONTENT="comÂ¬" HEIGHT="28" WIDTH="131" HPOS="4650" VPOS="4115" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="comprendÃ­" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0344" WIDTH="816" HEIGHT="51" HPOS="3963" VPOS="4149">
+            <a:String CONTENT="prendÃ­" HEIGHT="45" WIDTH="154" HPOS="3963" VPOS="4149" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="45" HPOS="4162" VPOS="4151" />
+            <a:String CONTENT="todo" HEIGHT="38" WIDTH="102" HPOS="4162" VPOS="4151" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="4305" VPOS="4163" />
+            <a:String CONTENT="y" HEIGHT="37" WIDTH="24" HPOS="4305" VPOS="4163" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="4371" VPOS="4163" />
+            <a:String CONTENT="no" HEIGHT="29" WIDTH="57" HPOS="4371" VPOS="4163" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="4472" VPOS="4164" />
+            <a:String CONTENT="me" HEIGHT="29" WIDTH="68" HPOS="4472" VPOS="4164" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="45" HPOS="4585" VPOS="4166" />
+            <a:String CONTENT="extraÃ±Ã³'" HEIGHT="39" WIDTH="194" HPOS="4585" VPOS="4159" WC="0.95" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0345" WIDTH="823" HEIGHT="49" HPOS="3959" VPOS="4204">
+            <a:String CONTENT="sorprender" HEIGHT="44" WIDTH="268" HPOS="3959" VPOS="4204" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="27" HPOS="4254" VPOS="4205" />
+            <a:String CONTENT="temblando," HEIGHT="48" WIDTH="268" HPOS="4254" VPOS="4205" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="4551" VPOS="4221" />
+            <a:String CONTENT="en" HEIGHT="28" WIDTH="54" HPOS="4551" VPOS="4220" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="29" HPOS="4634" VPOS="4212" />
+            <a:String CONTENT="la" HEIGHT="38" WIDTH="35" HPOS="4634" VPOS="4212" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4699" VPOS="4223" />
+            <a:String CONTENT="neÂ¬" HEIGHT="28" WIDTH="83" HPOS="4699" VPOS="4223" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="negra" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0346" WIDTH="822" HEIGHT="54" HPOS="3959" VPOS="4256">
+            <a:String CONTENT="gra" HEIGHT="37" WIDTH="80" HPOS="3959" VPOS="4264" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="30" HPOS="4069" VPOS="4266" />
+            <a:String CONTENT="mirada" HEIGHT="39" WIDTH="171" HPOS="4069" VPOS="4256" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4271" VPOS="4259" />
+            <a:String CONTENT="de" HEIGHT="37" WIDTH="51" HPOS="4271" VPOS="4259" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4353" VPOS="4270" />
+            <a:String CONTENT="mi" HEIGHT="37" WIDTH="59" HPOS="4353" VPOS="4260" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4443" VPOS="4272" />
+            <a:String CONTENT="amigo," HEIGHT="47" WIDTH="161" HPOS="4443" VPOS="4263" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="32" HPOS="4636" VPOS="4266" />
+            <a:String CONTENT="la" HEIGHT="37" WIDTH="41" HPOS="4636" VPOS="4266" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4710" VPOS="4267" />
+            <a:String CONTENT="luÂ¬" HEIGHT="38" WIDTH="71" HPOS="4710" VPOS="4267" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="luciÃ©rnaga" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0347" WIDTH="820" HEIGHT="61" HPOS="3960" VPOS="4308">
+            <a:String CONTENT="ciÃ©rnaga" HEIGHT="48" WIDTH="210" HPOS="3960" VPOS="4308" WC="0.98" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="41" HPOS="4211" VPOS="4311" />
+            <a:String CONTENT="furtiva" HEIGHT="41" WIDTH="169" HPOS="4211" VPOS="4311" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="4418" VPOS="4315" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="52" HPOS="4418" VPOS="4315" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="4512" VPOS="4326" />
+            <a:String CONTENT="una" HEIGHT="31" WIDTH="87" HPOS="4512" VPOS="4326" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="4643" VPOS="4319" />
+            <a:String CONTENT="lÃ¡griÂ¬" HEIGHT="50" WIDTH="137" HPOS="4643" VPOS="4319" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="lÃ¡grima." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0348" WIDTH="83" HEIGHT="29" HPOS="3961" VPOS="4371">
+            <a:String CONTENT="ma." HEIGHT="29" WIDTH="83" HPOS="3961" VPOS="4371" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0056" HEIGHT="304" WIDTH="825" HPOS="3957" VPOS="4427" STYLEREFS="PARSTYLE0037">
+          <a:TextLine ID="PAG001LIN0349" WIDTH="765" HEIGHT="60" HPOS="4016" VPOS="4427">
+            <a:String CONTENT="La" HEIGHT="37" WIDTH="61" HPOS="4016" VPOS="4427" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="4105" VPOS="4437" />
+            <a:String CONTENT="vÃ­spera" HEIGHT="47" WIDTH="177" HPOS="4105" VPOS="4428" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4312" VPOS="4431" />
+            <a:String CONTENT="de" HEIGHT="40" WIDTH="49" HPOS="4312" VPOS="4431" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="30" HPOS="4391" VPOS="4442" />
+            <a:String CONTENT="mi" HEIGHT="36" WIDTH="59" HPOS="4391" VPOS="4434" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="28" HPOS="4478" VPOS="4444" />
+            <a:String CONTENT="marcha," HEIGHT="47" WIDTH="197" HPOS="4478" VPOS="4437" WC="0.96" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4706" VPOS="4450" />
+            <a:String CONTENT="qui" HEIGHT="46" WIDTH="75" HPOS="4706" VPOS="4441" WC="0.99" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0350" WIDTH="819" HEIGHT="55" HPOS="3960" VPOS="4480">
+            <a:String CONTENT="se" HEIGHT="28" WIDTH="46" HPOS="3960" VPOS="4489" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="38" HPOS="4044" VPOS="4480" />
+            <a:String CONTENT="despedirme" HEIGHT="48" WIDTH="277" HPOS="4044" VPOS="4480" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="4360" VPOS="4485" />
+            <a:String CONTENT="de" HEIGHT="39" WIDTH="50" HPOS="4360" VPOS="4485" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="4449" VPOS="4498" />
+            <a:String CONTENT="aquel" HEIGHT="46" WIDTH="129" HPOS="4449" VPOS="4489" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="4617" VPOS="4500" />
+            <a:String CONTENT="esconÂ¬" HEIGHT="32" WIDTH="162" HPOS="4617" VPOS="4500" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="escondrijo." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0351" WIDTH="815" HEIGHT="55" HPOS="3961" VPOS="4531">
+            <a:String CONTENT="drijo." HEIGHT="49" WIDTH="130" HPOS="3961" VPOS="4531" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+            <a:SP WIDTH="42" HPOS="4133" VPOS="4535" />
+            <a:String CONTENT="Agua" HEIGHT="47" WIDTH="123" HPOS="4133" VPOS="4535" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="45" HPOS="4301" VPOS="4537" />
+            <a:String CONTENT="del" HEIGHT="38" WIDTH="68" HPOS="4301" VPOS="4537" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="4413" VPOS="4549" />
+            <a:String CONTENT="cielo" HEIGHT="42" WIDTH="112" HPOS="4413" VPOS="4540" WC="0.92" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="45" HPOS="4570" VPOS="4553" />
+            <a:String CONTENT="colmaWa" HEIGHT="43" WIDTH="206" HPOS="4570" VPOS="4543" WC="0.94" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0352" WIDTH="819" HEIGHT="54" HPOS="3959" VPOS="4585">
+            <a:String CONTENT="el" HEIGHT="37" WIDTH="36" HPOS="3959" VPOS="4585" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="4036" VPOS="4587" />
+            <a:String CONTENT="hoyo" HEIGHT="48" WIDTH="112" HPOS="4036" VPOS="4587" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="4184" VPOS="4588" />
+            <a:String CONTENT="dt" HEIGHT="38" WIDTH="48" HPOS="4184" VPOS="4588" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="36" HPOS="4268" VPOS="4600" />
+            <a:String CONTENT="granito." HEIGHT="44" WIDTH="192" HPOS="4268" VPOS="4593" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="39" HPOS="4499" VPOS="4594" />
+            <a:String CONTENT="Y" HEIGHT="37" WIDTH="29" HPOS="4499" VPOS="4594" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="40" HPOS="4568" VPOS="4605" />
+            <a:String CONTENT="sobre" HEIGHT="39" WIDTH="130" HPOS="4568" VPOS="4598" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="4738" VPOS="4610" />
+            <a:String CONTENT="el" HEIGHT="38" WIDTH="37" HPOS="4738" VPOS="4601" WC="1" STYLEREFS="TEXTSTYLE0002" />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0353" WIDTH="819" HEIGHT="60" HPOS="3957" VPOS="4641">
+            <a:String CONTENT="agua" HEIGHT="38" WIDTH="111" HPOS="3957" VPOS="4648" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="44" HPOS="4112" VPOS="4641" />
+            <a:String CONTENT="boyaba" HEIGHT="47" WIDTH="167" HPOS="4112" VPOS="4641" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="41" HPOS="4320" VPOS="4654" />
+            <a:String CONTENT="una" HEIGHT="29" WIDTH="88" HPOS="4320" VPOS="4654" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="42" HPOS="4450" VPOS="4657" />
+            <a:String CONTENT="estrella" HEIGHT="38" WIDTH="182" HPOS="4450" VPOS="4651" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="40" HPOS="4672" VPOS="4663" />
+            <a:String CONTENT="preÂ¬" HEIGHT="38" WIDTH="104" HPOS="4672" VPOS="4663" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart1" SUBS_CONTENT="precoz." />
+          </a:TextLine>
+          <a:TextLine ID="PAG001LIN0354" WIDTH="87" HEIGHT="28" HPOS="3959" VPOS="4702">
+            <a:String CONTENT="coz." HEIGHT="28" WIDTH="87" HPOS="3959" VPOS="4702" WC="1" STYLEREFS="TEXTSTYLE0002" SUBS_TYPE="HypPart2" SUBS_CONTENT="" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0057" HEIGHT="54" WIDTH="737" HPOS="4040" VPOS="4769" STYLEREFS="PARSTYLE0038">
+          <a:TextLine ID="PAG001LIN0355" WIDTH="736" HEIGHT="53" HPOS="4040" VPOS="4769">
+            <a:String CONTENT="Francisco" HEIGHT="41" WIDTH="241" HPOS="4040" VPOS="4769" WC="0.98" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="31" HPOS="4312" VPOS="4774" />
+            <a:String CONTENT="Luis" HEIGHT="38" WIDTH="104" HPOS="4312" VPOS="4774" WC="1" STYLEREFS="TEXTSTYLE0002" />
+            <a:SP WIDTH="33" HPOS="4449" VPOS="4777" />
+            <a:String CONTENT="BERNARDEZ" HEIGHT="45" WIDTH="327" HPOS="4449" VPOS="4777" WC="1" STYLEREFS="TEXTSTYLE0001" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0058" HEIGHT="79" WIDTH="1580" HPOS="3127" VPOS="4899" STYLEREFS="PARSTYLE0003">
+          <a:TextLine ID="PAG001LIN0356" WIDTH="1579" HEIGHT="78" HPOS="3127" VPOS="4899">
+            <a:String CONTENT="CavÃ­lacÃ­ons" HEIGHT="59" WIDTH="418" HPOS="3127" VPOS="4899" WC="0.98" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="42" HPOS="3587" VPOS="4906" />
+            <a:String CONTENT="d" HEIGHT="53" WIDTH="40" HPOS="3587" VPOS="4906" WC="0.95" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="20" HPOS="3647" VPOS="4924" />
+            <a:String CONTENT="an" HEIGHT="38" WIDTH="88" HPOS="3647" VPOS="4924" WC="0.95" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="40" HPOS="3775" VPOS="4911" />
+            <a:String CONTENT="&quot;Ã­uerza" HEIGHT="59" WIDTH="266" HPOS="3775" VPOS="4909" WC="0.95" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="43" HPOS="4084" VPOS="4926" />
+            <a:String CONTENT="viva&quot;" HEIGHT="54" WIDTH="194" HPOS="4084" VPOS="4911" WC="0.94" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="183" HPOS="4461" VPOS="4917" />
+            <a:String CONTENT="Por" HEIGHT="54" WIDTH="97" HPOS="4461" VPOS="4917" WC="0.98" STYLEREFS="TEXTSTYLE0005" />
+            <a:SP WIDTH="37" HPOS="4595" VPOS="4922" />
+            <a:String CONTENT="Xan" HEIGHT="55" WIDTH="111" HPOS="4595" VPOS="4922" WC="1" STYLEREFS="TEXTSTYLE0005" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:ComposedBlock ID="PAG001BLK0059" HEIGHT="147" WIDTH="1051" HPOS="3230" VPOS="7266" />
+        <a:TextBlock ID="PAG001BLK0060" HEIGHT="58" WIDTH="802" HPOS="3249" VPOS="7282" STYLEREFS="PARSTYLE0039">
+          <a:TextLine ID="PAG001LIN0357" WIDTH="801" HEIGHT="57" HPOS="3249" VPOS="7282">
+            <a:String CONTENT="Pero" HEIGHT="45" WIDTH="117" HPOS="3249" VPOS="7282" WC="1" STYLEREFS="TEXTSTYLE0009" />
+            <a:SP WIDTH="23" HPOS="3389" VPOS="7295" />
+            <a:String CONTENT="Â¿a" HEIGHT="43" WIDTH="51" HPOS="3389" VPOS="7295" WC="1" STYLEREFS="TEXTSTYLE0009" />
+            <a:SP WIDTH="29" HPOS="3469" VPOS="7295" />
+            <a:String CONTENT="quÃ©" HEIGHT="50" WIDTH="85" HPOS="3469" VPOS="7289" WC="1" STYLEREFS="TEXTSTYLE0001" />
+            <a:SP WIDTH="26" HPOS="3580" VPOS="7292" />
+            <a:String CONTENT="vipnen" HEIGHT="46" WIDTH="165" HPOS="3580" VPOS="7283" WC="0.67" STYLEREFS="TEXTSTYLE0009" />
+            <a:SP WIDTH="28" HPOS="3773" VPOS="7300" />
+            <a:String CONTENT="estos" HEIGHT="41" WIDTH="141" HPOS="3773" VPOS="7292" WC="1" STYLEREFS="TEXTSTYLE0009" />
+            <a:SP WIDTH="21" HPOS="3935" VPOS="7294" />
+            <a:String CONTENT="lies?" HEIGHT="45" WIDTH="115" HPOS="3935" VPOS="7294" WC="0.86" STYLEREFS="TEXTSTYLE0009" />
+          </a:TextLine>
+        </a:TextBlock>
+        <a:TextBlock ID="PAG001BLK0061" HEIGHT="65" WIDTH="1020" HPOS="3247" VPOS="7341" STYLEREFS="PARSTYLE0003">
+          <a:TextLine ID="PAG001LIN0358" WIDTH="1019" HEIGHT="64" HPOS="3247" VPOS="7341">
+            <a:String CONTENT="Â¿No" HEIGHT="56" WIDTH="93" HPOS="3247" VPOS="7342" WC="1" STYLEREFS="TEXTSTYLE0009" />
+            <a:SP WIDTH="23" HPOS="3363" VPOS="7341" />
+            <a:String CONTENT="''marchaba&quot;" HEIGHT="45" WIDTH="303" HPOS="3363" VPOS="7341" WC="0.85" STYLEREFS="TEXTSTYLE0009" />
+            <a:SP WIDTH="28" HPOS="3694" VPOS="7347" />
+            <a:String CONTENT="todo" HEIGHT="46" WIDTH="109" HPOS="3694" VPOS="7344" WC="1" STYLEREFS="TEXTSTYLE0009" />
+            <a:SP WIDTH="28" HPOS="3831" VPOS="7361" />
+            <a:String CONTENT="admirablemente?" HEIGHT="58" WIDTH="435" HPOS="3831" VPOS="7347" WC="0.98" STYLEREFS="TEXTSTYLE0009" />
+          </a:TextLine>
+        </a:TextBlock>
+      </a:PrintSpace>
+    </a:Page>
+  </a:Layout>
+</a:alto>


### PR DESCRIPTION
Previously we didn't support namespaced ALTO XML since our heuristics for detecting ALTO didn't consider them. This PR remedies that and expands the XML sanitizer to not consider namespaces as illegal tags.