### PR TITLE
fix snippet preview on example page

### DIFF
--- a/example/frontend/index.js
+++ b/example/frontend/index.js
@@ -150,6 +150,7 @@ const RegionDisplay = ({
       <div class="region-img-container">
         <a href={viewerUrl} target="_blank" title="Open page in viewer">
           <img ref={ref} alt={region.text} src={getImageUrl(region, page)} />
+          <p class="highlightable" dangerouslySetInnerHTML={{ __html: region.text }} />
         </a>
         {scaleFactor &&
           highlights.map((hl) => (

--- a/example/frontend/style.css
+++ b/example/frontend/style.css
@@ -62,12 +62,14 @@ main p {
 
 .snippet-display {
 	box-shadow: 1px 2px 8px;
-    border-radius: 8px;
+    	border-radius: 8px;
+	margin: 20px 0;
 }
 
 .snippet-display img {
 	max-width: 100%;
-	border-radius: 8px;
+	border-top-left-radius: 8px;
+    	border-top-right-radius: 8px;
 }
 
 .region-img-container {
@@ -77,6 +79,10 @@ main p {
 
 .metadata {
 	text-align: left;
+}
+
+.highlightable {
+	padding: 0 5px;
 }
 
 .highlightable em {


### PR DESCRIPTION
The display of the search interface on a locally running example folder varies slightly from that on the demo page https://ocrhl.jbaiter.de: there's a text excerpt in the snippet preview (class "highlightable") in addition to the image with some distance to the next snippet. Running the docker-compose file locally this excerpt has been missing.

This pull request would fix this, although the HTML structure is not quite the same as the demo. One aspect of issue #203 should be done with this.