### PR TITLE
Fix issues identified by `policeman-tools/forbidden-apis`

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/OcrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/OcrParser.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
@@ -100,13 +101,15 @@ public abstract class OcrParser implements Iterator<OcrBox>, Iterable<OcrBox> {
     xmlInputFactory
         .getConfig()
         .setUndeclaredEntityResolver(
-            (publicID, systemID, baseURI, namespace) -> String.format("&amp;%s;", namespace));
+            (publicID, systemID, baseURI, namespace) ->
+                String.format(Locale.US, "&amp;%s;", namespace));
     this.xmlReader = (XMLStreamReader2) xmlInputFactory.createXMLStreamReader(this.input);
     try {
       this.nextWord = this.readNext(this.xmlReader, this.features);
     } catch (XMLStreamException e) {
       throw new RuntimeException(
           String.format(
+              Locale.US,
               "Failed to parse the OCR markup, make sure your files are well-formed and your regions start/end on "
                   + "complete tags! (Source was: %s)",
               this.input.getSource().orElse("[unknown]")),
@@ -142,6 +145,7 @@ public abstract class OcrParser implements Iterator<OcrBox>, Iterable<OcrBox> {
     } catch (XMLStreamException | WstxLazyException e) {
       throw new RuntimeException(
           String.format(
+              Locale.US,
               "Failed to parse the OCR markup, make sure your files are well-formed and your regions start/end on "
                   + "complete tags! (Source was: %s)",
               this.input.getSource().orElse("[unknown]")),

--- a/src/main/java/de/digitalcollections/solrocr/iter/ExitingIterCharSeq.java
+++ b/src/main/java/de/digitalcollections/solrocr/iter/ExitingIterCharSeq.java
@@ -2,6 +2,7 @@ package de.digitalcollections.solrocr.iter;
 
 import de.digitalcollections.solrocr.model.SourcePointer;
 import java.nio.charset.Charset;
+import java.util.Locale;
 import java.util.stream.IntStream;
 import org.apache.lucene.index.QueryTimeout;
 
@@ -27,11 +28,16 @@ public class ExitingIterCharSeq implements IterableCharSequence {
     if (timeout.shouldExit()) {
       throw new ExitingIterCharSeqException(
           String.format(
+              Locale.US,
               "The request took to long to highlight the OCR files (pointer: %s, timeout was: %s)",
-              getPointer(), timeout));
+              getPointer(),
+              timeout));
     } else if (Thread.interrupted()) {
       throw new ExitingIterCharSeqException(
-          String.format("Interrupted while reading the file for OCR (pointer: %s).", getPointer()));
+          String.format(
+              Locale.US,
+              "Interrupted while reading the file for OCR (pointer: %s).",
+              getPointer()));
     }
   }
 

--- a/src/main/java/de/digitalcollections/solrocr/iter/MultiFileBytesCharIterator.java
+++ b/src/main/java/de/digitalcollections/solrocr/iter/MultiFileBytesCharIterator.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -66,7 +67,9 @@ public class MultiFileBytesCharIterator implements IterableCharSequence, AutoClo
   @Override
   public String getIdentifier() {
     return String.format(
-        "{%s}", this.paths.stream().map(Path::toString).collect(Collectors.joining(", ")));
+        Locale.US,
+        "{%s}",
+        this.paths.stream().map(Path::toString).collect(Collectors.joining(", ")));
   }
 
   @Override

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrPassageFormatter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrPassageFormatter.java
@@ -23,6 +23,7 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -101,9 +102,12 @@ public class OcrPassageFormatter extends PassageFormatter {
       } catch (IndexOutOfBoundsException e) {
         String errorMsg =
             String.format(
+                Locale.US,
                 "Could not create snippet (start=%d, end=%d) from content at '%s' due to an out-of-bounds error.\n"
                     + "\nDoes the file on disk correspond to the document that was used during indexing?",
-                passage.getStartOffset(), passage.getEndOffset(), content.getIdentifier());
+                passage.getStartOffset(),
+                passage.getEndOffset(),
+                content.getIdentifier());
         logger.error(errorMsg, e);
       }
     }
@@ -501,7 +505,7 @@ public class OcrPassageFormatter extends PassageFormatter {
 
     @Override
     public String toString() {
-      return String.format("PassageMatch{start=%d, end=%d}", start, end);
+      return String.format(Locale.US, "PassageMatch{start=%d, end=%d}", start, end);
     }
   }
 }

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
@@ -6,14 +6,17 @@ import de.digitalcollections.solrocr.reader.MultiFileReader;
 import de.digitalcollections.solrocr.util.Utf8;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
@@ -52,6 +55,7 @@ public class ExternalUtf8ContentFilterFactory extends CharFilterFactory {
       if (pointer == null) {
         throw new RuntimeException(
             String.format(
+                Locale.US,
                 "Could not parse source pointer from field, check the format (value was: '%s')!",
                 ptrStr));
       }
@@ -73,7 +77,9 @@ public class ExternalUtf8ContentFilterFactory extends CharFilterFactory {
             new MultiFileReader(
                 pointer.sources.stream().map(s -> s.path).collect(Collectors.toList()));
       } else {
-        r = new FileReader(pointer.sources.get(0).path.toFile());
+        r =
+            new InputStreamReader(
+                new FileInputStream(pointer.sources.get(0).path.toFile()), StandardCharsets.UTF_8);
       }
 
       List<SourcePointer.Region> charRegions =
@@ -81,7 +87,8 @@ public class ExternalUtf8ContentFilterFactory extends CharFilterFactory {
       return new ExternalUtf8ContentFilter(new BufferedReader(r), charRegions, ptrStr);
     } catch (IOException e) {
       throw new RuntimeException(
-          String.format("Error while reading external content from pointer '%s': %s", ptrStr, e));
+          String.format(
+              Locale.US, "Error while reading external content from pointer '%s': %s", ptrStr, e));
     }
   }
 
@@ -94,7 +101,8 @@ public class ExternalUtf8ContentFilterFactory extends CharFilterFactory {
     if (!f.exists() || !f.canRead()) {
       throw new SolrException(
           ErrorCode.BAD_REQUEST,
-          String.format("File at %s either does not exist or cannot be read.", src.path));
+          String.format(
+              Locale.US, "File at %s either does not exist or cannot be read.", src.path));
     }
   }
 
@@ -118,8 +126,10 @@ public class ExternalUtf8ContentFilterFactory extends CharFilterFactory {
     if (numRead < numBytes) {
       throw new IOException(
           String.format(
+              Locale.US,
               "Read fewer bytes than expected (%d vs %d), check your source pointer!",
-              numRead, numBytes));
+              numRead,
+              numBytes));
     }
     return decodedLength;
   }

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilter.java
@@ -7,6 +7,7 @@ import de.digitalcollections.solrocr.formats.OcrParser;
 import de.digitalcollections.solrocr.model.OcrBox;
 import java.io.StringReader;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import org.apache.lucene.analysis.CharFilter;
 import org.apache.lucene.analysis.charfilter.BaseCharFilter;
@@ -167,7 +168,11 @@ public class OcrCharFilter extends BaseCharFilter {
     @Override
     public String toString() {
       return String.format(
-          "TokenWithAlternatives{%d@[%d:%d[}", numForms, defaultFormStart, defaultFormEnd);
+          Locale.US,
+          "TokenWithAlternatives{%d@[%d:%d[}",
+          numForms,
+          defaultFormStart,
+          defaultFormEnd);
     }
   }
 }

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -82,7 +82,7 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
           break outer;
         }
         if (cbuf[match] == '<') {
-          // Start of element, no more entitites to check
+          // Start of element, no more entities to check
           break;
         }
         int entityEnd = multiIndexOf(cbuf, match + 1, '<', ';');

--- a/src/main/java/de/digitalcollections/solrocr/model/SourcePointer.java
+++ b/src/main/java/de/digitalcollections/solrocr/model/SourcePointer.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -25,12 +26,12 @@ public class SourcePointer {
     public FileSource(Path path, List<Region> regions, boolean isAscii) throws IOException {
       this.path = path;
       if (!path.toFile().exists()) {
-        String msg = String.format("File at %s does not exist, skipping.", path.toString());
+        String msg = String.format(Locale.US, "File at %s does not exist, skipping.", path);
         logger.warn(msg);
         throw new IOException(msg);
       }
       if (path.toFile().length() == 0) {
-        String msg = String.format("File at %s is empty, skipping.", path.toString());
+        String msg = String.format(Locale.US, "File at %s is empty, skipping.", path);
         logger.warn(msg);
         throw new IOException(msg);
       }

--- a/src/main/java/de/digitalcollections/solrocr/reader/MultiFileReader.java
+++ b/src/main/java/de/digitalcollections/solrocr/reader/MultiFileReader.java
@@ -1,28 +1,35 @@
 package de.digitalcollections.solrocr.reader;
 
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Queue;
 
 public class MultiFileReader extends Reader {
   private final Queue<Path> remainingSources;
-  private FileReader currentReader;
+  private Reader currentReader;
 
   public MultiFileReader(List<Path> sourcePaths) throws FileNotFoundException {
     for (Path path : sourcePaths) {
       if (!path.toFile().exists()) {
-        throw new FileNotFoundException(String.format("File at %s could not be found", path));
+        throw new FileNotFoundException(
+            String.format(Locale.US, "File at %s could not be found", path));
       } else if (path.toFile().isDirectory()) {
-        throw new FileNotFoundException(String.format("File at %s is a directory", path));
+        throw new FileNotFoundException(
+            String.format(Locale.US, "File at %s is a directory", path));
       }
     }
     this.remainingSources = new LinkedList<>(sourcePaths);
-    this.currentReader = new FileReader(remainingSources.remove().toFile());
+    this.currentReader =
+        new InputStreamReader(
+            new FileInputStream(remainingSources.remove().toFile()), StandardCharsets.UTF_8);
   }
 
   @Override
@@ -39,7 +46,9 @@ public class MultiFileReader extends Reader {
           // No more readers, return what was read so far
           this.currentReader = null;
         } else {
-          this.currentReader = new FileReader(this.remainingSources.remove().toFile());
+          this.currentReader =
+              new InputStreamReader(
+                  new FileInputStream(remainingSources.remove().toFile()), StandardCharsets.UTF_8);
         }
       }
       if (read < 0) {

--- a/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/AltoTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -346,7 +347,9 @@ public class AltoTest extends SolrTestCaseJ4 {
             .map(
                 idx ->
                     String.format(
-                        "src/test/resources/data/issue-173/es-scbg_bblg_18950101_%04d.xml", idx))
+                        Locale.US,
+                        "src/test/resources/data/issue-173/es-scbg_bblg_18950101_%04d.xml",
+                        idx))
             .collect(Collectors.joining("+"));
     assertU(adoc("id", "57372", "ocr_text", ptr));
     assertU(commit());
@@ -376,7 +379,7 @@ public class AltoTest extends SolrTestCaseJ4 {
     assertQ(
         req, "//lst[@name='47388']//arr[@name='highlights']//int[@name='lrx'][1]/text()='2499'");
   }
-  
+
   // https://github.com/dbmdz/solr-ocrhighlighting/issues/212
   public void testExcessivelyLongElements() {
     Path ocrPath = Paths.get("src/test/resources/data/altolongelement.xml");

--- a/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/HocrTest.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -32,7 +33,12 @@ public class HocrTest extends SolrTestCaseJ4 {
             "1337"));
     Path ocrPath = Paths.get("src/test/resources/data/hocr.html");
     assertU(adoc("ocr_text", ocrPath.toString(), "id", "42"));
-    assertU(adoc("ocr_text", String.format("%s[3001845:3065626]", ocrPath.toString()), "id", "84"));
+    assertU(
+        adoc(
+            "ocr_text",
+            String.format(Locale.US, "%s[3001845:3065626]", ocrPath.toString()),
+            "id",
+            "84"));
     Path multiColPath = Paths.get("src/test/resources/data/multicolumn.hocr");
     assertU(adoc("ocr_text", multiColPath.toString(), "id", "96"));
     String ptr =
@@ -262,11 +268,13 @@ public class HocrTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = xmlQ("q", "fenia", "hl.snippets", "1");
     assertQ(
         req,
-        String.format("//arr[@name='snippets']/lst[1]//str[@name='text']/text()='%s'", firstSnip));
+        String.format(
+            Locale.US, "//arr[@name='snippets']/lst[1]//str[@name='text']/text()='%s'", firstSnip));
     req = xmlQ("q", "fenia", "hl.snippets", "100");
     assertQ(
         req,
-        String.format("//arr[@name='snippets']/lst[1]//str[@name='text']/text()='%s'", firstSnip));
+        String.format(
+            Locale.US, "//arr[@name='snippets']/lst[1]//str[@name='text']/text()='%s'", firstSnip));
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/solrocr/util/MiniOcrByteOffsetsParser.java
+++ b/src/test/java/de/digitalcollections/solrocr/util/MiniOcrByteOffsetsParser.java
@@ -6,6 +6,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import net.byteseek.compiler.CompileException;
 import net.byteseek.compiler.matcher.SequenceMatcherCompiler;
@@ -105,7 +106,7 @@ public class MiniOcrByteOffsetsParser {
       throws IOException {
     for (Pair<String, Integer> pair : parse(ocrBytes, 0, firstId, lastId)) {
       os.write(pair.getLeft().getBytes(StandardCharsets.UTF_8));
-      os.write(String.format("⚑%d ", pair.getRight()).getBytes(StandardCharsets.UTF_8));
+      os.write(String.format(Locale.US, "⚑%d ", pair.getRight()).getBytes(StandardCharsets.UTF_8));
     }
   }
 }


### PR DESCRIPTION
https://github.com/policeman-tools/forbidden-apis

This includes:
- Explicitly specify locale for APIs that use `Locale.defaultLocale()` implicitly to avoid bugs caused by non-US locales
- Prefer `trySetAccessible()` on Java 9 over `setAccessible(true)` on earlier Java versions

Unfortunately we could not add this check to the CI setup, since we have one spot where we deliberatly use a deprecated API that uses the default locale for performance reasons ([`FileBytesCharIterator#getSubSequence(int, int, bool)`](https://github.com/dbmdz/solr-ocrhighlighting/blob/main/src/main/java/de/digitalcollections/solrocr/iter/FileBytesCharIterator.java#L138-L144)).