### PR TITLE
Fix multi-file parsing with UTF8 BOM (fixes #169)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
     <version.byteseek>2.0.3</version.byteseek>
     <version.commons-text>1.9</version.commons-text>
     <version.junit>5.8.2</version.junit>
-    <version.log4j>2.11.1</version.log4j>
     <version.mockito>4.1.0</version.mockito>
     <version.slf4j>1.7.32</version.slf4j>
     <version.solr>8.9.0</version.solr>

--- a/src/test/resources/data/chronicling_hocr/seq-1.html
+++ b/src/test/resources/data/chronicling_hocr/seq-1.html
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html
   PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/src/test/resources/data/chronicling_hocr/seq-2.html
+++ b/src/test/resources/data/chronicling_hocr/seq-2.html
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html
   PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/src/test/resources/data/chronicling_hocr/seq-3.html
+++ b/src/test/resources/data/chronicling_hocr/seq-3.html
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html
   PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/src/test/resources/data/chronicling_hocr/seq-4.html
+++ b/src/test/resources/data/chronicling_hocr/seq-4.html
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html
   PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
Previously parsing would crash when any file but the first in a
multi-file source pointer would start on a (legal, but unneeded)
UTF8 byte-order marker.

To fix this, when we detect a BOM in a file, we adjust source pointer
regions that start from the beginning of the file to not include the
UTF8 BOM.