### PR TITLE
Page regex updated to allow single quote.

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/miniocr/MiniOcrFormat.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/miniocr/MiniOcrFormat.java
@@ -18,7 +18,7 @@ import javax.xml.stream.XMLStreamException;
 public class MiniOcrFormat implements OcrFormat {
   private static final Pattern pagePat =
       Pattern.compile(
-          "<p (?:xml)?:id=\"(?<pageId>.+?)\" ?(?:wh=\"(?<width>\\d+) (?<height>\\d+)\")?>");
+          "<p (?:xml)?:id=(\"|')(?<pageId>.+?)(\"|') ?(?:wh=(\"|')(?<width>\\d+) (?<height>\\d+)(\"|'))?>");
   private static final Map<OcrBlock, String> blockTagMapping =
       ImmutableMap.of(
           OcrBlock.PAGE, "p",


### PR DESCRIPTION
Greetings. 

I am working on  a project that includes an option to submit MiniOcr files for indexing without lazy loading and I noticed that pages are not returned in query results when using this option. 

The cause is that the regex for matching the page element assumes double quoted xml. Unfortunately I submit single-quoted xml in a json post to solr.  This minor change is this PR fixes the problem. I hope you'll consider adding it. 

Thanks!