### PR TITLE
sanitization: Make 'end of tag' detection more robust.

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -175,7 +175,7 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
       }
 
       int startTag = cbuf[startElem + 1] == '/' ? startElem + 2 : startElem + 1;
-      int endTag = ArrayUtils.indexOf(cbuf, ' ', startTag);
+      int endTag = multiIndexOf(cbuf, startTag, ' ', '\n', '\t');
       if (endTag > endElem || endTag < 0) {
         endTag = cbuf[endElem - 1] == '/' ? endElem - 1 : endElem;
       }


### PR DESCRIPTION
Previously we would look for the first space (0x20) character within a
tag to determine where the element name ended. This is not robust, since
a given element may be split across multiple lines or include tab
characters instead of a simple whitesapce. This is why we now check for
those as well, hopefully making the XML sanitizer more robust.
Thanks to @schmika for spotting the bug!