### PR TITLE
hocr: Handle quoted property values in titles

### DIFF
--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrFormat.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrFormat.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 public class HocrFormat implements OcrFormat {
   private static final Pattern pageIdPat =
       Pattern.compile(
-          "(?:id=['\"](?<id>.+?)['\"]|x_source (?<source>.+?)['\";]|ppageno (?<pageno>\\d+))");
+          "(?:id=['\"](?<id>.+?)['\"]|x_source ['\"]?(?<source>.+?)['\"]?['\";]|ppageno (?<pageno>\\d+))");
   private static final Pattern pageBboxPat =
       Pattern.compile("bbox 0 0 (?<width>\\d+) (?<height>\\d+)");
   private static final Pattern pageElemPat =

--- a/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
+++ b/src/main/java/de/digitalcollections/solrocr/formats/hocr/HocrParser.java
@@ -124,7 +124,15 @@ public class HocrParser extends OcrParser {
     String[] parts = title.split(";");
     for (String part : parts) {
       int spaceIdx = part.indexOf(' ', 3);
-      props.put(part.substring(0, spaceIdx).trim(), part.substring(spaceIdx + 1).trim());
+      String propertyName = part.substring(0, spaceIdx).trim();
+      String propertyValue = part.substring(spaceIdx + 1).trim();
+      boolean isQuoted =
+          (propertyValue.startsWith("\"") && propertyValue.endsWith("\""))
+              || (propertyValue.startsWith("'") && propertyValue.endsWith("'"));
+      if (isQuoted) {
+        propertyValue = propertyValue.substring(1, propertyValue.length() - 1);
+      }
+      props.put(propertyName, propertyValue);
     }
     return props;
   }

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -24,9 +24,12 @@ import org.apache.lucene.analysis.charfilter.BaseCharFilter;
  */
 public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareReader {
 
-  /** Set of tags that we want to strip from the XML, currently this is mostly for HTML elements
-   *  that can occur without a closing tag and without the self-closing form. */
+  /**
+   * Set of tags that we want to strip from the XML, currently this is mostly for HTML elements that
+   * can occur without a closing tag and without the self-closing form.
+   */
   private static final Set<String> STRIP_TAGS = ImmutableSet.of("br");
+
   private final Deque<char[]> elementStack = new ArrayDeque<>();
   private char[] carryOver = null;
   private int carryOverIdx = -1;
@@ -39,6 +42,7 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
   private char[] closingTagsTrailer = null;
   /** Tracks how much of the trailer has already been written during previous `read` calls. */
   private int closingTagsTrailerIdx = -1;
+
   private boolean hasDocType = false;
   private final boolean advancedFixing;
 
@@ -252,9 +256,10 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
 
       // There might not be enough room in the output buffer for the whole trailer, so we keep track
       // of how much we've been able to write and continue from there for the next `read` call.
-      int toRead = Math.min(len - Math.max(0, numRead), closingTagsTrailer.length - closingTagsTrailerIdx);
-      System.arraycopy(this.closingTagsTrailer,
-          closingTagsTrailerIdx, cbuf, off + Math.max(0, numRead), toRead);
+      int toRead =
+          Math.min(len - Math.max(0, numRead), closingTagsTrailer.length - closingTagsTrailerIdx);
+      System.arraycopy(
+          this.closingTagsTrailer, closingTagsTrailerIdx, cbuf, off + Math.max(0, numRead), toRead);
       this.closingTagsTrailerIdx += toRead;
       if (numRead < 0) {
         numRead = 0;


### PR DESCRIPTION
The spec says these values have to be double-quoted, but in the wild you
can also find single-quoted titles or no quotes at all (which was the
only way we have supported so far). This change set makes the parser
more robust to the above possibilities.