### PR TITLE
Add support for Solr 9 while maintaining backwards-compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [11, 14]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 11
       - uses: actions/cache@v2
         env:
           cache-name: cache-maven-artifacts

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -4,6 +4,8 @@ SOLR_HOST="${SOLR_HOST:-localhost}"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SOLR7_VERSIONS="7.7 7.6 7.5"
 SOLR8_VERSIONS="8.11 8.10 8.9 8.8 8.7 8.6 8.5 8.4 8.3 8.2 8.1 8.0"
+SOLR9_VERSIONS="9.0.0"
+SOLR78_PLUGIN_PATH=/tmp/solrocr-solr78
 
 wait_for_solr() {
     while [[ "$(curl -s -o /dev/null http://$SOLR_HOST:31337/solr/ocr/select -w '%{http_code}')" != "200" ]]; do
@@ -11,14 +13,50 @@ wait_for_solr() {
     done
 }
 
+create_solr78_jar() {
+    solr9_jar="$(ls ../target/*.jar |egrep -v '(javadoc|sources|original)' |head -n 1)"
+    solr78_jar=$SOLR78_PLUGIN_PATH/$(basename $solr9_jar)
+    mkdir -p $SOLR78_PLUGIN_PATH
+    python3 ../util/patch_solr78_bytecode.py $solr9_jar $solr78_jar
+}
+
 # Make sure we're in the test directory
 cd $SCRIPT_DIR
 
-find ../target
+if [ ! -d "../target" ]; then
+    echo "Please run 'mvn clean package' in the parent directory first!"
+    exit 1
+fi
 
-# Solr 8 versions
+create_solr78_jar
+
+for version in $SOLR9_VERSIONS; do
+    printf "Testing $version: "
+    container_name="ocrhltest-$version"
+    docker run \
+        --name "$container_name" \
+        -e SOLR_LOG_LEVEL=ERROR \
+        -v "$(pwd)/solr/install-plugin.sh:/docker-entrypoint-initdb.d/install-plugin.sh" \
+        -v "$(pwd)/solr/core/v9:/opt/core-config" \
+        -v "$(pwd)/data:/ocr-data" \
+        -v "$(realpath ..)/target:/build" \
+        -p "31337:8983" \
+        solr:$version \
+        solr-precreate ocr /opt/core-config > /dev/null 2>&1 & \
+    wait_for_solr
+    if ! python3 test.py; then
+        printf " !!!FAIL!!!\n"
+        docker logs
+    else
+        printf " OK\n"
+    fi
+    docker stop "$container_name" > /dev/null
+    docker rm "$container_name" > /dev/null
+done
+
+# Solr 8 versions, use a different plugin JAR
 for version in $SOLR8_VERSIONS; do
-    echo "Testing $version"
+    printf "Testing $version: "
     container_name="ocrhltest-$version"
     docker run \
         --name "$container_name" \
@@ -26,33 +64,45 @@ for version in $SOLR8_VERSIONS; do
         -v "$(pwd)/solr/install-plugin.sh:/docker-entrypoint-initdb.d/install-plugin.sh" \
         -v "$(pwd)/solr/core/v8:/opt/core-config" \
         -v "$(pwd)/data:/ocr-data" \
-        -v "$(realpath ..)/target:/build" \
+        -v "$SOLR78_PLUGIN_PATH:/build" \
         -p "31337:8983" \
         solr:$version \
-        solr-precreate ocr /opt/core-config & \
+        solr-precreate ocr /opt/core-config > /dev/null 2>&1 & \
     wait_for_solr
-    python3 test.py
+    if ! python3 test.py; then
+        printf " !!!FAIL!!!\n"
+        docker logs
+    else
+        printf " OK\n"
+    fi
     docker stop "$container_name" > /dev/null
     docker rm "$container_name" > /dev/null
 done
 
 # Solr 7 has a different Docker setup
 for version in $SOLR7_VERSIONS; do
-    echo "Testing $version"
+    printf "Testing $version: "
     docker run \
         --name "ocrhltest-$version" \
         -e SOLR_LOG_LEVEL=ERROR \
         -v "$(pwd)/solr/install-plugin-v7.sh:/docker-entrypoint-initdb.d/install-plugin-v7.sh" \
         -v "$(pwd)/solr/core/v7:/opt/core-config" \
         -v "$(pwd)/data:/ocr-data" \
-        -v "$(realpath ..)/target:/build" \
+        -v "$SOLR78_PLUGIN_PATH:/build" \
         -p "31337:8983" \
         solr:$version \
-        solr-precreate ocr /opt/core-config & \
+        solr-precreate ocr /opt/core-config > /dev/null 2>&1 & \
     wait_for_solr
-    python3 test.py
+    if ! python3 test.py; then
+        printf " !!!FAIL!!!\n"
+        docker logs
+    else
+        printf " OK\n"
+    fi
     docker stop "ocrhltest-$version" > /dev/null
     docker rm "ocrhltest-$version" > /dev/null
 done
+
+rm -rf /tmp/solrocr-solr78
 
 echo "INTEGRATION TESTS SUCCEEDED"

--- a/integration-tests/solr/core/v8/schema.xml
+++ b/integration-tests/solr/core/v8/schema.xml
@@ -17,6 +17,14 @@
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldtype>
+    <fieldType name="text" class="solr.TextField">
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+  </fieldType>
   </types>
 
   <fields>

--- a/integration-tests/solr/core/v8/solrconfig.xml
+++ b/integration-tests/solr/core/v8/solrconfig.xml
@@ -1,5 +1,5 @@
 <config>
-  <luceneMatchVersion>7.6</luceneMatchVersion>
+  <luceneMatchVersion>8.0</luceneMatchVersion>
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 

--- a/integration-tests/solr/core/v9/schema.xml
+++ b/integration-tests/solr/core/v9/schema.xml
@@ -1,0 +1,35 @@
+<schema name="coordinateHighlight" version="1.0">
+  <types>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+    <fieldtype name="text_ocr" class="solr.TextField" storeOffsetsWithPositions="true" termVectors="true">
+      <analyzer type="index">
+        <charFilter class="de.digitalcollections.solrocr.lucene.filters.ExternalUtf8ContentFilterFactory" />
+        <charFilter class="de.digitalcollections.solrocr.lucene.filters.OcrCharFilterFactory" />
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+    </fieldtype>
+    <fieldType name="text" class="solr.TextField">
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+  </fieldType>
+  </types>
+
+  <fields>
+    <field name="id"              type="string"   multiValued="false" indexed="true" stored="true" required="true" />
+    <field name="ocr_text"        type="text_ocr" multiValued="false" indexed="true" stored="true" />
+  </fields>
+  <uniqueKey>id</uniqueKey>
+</schema>

--- a/integration-tests/solr/core/v9/solrconfig.xml
+++ b/integration-tests/solr/core/v9/solrconfig.xml
@@ -1,0 +1,18 @@
+<config>
+  <luceneMatchVersion>9.0</luceneMatchVersion>
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+  <lib dir="/var/solr/data/plugins" regex=".*\.jar" />
+
+  <searchComponent class="de.digitalcollections.solrocr.solr.OcrHighlightComponent"
+                   name="ocrHighlight" />
+
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <arr name="components">
+      <str>query</str>
+      <str>ocrHighlight</str>
+      <str>highlight</str>
+    </arr>
+  </requestHandler>
+</config>

--- a/integration-tests/test.py
+++ b/integration-tests/test.py
@@ -83,7 +83,7 @@ def index_documents(solr_port, docs):
 
 def run_query(solr_port, query):
     req = request.Request(
-        'http://{}:{}/solr/ocr/select?fl=id&hl=on&hl.ocr.fl=ocr_text&hl.weightMatches=true&q=ocr_text:"{}"'.format(
+        'http://{}:{}/solr/ocr/select?fl=id&hl=on&hl.fl=id&hl.ocr.fl=ocr_text&hl.weightMatches=true&q=ocr_text:"{}"'.format(
             SOLR_HOST, solr_port, quote(query)
         )
     )

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <version.junit>5.8.2</version.junit>
     <version.mockito>4.5.1</version.mockito>
     <version.slf4j>1.7.36</version.slf4j>
-    <version.solr>8.11.1</version.solr>
+    <version.solr>9.0.0</version.solr>
     <!-- DO NOT UPDATE THIS, this is the latest version that works with Java 8 -->
     <version.fmt-maven-plugin>2.9.1</version.fmt-maven-plugin>
     <version.maven-gpg-plugin>3.0.1</version.maven-gpg-plugin>
@@ -74,9 +74,34 @@
       <version>${version.commons-text}</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-core</artifactId>
       <version>${version.solr}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-highlighter</artifactId>
+      <version>${version.solr}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-analysis-common</artifactId>
+      <version>${version.solr}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
+      <version>6.2.8</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.apache.solr</groupId>
@@ -189,6 +214,9 @@
             <includes>
               <include>de.digitalcollections:solr-ocr-plugin</include>
               <include>org.apache.commons:commons-text</include>
+              <include>commons-io:commons-io</include>
+              <include>com.fasterxml.woodstox:woodstox-core</include>
+              <include>com.google.guava:guava</include>
             </includes>
           </artifactSet>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>solr-ocrhighlighting</artifactId>
-  <version>0.7.3-SNAPSHOT</version>
+  <version>0.8.0-SNAPSHOT</version>
 
   <name>Solr OCR Highlighting Plugin</name>
   <description>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
           </filters>
           <artifactSet>
             <includes>
-              <include>de.digitalcollections:solr-ocr-plugin</include>
+              <include>de.digitalcollections:solr-ocrhighlighting</include>
               <include>org.apache.commons:commons-text</include>
               <include>commons-io:commons-io</include>
               <include>com.fasterxml.woodstox:woodstox-core</include>

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrAlternativesFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrAlternativesFilterFactory.java
@@ -9,12 +9,12 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenFilterFactory;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
-import org.apache.lucene.analysis.util.TokenFilterFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * increasing this value to 512 or 1024 in the config will fix this, at the expense of an increase
  * in memory usage during indexing.
  *
- * <p><strong>You cannot use the {@link org.apache.lucene.analysis.standard.ClassicTokenizer} with
+ * <p><strong>You cannot use the {@link org.apache.lucene.analysis.classic.ClassicTokenizer} with
  * this filter</strong>, since it splits tokens on the U+2060 (Word Joiner) codepoint, contrary to
  * Unicode rules. Please use one of the newer, unicode-compliant tokenizers like {@link
  * org.apache.lucene.analysis.standard.StandardTokenizer}.

--- a/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/OcrHighlighter.java
@@ -106,9 +106,9 @@ public class OcrHighlighter extends UnifiedHighlighter {
   public static final String PARTIAL_OCR_HIGHLIGHTS = "partialOcrHighlights";
 
   private static final boolean VERSION_IS_PRE81 =
-      Version.LATEST.major < 8 || Version.LATEST.minor < 1;
+      Version.LATEST.major < 8 || (Version.LATEST.major == 8 && Version.LATEST.minor < 1);
   private static final boolean VERSION_IS_PRE82 =
-      Version.LATEST.major < 8 || Version.LATEST.minor < 2;
+      VERSION_IS_PRE81 || (Version.LATEST.major == 8 && Version.LATEST.minor < 2);
   private static final boolean VERSION_IS_PRE84 =
       VERSION_IS_PRE82 || (Version.LATEST.major == 8 && Version.LATEST.minor < 4);
   private static final boolean VERSION_IS_PRE89 =

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/ExternalUtf8ContentFilterFactory.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
-import org.apache.lucene.analysis.util.CharFilterFactory;
+import org.apache.lucene.analysis.CharFilterFactory;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 

--- a/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilterFactory.java
+++ b/src/main/java/de/digitalcollections/solrocr/lucene/filters/OcrCharFilterFactory.java
@@ -8,7 +8,7 @@ import de.digitalcollections.solrocr.model.OcrFormat;
 import de.digitalcollections.solrocr.reader.PeekingReader;
 import java.io.Reader;
 import java.util.Map;
-import org.apache.lucene.analysis.util.CharFilterFactory;
+import org.apache.lucene.analysis.CharFilterFactory;
 
 /**
  * A CharFilterFactory that detects the OCR format from the input and creates the correct CharFilter

--- a/src/test/java/de/digitalcollections/solrocr/solr/DistributedTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/DistributedTest.java
@@ -108,8 +108,8 @@ public class DistributedTest extends BaseDistributedSearchTestCase {
     assertEquals(hls.size(), 1);
     assertEquals(
         hls.get(0),
-        " aliquip ex ea <em>commodo</em> <em>consequat</em>. Duis aute irure dolor in "
-            + "reprehenderit in voluptate velit esse cillum");
+        "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea <em>commodo consequat</em>. Duis aute irure dolor in "
+            + "reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ");
   }
 
   @Test
@@ -135,8 +135,8 @@ public class DistributedTest extends BaseDistributedSearchTestCase {
     assertEquals(hls.size(), 1);
     assertEquals(
         hls.get(0),
-        " aliquip ex ea <em>commodo</em> <em>consequat</em>. Duis aute irure dolor in "
-            + "reprehenderit in voluptate velit esse cillum");
+        "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea <em>commodo consequat</em>. Duis aute irure dolor in "
+            + "reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ");
     NamedList<?> ocrHls = (NamedList<?>) resp.getResponse().get("ocrHighlighting");
     assertEquals(2, ocrHls.size());
     assertEquals(1, ((NamedList<?>) ocrHls.get("31337")).size());

--- a/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrTest.java
+++ b/src/test/java/de/digitalcollections/solrocr/solr/MiniOcrTest.java
@@ -93,7 +93,7 @@ public class MiniOcrTest extends SolrTestCaseJ4 {
     assertQ(
         req,
         "count(//lst[@name='highlighting']/lst[@name='1337']/arr[@name='some_text']/str)=1",
-        ".//arr[@name='some_text']/str/text()=' aliquip ex ea <em>commodo</em> consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum'",
+        ".//arr[@name='some_text']/str/text()='Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea <em>commodo</em> consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. '",
         "count(//lst[@name='ocrHighlighting']/lst[@name='31337']/lst[@name='ocr_text']/arr/lst)=3");
   }
 

--- a/src/test/resources/solr/distributed/solr.xml
+++ b/src/test/resources/solr/distributed/solr.xml
@@ -33,9 +33,6 @@
     <bool name="genericCoreNodeNames">${genericCoreNodeNames:true}</bool>
     <int name="distribUpdateConnTimeout">${distribUpdateConnTimeout:45000}</int>
     <int name="distribUpdateSoTimeout">${distribUpdateSoTimeout:340000}</int>
-    <int name="autoReplicaFailoverWaitAfterExpiration">${autoReplicaFailoverWaitAfterExpiration:10000}</int>
-    <int name="autoReplicaFailoverWorkLoopDelay">${autoReplicaFailoverWorkLoopDelay:10000}</int>
-    <int name="autoReplicaFailoverBadNodeExpiration">${autoReplicaFailoverBadNodeExpiration:60000}</int>
   </solrcloud>
 
   <shardHandlerFactory name="shardHandlerFactory"

--- a/util/patch_solr78_bytecode.py
+++ b/util/patch_solr78_bytecode.py
@@ -51,14 +51,14 @@ PACKAGE_SUBS = [
 
 def patch_package_paths(bytecode: bytes) -> bytes:
     """With Solr and Lucene 9, package paths have changed, modify
-    the class file so they point to the old locations insteaad.
+    the class file so they point to the old locations instead.
     """
     for src, target in PACKAGE_SUBS:
         if src not in bytecode:
             continue
         idx = bytecode.index(src)
 
-        # Check if we're in the constat pool, i.e. our value is
+        # Check if we're in the constant pool, i.e. our value is
         # preceded by a big-endian short with the length of our value
         length_idx = idx - 2
         length = struct.unpack_from(">H", bytecode, length_idx)[0]
@@ -144,9 +144,6 @@ if __name__ == "__main__":
         sys.exit(1)
     if len(sys.argv) == 3:
         target_path = Path(sys.argv[2])
-        if not source_path.exists():
-            print(f"File at {source_path} does not exist!")
-            sys.exit(1)
         with target_path.open("wb") as fp:
             patch_jar(source_path, fp)
     else:

--- a/util/patch_solr78_bytecode.py
+++ b/util/patch_solr78_bytecode.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+""" Patch a JAR file with classes built against Solr 9 to work with Solr 7 and 8.
+
+Why didn't we use ByteBuddy or at least ASM for this? Well, blame Maven.
+Building two JARs from one pom without a ton of ceremony seems to be
+out of scope for it, so this manual approach was chosen instead.
+"""
+import struct
+import sys
+import zipfile
+from pathlib import Path
+from typing import BinaryIO
+
+
+def _get_utf8_size(entry: bytes) -> int:
+    """Get the size in bytes of a Utf8 constant pool entry."""
+    length = struct.unpack_from(">H", entry, 1)[0]
+    return 3 + length
+
+
+#: Mapping from tags used in the constant pool to the size their
+#: associated information takes up in the pool
+CONSTANT_POOL_SIZES = {
+    7: 3,  # classinfo(u1 tag, u2 name_idx),
+    9: 5,  # fieldref(u1 tag, u2 class_idx, u2 name_and_type_idx)
+    10: 5,  # methodref(u1 tag, u2 class_idx, u2 name_and_type_idx)
+    11: 5,  # interfacemethodref(u1 tag, u2 class_idx, u2 name_and_type_idx)
+    8: 3,  # string(u1 tag, u2 string_idx)
+    3: 5,  # integer(u1 tag, u4 bytes)
+    4: 5,  # float(u1 tag, u4 bytes)
+    5: 9,  # long(u1 tag, u4 hi_bytes, u4 lo_bytes)
+    6: 9,  # double(u1 tag, u4 hi_bytes, u4 lo_bytes)
+    12: 5,  # nameandbytes(u1 tag, u2 name_idx, u2 descriptor_idx)
+    1: _get_utf8_size,
+    15: 4,  # methodhandle(u1 tag, u2 ref_kind, u2 ref_idx)
+    16: 3,  # methodtype(u1 tag, u2 descriptor_idx)
+    17: 5,  # dynamic(u1 tag, u2 bootstrap_method_attr_idx, u2 name_and_type_idx)
+    18: 5,  # invokedynamic(u1 tag, u2 bootstrap_method_attr_idx, u2 name_and_type_idx)
+    19: 3,  # module(u1 tag, u2 name_idx)
+    20: 3,  # package(u1 tag, u2 name_idx)
+}
+
+#: Package substitutions that need to be made for Solr <9 compatbility
+PACKAGE_SUBS = [
+    (
+        b"org/apache/lucene/analysis/CharFilterFactory",
+        b"org/apache/lucene/analysis/util/CharFilterFactory",
+    )
+]
+
+
+def patch_package_paths(bytecode: bytes) -> bytes:
+    """With Solr and Lucene 9, package paths have changed, modify
+    the class file so they point to the old locations insteaad.
+    """
+    for src, target in PACKAGE_SUBS:
+        if src not in bytecode:
+            continue
+        idx = bytecode.index(src)
+
+        # Check if we're in the constat pool, i.e. our value is
+        # preceded by a big-endian short with the length of our value
+        length_idx = idx - 2
+        length = struct.unpack_from(">H", bytecode, length_idx)[0]
+        if length != len(src):
+            continue
+
+        # Now we update the name of the package as well as the length
+        # of the value in the constant pool info structure
+        buf = bytearray(bytecode.replace(src, target))
+        struct.pack_into(">H", buf, length_idx, len(target))
+        bytecode = bytes(buf)
+    return bytecode
+
+
+def patch_close_hook(bytecode: bytes) -> bytes:
+    """With Solr 9, `org.apache.solr.core.CloseHook` became an interface,
+    this function will patch the resulting byte code to use it as
+    an abstract base class instead to be compatible with Solr<9.
+    """
+    buf = bytearray(bytecode)
+    if buf[:4] != b"\xca\xfe\xba\xbe":
+        raise ValueError("Not a classfile, corrupt JAR?")
+    constant_pool_count = struct.unpack_from(">H", buf, 8)[0]
+
+    # Traverse constant pool
+    constant_pool_size = 0
+    constant_pool_start = 10
+    for _ in range(constant_pool_count - 1):
+        tag = buf[constant_pool_start + constant_pool_size]
+        # Modify reference to super class constructor to point to our
+        # new base class instead of java.lang.Object<init>
+        if tag == 10:  # method reference
+            target_idx = constant_pool_start + constant_pool_size + 2
+            if buf[target_idx] == 7:  # reference to java.lang.Object
+                buf[target_idx] = 8  # change to CloseHook
+        # Update the constant pool size
+        if isinstance(CONSTANT_POOL_SIZES[tag], int):
+            constant_pool_size += CONSTANT_POOL_SIZES[tag]
+        else:
+            constant_pool_size += CONSTANT_POOL_SIZES[tag](
+                buf[constant_pool_start + constant_pool_size :]
+            )
+    after_pool_idx = constant_pool_start + constant_pool_size
+    iface_count = struct.unpack_from(">H", buf, after_pool_idx + 6)[0]
+    if iface_count != 1:
+        return bytes
+
+    # Start of interface pointers
+    ifaces_idx = after_pool_idx + 8
+    # Object pool index of the `CloseHook` type
+    closehook_idx = struct.unpack_from(">H", buf, ifaces_idx)[0]
+    # Strip interfaces list from class file
+    del buf[ifaces_idx : ifaces_idx + 2]
+    # Set `CloseHook` as the super class
+    buf[after_pool_idx + 4 : after_pool_idx + 6] = struct.pack(">H", closehook_idx)
+    # Clear all interfaces for the class
+    buf[after_pool_idx + 6 : after_pool_idx + 8] = b"\x00\x00"
+    return bytes(buf)
+
+
+def patch_jar(source_path: Path, target: BinaryIO) -> None:
+    with zipfile.ZipFile(source_path) as source_jar, zipfile.ZipFile(
+        target, "w", compression=zipfile.ZIP_DEFLATED
+    ) as target_jar:
+        for fname in source_jar.namelist():
+            data = source_jar.read(fname)
+            if fname.endswith(".class"):
+                data = patch_package_paths(data)
+            if fname.endswith("OcrHighlightComponent$1.class"):
+                data = patch_close_hook(data)
+            target_jar.writestr(fname, data)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__)
+        print("Usage:")
+        print("$ patch_solr78_bytecode.py <source_jar> [<target_jar>]", file=sys.stderr)
+        sys.exit(1)
+    source_path = Path(sys.argv[1])
+    if not source_path.exists():
+        print(f"File at {source_path} does not exist!")
+        sys.exit(1)
+    if len(sys.argv) == 3:
+        target_path = Path(sys.argv[2])
+        if not source_path.exists():
+            print(f"File at {source_path} does not exist!")
+            sys.exit(1)
+        with target_path.open("wb") as fp:
+            patch_jar(source_path, fp)
+    else:
+        patch_jar(source_path, sys.stdout.buffer)


### PR DESCRIPTION
Add support for Solr 9.

From this change on, we will have to release two separate JAR files, one for Solr 9 and later, and one for Solr 8 and earlier. The reason for this is that with Lucene 9, the package path for `CharFilterFactory` has changed, which is something we can't work around with Reflection magic like we did so far. 
Additionally, `CloseHook` became an interface in Solr, instead of an abstract class, with the same problem.

So we now provide a script in `util/patch_solr78_bytecode.py` to create a Solr7/8 compatible JAR from one built against Solr 9.

We did not use ByteBuddy or ASM, since building multiple JARs from a single POM is a ridiculous pain, so this little Python script to do the neccessary bytecode manipulation manually seemed easier and simpler to maintain.
