### PR TITLE
Update CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,62 +8,30 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: 11
-      - uses: actions/cache@v2
-        env:
-          cache-name: cache-maven-artifacts
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          cache: maven
       - name: Build with Maven and run unit tests
         run: mvn -B package
-      - name: Run integration tests
-        run: ./integration-tests/run.sh
-  publish:
+      - name: Create Solr 7/8 JAR
+        run: ./util/patch_solr78_bytecode.py
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: target/*.jar
+
+  integration_tests:
     if: github.event_name == 'push' && contains(github.ref, 'main')
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/download-artifact@v3
         with:
-          java-version: 11
-          server-id: ossrh-snapshots
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - uses: actions/cache@v2
-        env:
-          cache-name: cache-maven-artifacts
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-      - name: Install XML utils
-        run: sudo apt update && sudo apt install libxml2-utils
-      - name: Set project version
-        run: echo "PROJECT_VERSION=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' pom.xml)" >> $GITHUB_ENV
-      - name: Publish to the Maven Central Repository
-        run: if [[ "$PROJECT_VERSION" =~ .*SNAPSHOT ]]; then mvn -B deploy; fi
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-  publish_mkdocs:
-    if: github.event_name == 'push' && contains(github.ref, 'main')
-    runs-on: ubuntu-latest
-    needs: [build, publish]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install mkdocs singledispatch
-      - name: Mkdocs deploy
-        run: mkdocs gh-deploy --force
+          name: build-artifacts
+      - name: Run integration tests
+        run: ./integration-tests/run.sh


### PR DESCRIPTION
- Caching of build artifacts between steps works now
- Integration Tests are their own job now
- All dependencies updated to v3
- Bytecode patching performed as part of build step via CI
- Removed mkdocs deployment temporarily, will be added back again in a
  separate change
- Fixed a bug in the bytecoder patcher, formatted with black