### PR TITLE
Update example setup to Solr 9

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,26 +1,20 @@
 version: '2'
 services:
   solr:
-    image: solr:8.7
+    image: solr:9.0
     ports:
       - "1044:1044"  # Debugging port
       - "8983:8983"  # Solr admin interface
     volumes:
       - ./solr/install-plugin.sh:/docker-entrypoint-initdb.d/install-plugin.sh
       - ./solr/core:/opt/core-config
-      - index-data:/var/solr/data
+      - index-data:/var/solr
       - ./data:/data
       - ../target:/build
-      #- /opt/async-profiler:/opt/async-profiler
     environment:
       - ENABLE_REMOTE_JMX_OPTS=true
       - SOLR_HEAP=4g
       - ADDITIONAL_CMD_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:1044
-    # Needed for async profiler
-    #security_opt:
-    #  - seccomp:unconfined
-    #cap_add:
-    #  - SYS_ADMIN
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate
@@ -35,7 +29,7 @@ services:
     environment:
       - CFG_SOLR_BASE=http://solr:8983/solr
       - CFG_SERVER_NAME=localhost:8181
-      - CFG_IMAGE_API_BASE=https://ocrhl.jbaiter.de/iiif/image/v2
+      - CFG_IMAGE_API_BASE=https://ocrhl.jbaiter.de/iiif/image/v3
       - CFG_GOOGLE1000_PATH=/data/google1000
       - CFG_BNL_PATH=/data/bnl_lunion
       - CFG_APP_PATH=/iiif/presentation
@@ -44,6 +38,11 @@ services:
     build: frontend
     ports:
       - "8181:80"
+    depends_on:
+      solr:
+        condition: service_started
+      iiif-prezi:
+        condition: service_started
 
 volumes:
   index-data:

--- a/example/frontend/Dockerfile
+++ b/example/frontend/Dockerfile
@@ -1,11 +1,12 @@
-FROM node:alpine as builder
+FROM node:14-alpine as builder
 
 COPY . /build
 
 RUN apk add git &&\
     cd /build &&\
     npm install &&\
-    npm run build
+    npm run build &&\
+    rm -rf build/sw.js
 
 FROM nginx:alpine
 

--- a/example/frontend/index.js
+++ b/example/frontend/index.js
@@ -28,7 +28,7 @@ var PARAMS = {
   "hl.ocr.fl": "ocr_text",
 };
 var BNL_10MM_TO_PIX_FACTOR = 300 / 254;
-var IMAGE_API_BASE = "https://ocrhl.jbaiter.de/iiif/image/v2";
+var IMAGE_API_BASE = "https://ocrhl.jbaiter.de/iiif/image/v3";
 if (typeof window !== "undefined") {
   var APP_BASE = `${window.location.protocol || "http:"}//${
     window.location.host
@@ -204,7 +204,7 @@ class NewspaperResultDocument extends Component {
     const w = parseInt(BNL_10MM_TO_PIX_FACTOR * (region.lrx - region.ulx));
     const h = parseInt(BNL_10MM_TO_PIX_FACTOR * (region.lry - region.uly));
     const regionStr = `${x},${y},${w},${h}`;
-    const widthStr = width ? `${width},` : "full";
+    const widthStr = width ? `${width},` : "max";
     return `${IMAGE_API_BASE}/bnl:${issueId}_${pageNo}/${regionStr}/${widthStr}/0/default.jpg`;
   }
 
@@ -280,7 +280,7 @@ class GoogleResultDocument extends Component {
     const regionStr = `${region.ulx},${region.uly},${region.lrx - region.ulx},${
       region.lry - region.uly
     }`;
-    const widthStr = width ? `${width},` : "full";
+    const widthStr = width ? `${width},` : "max";
     return `${IMAGE_API_BASE}/gbooks:${volId}_${pageId}/${regionStr}/${widthStr}/0/default.jpg`;
   }
 

--- a/example/ingest.py
+++ b/example/ingest.py
@@ -179,14 +179,17 @@ def bnl_load_documents(base_path):
             tf = tarfile.open(fileobj=resp, mode='r|gz')
             last_vol = None
             for ti in tf:
-                if ti.isdir() and '/' not in ti.name:
+                sanitized_name = re.sub(r'^\./?', '', ti.name)
+                if not sanitized_name:
+                    continue
+                if ti.isdir() and '/' not in sanitized_name:
                     if last_vol is not None:
                         vol_path = base_path / last_vol
                         mets_path = next(iter(vol_path.glob("*-mets.xml")))
                         vol_id = last_vol.replace("newspaper_lunion_", "")
                         yield from bnl_extract_article_docs(
                             vol_id, mets_path, vol_path / 'text')
-                    last_vol = ti.name
+                    last_vol = sanitized_name
                 if ti.isdir():
                     (base_path / ti.name).mkdir(parents=True, exist_ok=True)
                 else:

--- a/example/solr/core/solrconfig.xml
+++ b/example/solr/core/solrconfig.xml
@@ -1,9 +1,8 @@
 <config>
-  <luceneMatchVersion>7.6</luceneMatchVersion>
-  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
-  <schemaFactory class="ClassicIndexSchemaFactory"/>
+  <luceneMatchVersion>9.0</luceneMatchVersion>
 
-  <lib dir="/var/solr/data/plugins" regex=".*\.jar" />
+  <!-- Only used when running a local development build -->
+  <lib dir="/var/solr/plugins" regex=".*\.jar" />
 
   <searchComponent class="solrocr.OcrHighlightComponent"
                    name="ocrHighlight" />

--- a/example/solr/install-plugin.sh
+++ b/example/solr/install-plugin.sh
@@ -2,7 +2,7 @@
 set -e
 
 RELEASE_URL="https://api.github.com/repos/dbmdz/solr-ocrhighlighting/releases/latest"
-PLUGIN_LIB_DIR="/var/solr/data/plugins"
+PLUGIN_LIB_DIR="/var/solr/plugins"
 
 wget -q https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O/tmp/jq
 chmod +x /tmp/jq


### PR DESCRIPTION
- Changed volume definitions to match the new container structure
- Changed Image API endpoints and Image API requests to match updated image server at ocrhl.jbaiter.de
- Pinned version of `node:alpine` frontend build container to fix broken builds
- Remove service worker of frontend code after build to fix strange routing behavior in the frontend
- Fix bug in ingest script to handle changed return API from newer versions of Python's `tarfile` API