### PR TITLE
Allow overriding of some `hl.*` parameters

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -9,7 +9,7 @@ hints on potential knobs to tune to improve the performance.
     **You can expect a reduction in runtime of more than 50% if you use a JVM with string compaction
     enabled compared to one without** (assuming you're running on flash storage).
     We highly recommend using the latest LTS OpenJDK version released after Java 9, which
-    as of January 2021 is OpenJDK 11.
+    as of September 2021 is OpenJDK 17.
 
 ## Performance Analysis
 Before you start tuning the plugin, it is important to spend some time on analyzing the nature of the problems:

--- a/docs/query.md
+++ b/docs/query.md
@@ -113,15 +113,30 @@ Of special interest for purposes of OCR highlighting are these:
 
 `hl.snippets`
 :   Number of snippets per document to include in the response, defaults to `1`.
+    Use `f.<ocr_field>.hl.snippets` if you want a different number of snippets between regular highlighting
+    and OCR highlighting.
 
 `hl.tag.pre`/`hl.tag.post`
 :   Strings to wrap matches in the plaintext version of the snippet with, defaults to `<em>`/`</em>`.
+    Use `hl.ocr.tag.pre` / `hl.ocr.tag.post` if you want different tags for regular highlighting
+    and OCR highlighting.
 
 `hl.weightMatches`
 :   Uses a new and improved highlighting algorithm that is much more precise than the old approach.
     For example, with this set to `true`, results for a phrase query `"foo bar baz"` will actually be
     highlighted as `<em>foo bar baz</em>` and not as `<em>foo</em> <em>bar</em> <em>baz</em>`. Defaults to
     `off` in Solr versions < 8.0, `on` for all versions > 8.0.
+    Use `f.<ocr_field>.hl.weightMatches` if you want to set this differently from regular highlighting.
+
+`hl.qparser`:
+:   Allows you to customize the query parser used for analyzing the query for highlighting.
+    See the [`hl.qparser` documentation in the Solr guide for more details](https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html).
+    Use `hl.ocr.qparser` if you want to set this differently between OCR highlighting and regular highlighting.
+
+`hl.q`:
+:   Allows you to customize the query used for highlighting the documents in the result set.
+    See the [`hl.q` documentation in the Solr guide for more details](https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html).
+    Use `hl.ocr.q` if you want to set this differently between OCR highlighting and regular highlighting.
 
 Additionally, the plugin allows you to customize various OCR-specific parameters:
 

--- a/docs/query.md
+++ b/docs/query.md
@@ -2,6 +2,15 @@
 To enable highlighting, make sure you set `hl=true` in you query. Additionally, you need to pass the OCR fields that
 you want to have highlighted in the `hl.ocr.fl` parameter.
 
+!!! caution "Setting highlighting fields for regular highlighting"
+
+    In some circumstances you need to set the `hl.fl` parameter for the list of fields to use for regular
+    highlighting explicitly. It suffices to set this to an empty string (i.e. `hl.fl=`).
+    You will know you're affected by this problem if highlighting fails, and you see an error message
+    `undefined field null` in your Solr logs. This is probably due to a bug in Solr itself that has
+    yet to be investigated. Setting `hl.fl` explicitly avoids the problem.
+
+
 ## Response Format
 With OCR highlighting enabled, your Solr response will now include a new item `ocrHighlighting`, mapping all
 highlighted OCR fields to their highlighting snippets:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>solr-ocrhighlighting</artifactId>
-  <version>0.8.1</version>
+  <version>0.8.2-SNAPSHOT</version>
 
   <name>Solr OCR Highlighting Plugin</name>
   <description>

--- a/src/main/java/com/github/dbmdz/solrocr/model/SourcePointer.java
+++ b/src/main/java/com/github/dbmdz/solrocr/model/SourcePointer.java
@@ -90,8 +90,7 @@ public class SourcePointer {
                   if (!m.find()) {
                     throw new RuntimeException(
                         "Could not parse source pointer from '"
-                            + ptr
-                            + "', cannot index document.");
+                            + ptr + ".");
                   }
                   Path sourcePath = Paths.get(m.group("path"));
                   List<Region> regions = ImmutableList.of();
@@ -107,13 +106,13 @@ public class SourcePointer {
                   } catch (FileNotFoundException e) {
                     throw new RuntimeException(
                         "Could not locate file at '"
-                            + sourcePath.toString()
-                            + "', cannot index document.");
+                            + sourcePath
+                            + ".");
                   } catch (IOException e) {
                     throw new RuntimeException(
                         "Could not read file at '"
-                            + sourcePath.toString()
-                            + "', cannot index document.");
+                            + sourcePath
+                            + ".");
                   }
                 })
             .collect(Collectors.toList());

--- a/src/main/java/com/github/dbmdz/solrocr/model/SourcePointer.java
+++ b/src/main/java/com/github/dbmdz/solrocr/model/SourcePointer.java
@@ -88,9 +88,7 @@ public class SourcePointer {
                 ptr -> {
                   Matcher m = POINTER_PAT.matcher(ptr);
                   if (!m.find()) {
-                    throw new RuntimeException(
-                        "Could not parse source pointer from '"
-                            + ptr + ".");
+                    throw new RuntimeException("Could not parse source pointer from '" + ptr + ".");
                   }
                   Path sourcePath = Paths.get(m.group("path"));
                   List<Region> regions = ImmutableList.of();
@@ -104,15 +102,9 @@ public class SourcePointer {
                   try {
                     return new FileSource(sourcePath, regions, m.group("isAscii") != null);
                   } catch (FileNotFoundException e) {
-                    throw new RuntimeException(
-                        "Could not locate file at '"
-                            + sourcePath
-                            + ".");
+                    throw new RuntimeException("Could not locate file at '" + sourcePath + ".");
                   } catch (IOException e) {
-                    throw new RuntimeException(
-                        "Could not read file at '"
-                            + sourcePath
-                            + ".");
+                    throw new RuntimeException("Could not read file at '" + sourcePath + ".");
                   }
                 })
             .collect(Collectors.toList());

--- a/src/main/java/com/github/dbmdz/solrocr/solr/OcrHighlightParams.java
+++ b/src/main/java/com/github/dbmdz/solrocr/solr/OcrHighlightParams.java
@@ -1,8 +1,13 @@
 package com.github.dbmdz.solrocr.solr;
 
-import org.apache.solr.common.params.HighlightParams;
+import org.apache.solr.common.params.SolrParams;
 
-public interface OcrHighlightParams extends HighlightParams {
+public interface OcrHighlightParams {
+  String HIGHLIGHT = "hl.ocr";
+  String QPARSER = "hl.ocr.qparser";
+  String Q = "hl.ocr.q";
+  String TAG_PRE = "hl.ocr.tag.pre";
+  String TAG_POST = "hl.ocr.tag.pre";
   String OCR_FIELDS = "hl.ocr.fl";
   String CONTEXT_BLOCK = "hl.ocr.contextBlock";
   String CONTEXT_SIZE = "hl.ocr.contextSize";
@@ -15,4 +20,40 @@ public interface OcrHighlightParams extends HighlightParams {
   String TIME_ALLOWED = "hl.ocr.timeAllowed";
   String ALIGN_SPANS = "hl.ocr.alignSpans";
   String TRACK_PAGES = "hl.ocr.trackPages";
+
+  /**
+   * Get a boolean value from a `hl.ocr.*` parameter. If no value is given for the parameter, try to
+   * get the value from the corresponding `hl.*` parameter, otherwise return the default.
+   */
+  static boolean getBool(SolrParams params, String name, boolean defaultValue) {
+    Boolean value = params.getBool(name);
+    if (value == null) {
+      return params.getBool(name.replace("hl.ocr", "hl"), defaultValue);
+    }
+    return value;
+  }
+
+  /**
+   * Get a String value from a `hl.ocr.*` parameter. If no value is given for the parameter, try to
+   * get the value from the corresponding `hl.*` parameter.
+   */
+  static String get(SolrParams params, String name) {
+    String value = params.get(name);
+    if (value == null) {
+      return params.get(name.replace("hl.ocr", "hl"));
+    }
+    return value;
+  }
+
+  /**
+   * Get a String value from a `hl.ocr.*` parameter. If no value is given for the parameter, try to
+   * get the value from the corresponding `hl.*` parameter, otherwise return the default.
+   */
+  static String get(SolrParams params, String name, String defaultValue) {
+    String value = OcrHighlightParams.get(params, name);
+    if (value == null) {
+      return defaultValue;
+    }
+    return value;
+  }
 }

--- a/src/main/java/com/github/dbmdz/solrocr/solr/OcrHighlightParams.java
+++ b/src/main/java/com/github/dbmdz/solrocr/solr/OcrHighlightParams.java
@@ -7,7 +7,7 @@ public interface OcrHighlightParams {
   String QPARSER = "hl.ocr.qparser";
   String Q = "hl.ocr.q";
   String TAG_PRE = "hl.ocr.tag.pre";
-  String TAG_POST = "hl.ocr.tag.pre";
+  String TAG_POST = "hl.ocr.tag.post";
   String OCR_FIELDS = "hl.ocr.fl";
   String CONTEXT_BLOCK = "hl.ocr.contextBlock";
   String CONTEXT_SIZE = "hl.ocr.contextSize";

--- a/src/main/java/solrocr/OcrHighlightComponent.java
+++ b/src/main/java/solrocr/OcrHighlightComponent.java
@@ -56,12 +56,14 @@ public class OcrHighlightComponent extends SearchComponent
   @Override
   public void prepare(ResponseBuilder rb) throws IOException {
     SolrParams params = rb.req.getParams();
-    rb.doHighlights = params.getBool(HighlightParams.HIGHLIGHT, false);
+    rb.doHighlights = OcrHighlightParams.getBool(params, OcrHighlightParams.HIGHLIGHT, false);
     if (rb.doHighlights) {
       rb.setNeedDocList(true);
-      String hlq = params.get(HighlightParams.Q);
+      String hlq = OcrHighlightParams.get(params, OcrHighlightParams.Q);
       String hlparser =
-          Stream.of(params.get(HighlightParams.QPARSER), params.get(QueryParsing.DEFTYPE))
+          Stream.of(
+                  OcrHighlightParams.get(params, OcrHighlightParams.QPARSER),
+                  params.get(QueryParsing.DEFTYPE))
               .filter(Objects::nonNull)
               .findFirst()
               .orElse(QParserPlugin.DEFAULT_QTYPE);

--- a/src/main/java/solrocr/OcrHighlighter.java
+++ b/src/main/java/solrocr/OcrHighlighter.java
@@ -406,8 +406,8 @@ public class OcrHighlighter extends UnifiedHighlighter {
                   contextLocator, limitLocator, params.getInt(OcrHighlightParams.CONTEXT_SIZE, 2));
           OcrPassageFormatter formatter =
               ocrFormat.getPassageFormatter(
-                  params.get(HighlightParams.TAG_PRE, "<em>"),
-                  params.get(HighlightParams.TAG_POST, "</em>"),
+                  OcrHighlightParams.get(params, OcrHighlightParams.TAG_PRE, "<em>"),
+                  OcrHighlightParams.get(params, OcrHighlightParams.TAG_POST, "</em>"),
                   params.getBool(OcrHighlightParams.ABSOLUTE_HIGHLIGHTS, false),
                   params.getBool(OcrHighlightParams.ALIGN_SPANS, false),
                   params.getBool(OcrHighlightParams.TRACK_PAGES, true));


### PR DESCRIPTION
Sometimes users may want to set parameters differently between regular highlighting and OCR highlighting. This is already possible for some parameters (`hl.score.{k1,b,pivot}`, `hl.weightMatches`) via the `f.<field-name>.<param>` syntax, but for more global values this was impossible.

This PR introduces a few new `hl.ocr.*` parameters that can be used to override their corresponding `hl.*` counterparts:

- `hl.ocr.q`
- `hl.ocr.qparser`
- `hl.ocr.tag.pre`
- `hl.ocr.tag.post`

Additionally, the docs were updated in some places.