### PR TITLE
hOCR: empty word fix

### DIFF
--- a/src/main/java/com/github/dbmdz/solrocr/formats/hocr/HocrParser.java
+++ b/src/main/java/com/github/dbmdz/solrocr/formats/hocr/HocrParser.java
@@ -178,6 +178,10 @@ public class HocrParser extends OcrParser {
           inAlternatives = false;
           continue;
         }
+        // Ignore empty words
+        if (txt == null) {
+          return;
+        }
         // We assume that we're dealing with valid hOCR, and in this case this is the event for the
         // end of the ocrx_word span, i.e. we have all the text we needed from the box and can
         // terminate and return

--- a/src/test/java/com/github/dbmdz/solrocr/formats/hocr/HocrParserTest.java
+++ b/src/test/java/com/github/dbmdz/solrocr/formats/hocr/HocrParserTest.java
@@ -208,4 +208,13 @@ public class HocrParserTest {
     List<OcrBox> boxes = parser.stream().collect(Collectors.toList());
     assertThat(boxes).hasSize(22);
   }
+
+  @Test
+  public void testEmptyWord() throws FileNotFoundException, XMLStreamException {
+    Path p = Paths.get("src/test/resources/data/empty_words_bug.html");
+    CharFilter input = (CharFilter) filterFac.create(new StringReader(p.toString()));
+    OcrParser parser = new HocrParser(input);
+    List<OcrBox> boxes = parser.stream().collect(Collectors.toList());
+    assertThat(boxes).hasSize(7);
+  }
 }

--- a/src/test/resources/data/empty_words_bug.html
+++ b/src/test/resources/data/empty_words_bug.html
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html>
+  <head>
+    <title>bsb10486426</title>
+    <meta name="ocr-capabilities" content="ocr_page ocrx_block ocr_par ocr_line ocrx_word ocrp_lang x_source x_wconf" />
+  </head>
+  <body>
+    <div class="ocr_page" title="x_source bsb10486426_00001; ppageno 1; bbox 0 0 2940 5457" lang="unknown">
+      <div class="ocrx_block" title="bbox 0 0 2943 5460">
+        <p class="ocr_par" title="bbox 0 0 2943 5460">
+          <span class="ocr_line" title="bbox 0 0 2 2">
+            <span class="ocrx_word" title="bbox 0 0 2 2" />
+          </span>
+        </p>
+      </div>
+    </div>
+    <div class="ocr_page" title="x_source bsb10486426_00002; ppageno 2; bbox 0 0 3021 4790" lang="unknown">
+      <div class="ocrx_block" title="bbox 134 132 2068 769">
+        <p class="ocr_par" title="bbox 134 132 2068 769">
+          <span class="ocr_line" title="bbox 134 132 1429 447">
+            <span class="ocrx_word" title="bbox 134 431 140 441">A</span>
+            <span class="ocrx_word" title="bbox 423 194 1123 447">Ephpol.</span>
+            <span class="ocrx_word" title="bbox 1342 132 1429 425">/</span>
+          </span>
+          <span class="ocr_line" title="bbox 1803 567 2068 769">
+            <span class="ocrx_word" title="bbox 1803 567 2068 769">2/2</span>
+          </span>
+        </p>
+      </div>
+    </div>
+    <div class="ocr_page" title="x_source bsb10486426_00003; ppageno 3; bbox 0 0 2979 4773" lang="unknown" />
+    <div class="ocr_page" title="x_source bsb10486426_00004; ppageno 4; bbox 0 0 2901 4792" lang="unknown" />
+    <div class="ocr_page" title="x_source bsb10486426_00005; ppageno 5; bbox 0 0 2897 4777" lang="de">
+      <div class="ocrx_block" title="bbox 2033 85 2052 159">
+        <p class="ocr_par" title="bbox 2033 85 2052 159">
+          <span class="ocr_line" title="bbox 2033 85 2052 159">
+            <span class="ocrx_word" title="bbox 2033 85 2052 159">-</span>
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 59 213 2812 577">
+        <p class="ocr_par" title="bbox 59 213 2812 577">
+          <span class="ocr_line" title="bbox 59 213 2812 577">
+            <span class="ocrx_word" title="bbox 59 213 1101 577">Rhein-u.</span>
+            <span class="ocrx_word" title="bbox 1159 213 2812 577">Moſelzeitung.</span>
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 106 887 488 934">
+        <p class="ocr_par" title="bbox 106 887 488 934">
+          <span class="ocr_line" title="bbox 106 887 107 888">
+            <span class="ocrx_word" title="bbox 106 887 107 888" />
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 106 887 488 934">
+        <p class="ocr_par" title="bbox 106 887 488 934">
+          <span class="ocr_line" title="bbox 106 887 107 888">
+            <span class="ocrx_word" title="bbox 106 887 107 888" />
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 581 908 993 931">
+        <p class="ocr_par" title="bbox 581 908 993 931">
+          <span class="ocr_line" title="bbox 581 908 582 909">
+            <span class="ocrx_word" title="bbox 581 908 582 909" />
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 1853 668 2220 756">
+        <p class="ocr_par" title="bbox 1853 668 2220 756">
+          <span class="ocr_line" title="bbox 1853 668 1854 669">
+            <span class="ocrx_word" title="bbox 1853 668 1854 669" />
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 1853 668 2220 756">
+        <p class="ocr_par" title="bbox 1853 668 2220 756">
+          <span class="ocr_line" title="bbox 1853 668 1854 669">
+            <span class="ocrx_word" title="bbox 1853 668 1854 669" />
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 1852 754 2259 822">
+        <p class="ocr_par" title="bbox 1852 754 2259 822">
+          <span class="ocr_line" title="bbox 1852 754 1853 755">
+            <span class="ocrx_word" title="bbox 1852 754 1853 755" />
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 1852 754 2259 822">
+        <p class="ocr_par" title="bbox 1852 754 2259 822">
+          <span class="ocr_line" title="bbox 1852 754 1853 755">
+            <span class="ocrx_word" title="bbox 1852 754 1853 755" />
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 1852 820 2259 923">
+        <p class="ocr_par" title="bbox 1852 820 2259 923">
+          <span class="ocr_line" title="bbox 1852 820 1853 821">
+            <span class="ocrx_word" title="bbox 1852 820 1853 821" />
+          </span>
+        </p>
+      </div>
+      <div class="ocrx_block" title="bbox 2174 696 2217 717">
+        <p class="ocr_par" title="bbox 2174 696 2217 717">
+          <span class="ocr_line" title="bbox 2174 696 2175 697">
+            <span class="ocrx_word" title="bbox 2174 696 2175 697" />
+          </span>
+        </p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Hi,

we have seen a parser bug when trying to read an hOCR that contains empty words, such as:

```xml
<div class="ocrx_block" title="bbox 106 887 488 934">
  <p class="ocr_par" title="bbox 106 887 488 934">
    <span class="ocr_line" title="bbox 106 887 107 888">
      <span class="ocrx_word" title="bbox 106 887 107 888" />
     </span>
  </p>
</div>
```

Thus, this PR:

* introduces a bug fix in the hOCR logic
* adds an extensive unit test
