### PR TITLE
Fix incomplete forward passes in HocrClassBreakLocator (fixes #288)

### DIFF
--- a/src/main/java/com/github/dbmdz/solrocr/formats/hocr/HocrClassBreakLocator.java
+++ b/src/main/java/com/github/dbmdz/solrocr/formats/hocr/HocrClassBreakLocator.java
@@ -24,6 +24,7 @@ public class HocrClassBreakLocator extends BaseBreakLocator {
   public int getFollowing(int offset) {
     int start = Math.min(offset + 1, this.text.getEndIndex());
     int end = Math.min(start + blockSize, this.text.getEndIndex());
+    boolean needsMoreData = end == start + blockSize;
     while (start < this.text.getEndIndex()) {
       String block = text.subSequence(start, end, true).toString();
       // Truncate block to last '>' to avoid splitting element openings across blocks
@@ -36,8 +37,7 @@ public class HocrClassBreakLocator extends BaseBreakLocator {
       }
 
       // In hOCR, there can be multiple options for expressing the same level in the block
-      // hierarchy,
-      // so we need to check for all of them.
+      // hierarchy, so we need to check for all of them.
       int idx = blockEnd;
       int closeIdx = blockEnd - 1;
       outer:
@@ -69,6 +69,7 @@ public class HocrClassBreakLocator extends BaseBreakLocator {
           if (elemOpen < idx) {
             // Found match
             idx = elemOpen;
+            needsMoreData = false;
             break outer;
           } else {
             // Try next class
@@ -76,7 +77,7 @@ public class HocrClassBreakLocator extends BaseBreakLocator {
           }
         }
       }
-      if (idx != block.length()) {
+      if (!needsMoreData) {
         if (closeIdx < idx) {
           closeIdx = block.length();
         }

--- a/src/main/java/com/github/dbmdz/solrocr/iter/BaseBreakLocator.java
+++ b/src/main/java/com/github/dbmdz/solrocr/iter/BaseBreakLocator.java
@@ -28,7 +28,7 @@ public abstract class BaseBreakLocator implements BreakLocator {
    * block hierarchy, i.e. we often run into the situation there is no match. These cases are the
    * absolute worst case for both {@link String#lastIndexOf(String, int)} and {@link
    * String#indexOf(String, int)}. So why is the latter faster? Well, in recent Hotspot versions, it
-   * is is SIMD-accelerated via compiler intrinsics. And the speed-up we get from these worst cases
+   * is SIMD-accelerated via compiler intrinsics. And the speed-up we get from these worst cases
    * is significant enough to completely make up for the slightly worse performance in more ideal
    * cases (~25% slower).
    */

--- a/src/main/java/com/github/dbmdz/solrocr/model/OcrFormat.java
+++ b/src/main/java/com/github/dbmdz/solrocr/model/OcrFormat.java
@@ -106,7 +106,7 @@ public interface OcrFormat {
    * Get the range of positions contained by the word containing the given position.
    *
    * <p>This default implementation is valid for OCR formats that encode word text as character
-   * nodes inside of a containing element (like hOCR and MiniOCR). For other formats, override. *
+   * nodes inside a containing element (like hOCR and MiniOCR). For other formats, override.
    */
   default Range<Integer> getContainingWordLimits(String fragment, int position) {
     return Range.closedOpen(

--- a/src/main/java/solrocr/OcrHighlighter.java
+++ b/src/main/java/solrocr/OcrHighlighter.java
@@ -296,7 +296,10 @@ public class OcrHighlighter extends UnifiedHighlighter {
     }
     log.debug(
         "Highlighting OCR fields={} for query={} in docIDs={} with maxPassagesOcr={}",
-        ocrFieldNames, query, docIDs, maxPassagesOcr);
+        ocrFieldNames,
+        query,
+        docIDs,
+        maxPassagesOcr);
     Long timeAllowed = params.getLong(OcrHighlightParams.TIME_ALLOWED);
     if (timeAllowed != null) {
       HighlightTimeout.set(timeAllowed);
@@ -442,11 +445,15 @@ public class OcrHighlighter extends UnifiedHighlighter {
             if (content.getPointer() != null) {
               log.error(
                   "Could not highlight OCR content for document {} at '{}'",
-                  docId, content.getPointer(), e);
+                  docId,
+                  content.getPointer(),
+                  e);
             } else {
               log.error(
                   "Could not highlight OCR for document {} with OCR markup '{}...'",
-                  docId, content.subSequence(0, 256), e);
+                  docId,
+                  content.subSequence(0, 256),
+                  e);
             }
           } finally {
             if (content instanceof AutoCloseable) {

--- a/src/test/java/com/github/dbmdz/solrocr/solr/HocrTest.java
+++ b/src/test/java/com/github/dbmdz/solrocr/solr/HocrTest.java
@@ -1,6 +1,8 @@
 package com.github.dbmdz.solrocr.solr;
 
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -502,5 +504,13 @@ public class HocrTest extends SolrTestCaseJ4 {
     assertU(adoc("id", "57371"));
     assertU(adoc("id", "57371", "ocr_text", ""));
     assertU(commit());
+  }
+
+  public void testIssue288() throws IOException {
+    Path ocrPath = Paths.get("src/test/resources/data/issue_288.hocr");
+    assertU(adoc("ocr_text_stored", new String(Files.readAllBytes(ocrPath), StandardCharsets.UTF_8), "id", "87371"));
+    assertU(commit());
+    SolrQueryRequest req = xmlQ("q", "il", "hl.snippets", "4096", "hl.weightMatches", "true", "df", "ocr_text_stored", "hl.ocr.fl", "ocr_text_stored");
+    assertQ(req, "count(.//lst[@name=\"87371\"]//arr[@name='snippets']/lst)=19");
   }
 }

--- a/src/test/resources/data/issue_288.hocr
+++ b/src/test/resources/data/issue_288.hocr
@@ -1,0 +1,2606 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+ <head>
+  <title></title>
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+  <meta name='ocr-system' content='tesseract 4.1.1' />
+  <meta name='ocr-capabilities' content='ocr_page ocr_carea ocr_par ocr_line ocrx_word ocrp_wconf'/>
+ </head>
+ <body>
+  <div class='ocr_page' id='page_2' title='image "/media/remoteStorage/iiif-gramsci-0002/1924/Ordine_Nuovo_1924_03_01_02.jpg"; bbox 0 0 2491 3600; ppageno 0'>
+   <div class='ocr_carea' id='block_1_1' title="bbox 177 179 836 1742">
+    <p class='ocr_par' id='par_1_1' lang='ita' title="bbox 177 179 836 1742">
+     <span class='ocr_line' id='line_1_1' title="bbox 177 179 821 215; baseline -0.003 -9; x_size 34; x_descenders 8; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_1' title='bbox 177 189 260 206; x_wconf 91'>aveva</span>
+      <span class='ocrx_word' id='word_1_2' title='bbox 280 190 315 206; x_wconf 92'>un</span>
+      <span class='ocrx_word' id='word_1_3' title='bbox 338 180 440 215; x_wconf 89'>grande</span>
+      <span class='ocrx_word' id='word_1_4' title='bbox 461 179 613 213; x_wconf 91'>significato</span>
+      <span class='ocrx_word' id='word_1_5' title='bbox 634 179 740 204; x_wconf 89'>storico.</span>
+      <span class='ocrx_word' id='word_1_6' title='bbox 770 179 821 204; x_wconf 57'>ÉEra</span>
+     </span>
+     <span class='ocr_line' id='line_1_2' title="bbox 178 218 819 254; baseline -0.005 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_7' title='bbox 178 221 203 246; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_8' title='bbox 224 229 307 254; x_wconf 90'>prova</span>
+      <span class='ocrx_word' id='word_1_9' title='bbox 329 220 377 245; x_wconf 90'>che</span>
+      <span class='ocrx_word' id='word_1_10' title='bbox 390 220 406 245; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_11' title='bbox 423 219 593 253; x_wconf 92'>proletariato</span>
+      <span class='ocrx_word' id='word_1_12' title='bbox 609 218 753 244; x_wconf 91'>esercitava</span>
+      <span class='ocrx_word' id='word_1_13' title='bbox 769 227 819 243; x_wconf 92'>non</span>
+     </span>
+     <span class='ocr_line' id='line_1_3' title="bbox 180 257 823 294; baseline -0.005 -9; x_size 33; x_descenders 7; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_14' title='bbox 180 260 238 286; x_wconf 90'>solo</span>
+      <span class='ocrx_word' id='word_1_15' title='bbox 260 260 305 294; x_wconf 90'>più</span>
+      <span class='ocrx_word' id='word_1_16' title='bbox 320 269 355 284; x_wconf 92'>un</span>
+      <span class='ocrx_word' id='word_1_17' title='bbox 377 258 497 284; x_wconf 92'>dominio</span>
+      <span class='ocrx_word' id='word_1_18' title='bbox 519 258 601 290; x_wconf 92'>fisico,</span>
+      <span class='ocrx_word' id='word_1_19' title='bbox 618 267 660 283; x_wconf 91'>ma</span>
+      <span class='ocrx_word' id='word_1_20' title='bbox 680 257 823 283; x_wconf 92'>dominava</span>
+     </span>
+     <span class='ocr_line' id='line_1_4' title="bbox 182 296 824 332; baseline -0.006 -7; x_size 35; x_descenders 9; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_21' title='bbox 182 299 268 325; x_wconf 92'>anche</span>
+      <span class='ocrx_word' id='word_1_22' title='bbox 289 298 510 332; x_wconf 92'>spiritualmente.</span>
+      <span class='ocrx_word' id='word_1_23' title='bbox 535 298 563 323; x_wconf 92'>In</span>
+      <span class='ocrx_word' id='word_1_24' title='bbox 585 297 677 327; x_wconf 92'>fondo,</span>
+      <span class='ocrx_word' id='word_1_25' title='bbox 699 296 824 322; x_wconf 92'>confusa-</span>
+     </span>
+     <span class='ocr_line' id='line_1_5' title="bbox 184 337 825 370; baseline -0.005 -6; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_26' title='bbox 184 344 279 368; x_wconf 92'>mente,</span>
+      <span class='ocrx_word' id='word_1_27' title='bbox 302 338 386 364; x_wconf 92'>anche</span>
+      <span class='ocrx_word' id='word_1_28' title='bbox 407 337 424 362; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_29' title='bbox 445 337 577 370; x_wconf 92'>borghese</span>
+      <span class='ocrx_word' id='word_1_30' title='bbox 598 345 673 362; x_wconf 92'>russo</span>
+      <span class='ocrx_word' id='word_1_31' title='bbox 688 344 825 369; x_wconf 92'>compren-</span>
+     </span>
+     <span class='ocr_line' id='line_1_6' title="bbox 185 374 824 408; baseline -0.006 -5; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_32' title='bbox 185 378 252 403; x_wconf 91'>deva</span>
+      <span class='ocrx_word' id='word_1_33' title='bbox 272 377 322 403; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_34' title='bbox 343 377 426 402; x_wconf 91'>Lenin</span>
+      <span class='ocrx_word' id='word_1_35' title='bbox 449 385 500 402; x_wconf 92'>non</span>
+      <span class='ocrx_word' id='word_1_36' title='bbox 522 376 634 401; x_wconf 91'>sarebbe</span>
+      <span class='ocrx_word' id='word_1_37' title='bbox 665 380 757 408; x_wconf 91'>potuto</span>
+      <span class='ocrx_word' id='word_1_38' title='bbox 788 374 824 399; x_wconf 91'>di-</span>
+     </span>
+     <span class='ocr_line' id='line_1_7' title="bbox 185 413 824 448; baseline -0.006 -6; x_size 34.503891; x_descenders 8.4741039; x_ascenders 9.5297871">
+      <span class='ocrx_word' id='word_1_39' title='bbox 185 424 292 442; x_wconf 91'>ventare</span>
+      <span class='ocrx_word' id='word_1_40' title='bbox 314 425 327 442; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_41' title='bbox 349 425 402 441; x_wconf 92'>non</span>
+      <span class='ocrx_word' id='word_1_42' title='bbox 424 415 538 440; x_wconf 91'>avrebbe</span>
+      <span class='ocrx_word' id='word_1_43' title='bbox 569 420 662 448; x_wconf 90'>potuto</span>
+      <span class='ocrx_word' id='word_1_44' title='bbox 693 413 824 439; x_wconf 92'>rimanere</span>
+     </span>
+     <span class='ocr_line' id='line_1_8' title="bbox 187 452 825 489; baseline -0.006 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_45' title='bbox 187 465 255 489; x_wconf 92'>capo</span>
+      <span class='ocrx_word' id='word_1_46' title='bbox 276 455 347 481; x_wconf 91'>dello</span>
+      <span class='ocrx_word' id='word_1_47' title='bbox 375 455 449 480; x_wconf 91'>Stato</span>
+      <span class='ocrx_word' id='word_1_48' title='bbox 480 463 558 479; x_wconf 92'>senza</span>
+      <span class='ocrx_word' id='word_1_49' title='bbox 589 454 605 478; x_wconf 87'>il</span>
+      <span class='ocrx_word' id='word_1_50' title='bbox 634 452 752 478; x_wconf 89'>dominio</span>
+      <span class='ocrx_word' id='word_1_51' title='bbox 783 452 825 477; x_wconf 89'>del</span>
+     </span>
+     <span class='ocr_line' id='line_1_9' title="bbox 188 487 826 528; baseline -0.006 -8; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_52' title='bbox 188 494 366 528; x_wconf 92'>proletariato,</span>
+      <span class='ocrx_word' id='word_1_53' title='bbox 389 502 467 519; x_wconf 91'>senza</span>
+      <span class='ocrx_word' id='word_1_54' title='bbox 488 493 536 518; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_55' title='bbox 558 492 575 517; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_56' title='bbox 600 492 698 517; x_wconf 92'>Partito</span>
+      <span class='ocrx_word' id='word_1_57' title='bbox 729 487 826 524; x_wconf 85'>Comu-</span>
+     </span>
+     <span class='ocr_line' id='line_1_10' title="bbox 190 530 827 565; baseline -0.008 -6; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_58' title='bbox 190 534 258 559; x_wconf 90'>nista</span>
+      <span class='ocrx_word' id='word_1_59' title='bbox 279 533 350 558; x_wconf 90'>fosse</span>
+      <span class='ocrx_word' id='word_1_60' title='bbox 372 533 389 557; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_61' title='bbox 411 531 507 565; x_wconf 91'>partito</span>
+      <span class='ocrx_word' id='word_1_62' title='bbox 528 532 570 556; x_wconf 91'>del</span>
+      <span class='ocrx_word' id='word_1_63' title='bbox 592 539 724 564; x_wconf 89'>governo:</span>
+      <span class='ocrx_word' id='word_1_64' title='bbox 742 530 766 555; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_65' title='bbox 780 538 827 555; x_wconf 92'>sua</span>
+     </span>
+     <span class='ocr_line' id='line_1_11' title="bbox 191 569 829 603; baseline -0.008 -5; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_66' title='bbox 191 572 328 598; x_wconf 91'>coscienza</span>
+      <span class='ocrx_word' id='word_1_67' title='bbox 350 572 376 596; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_68' title='bbox 398 571 481 596; x_wconf 89'>classe</span>
+      <span class='ocrx_word' id='word_1_69' title='bbox 502 570 539 603; x_wconf 90'>gli</span>
+      <span class='ocrx_word' id='word_1_70' title='bbox 567 569 701 603; x_wconf 92'>impediva</span>
+      <span class='ocrx_word' id='word_1_71' title='bbox 732 577 829 594; x_wconf 92'>ancora</span>
+     </span>
+     <span class='ocr_line' id='line_1_12' title="bbox 192 607 829 636; baseline -0.008 0; x_size 33.217312; x_descenders 8.2173128; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_72' title='bbox 192 611 218 636; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_73' title='bbox 240 611 406 636; x_wconf 91'>riconoscere</span>
+      <span class='ocrx_word' id='word_1_74' title='bbox 428 609 493 634; x_wconf 91'>oltre</span>
+      <span class='ocrx_word' id='word_1_75' title='bbox 514 609 565 634; x_wconf 90'>alla</span>
+      <span class='ocrx_word' id='word_1_76' title='bbox 586 617 633 634; x_wconf 89'>sua</span>
+      <span class='ocrx_word' id='word_1_77' title='bbox 660 608 782 633; x_wconf 90'>sconfitta</span>
+      <span class='ocrx_word' id='word_1_78' title='bbox 804 607 829 631; x_wconf 91'>fi-</span>
+     </span>
+     <span class='ocr_line' id='line_1_13' title="bbox 193 646 829 679; baseline -0.008 -4; x_size 30; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_79' title='bbox 193 650 255 679; x_wconf 91'>sica,</span>
+      <span class='ocrx_word' id='word_1_80' title='bbox 277 648 438 678; x_wconf 92'>immediata,</span>
+      <span class='ocrx_word' id='word_1_81' title='bbox 473 648 556 673; x_wconf 91'>anche</span>
+      <span class='ocrx_word' id='word_1_82' title='bbox 577 648 601 672; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_83' title='bbox 631 655 679 672; x_wconf 91'>sua</span>
+      <span class='ocrx_word' id='word_1_84' title='bbox 708 646 829 671; x_wconf 91'>sconfitta</span>
+     </span>
+     <span class='ocr_line' id='line_1_14' title="bbox 194 683 830 721; baseline -0.009 -7; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_85' title='bbox 194 688 344 721; x_wconf 91'>ideologica</span>
+      <span class='ocrx_word' id='word_1_86' title='bbox 365 696 378 712; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_87' title='bbox 406 686 516 715; x_wconf 90'>storica;</span>
+      <span class='ocrx_word' id='word_1_88' title='bbox 544 695 586 710; x_wconf 90'>ma</span>
+      <span class='ocrx_word' id='word_1_89' title='bbox 617 684 699 718; x_wconf 87'>già</span>
+      <span class='ocrx_word' id='word_1_90' title='bbox 667 679 711 725; x_wconf 87'>il</span>
+      <span class='ocrx_word' id='word_1_91' title='bbox 730 683 830 709; x_wconf 88'>dubbio</span>
+     </span>
+     <span class='ocr_line' id='line_1_15' title="bbox 195 723 831 758; baseline -0.009 -6; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_92' title='bbox 195 736 238 752; x_wconf 90'>era</span>
+      <span class='ocrx_word' id='word_1_93' title='bbox 259 727 284 751; x_wconf 90'>in</span>
+      <span class='ocrx_word' id='word_1_94' title='bbox 307 726 350 755; x_wconf 90'>lui,</span>
+      <span class='ocrx_word' id='word_1_95' title='bbox 371 734 385 750; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_96' title='bbox 406 730 499 758; x_wconf 90'>questo</span>
+      <span class='ocrx_word' id='word_1_97' title='bbox 520 724 619 749; x_wconf 91'>dubbio</span>
+      <span class='ocrx_word' id='word_1_98' title='bbox 641 723 661 749; x_wconf 92'>si</span>
+      <span class='ocrx_word' id='word_1_99' title='bbox 683 723 831 756; x_wconf 91'>esprimeva</span>
+     </span>
+     <span class='ocr_line' id='line_1_16' title="bbox 195 764 753 798; baseline -0.005 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_100' title='bbox 195 765 220 790; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_101' title='bbox 242 765 330 798; x_wconf 91'>quella</span>
+      <span class='ocrx_word' id='word_1_102' title='bbox 350 764 427 789; x_wconf 89'>frase.</span>
+      <span class='ocrx_word' id='word_1_103' title='bbox 746 791 753 798; x_wconf 25'>a</span>
+     </span>
+     <span class='ocr_line' id='line_1_17' title="bbox 253 799 831 835; baseline -0.009 -7; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_104' title='bbox 253 801 523 835; x_wconf 71'>Un’altra.quistione</span>
+      <span class='ocrx_word' id='word_1_105' title='bbox 543 801 563 825; x_wconf 83'>si</span>
+      <span class='ocrx_word' id='word_1_106' title='bbox 586 805 716 833; x_wconf 91'>presenta.</span>
+      <span class='ocrx_word' id='word_1_107' title='bbox 739 799 759 823; x_wconf 92'>È</span>
+      <span class='ocrx_word' id='word_1_108' title='bbox 774 807 831 832; x_wconf 91'>pos-</span>
+     </span>
+     <span class='ocr_line' id='line_1_18' title="bbox 196 837 832 874; baseline -0.009 -7; x_size 34; x_descenders 8; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_109' title='bbox 196 841 280 870; x_wconf 92'>sibile,</span>
+      <span class='ocrx_word' id='word_1_110' title='bbox 302 841 374 874; x_wconf 91'>oggi,</span>
+      <span class='ocrx_word' id='word_1_111' title='bbox 397 840 438 865; x_wconf 91'>nel</span>
+      <span class='ocrx_word' id='word_1_112' title='bbox 459 839 568 872; x_wconf 91'>periodo</span>
+      <span class='ocrx_word' id='word_1_113' title='bbox 583 838 653 863; x_wconf 91'>della</span>
+      <span class='ocrx_word' id='word_1_114' title='bbox 673 837 832 862; x_wconf 91'>rivoluzione</span>
+     </span>
+     <span class='ocr_line' id='line_1_19' title="bbox 197 875 833 910; baseline -0.009 -5; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_115' title='bbox 197 880 338 908; x_wconf 91'>mondiale,</span>
+      <span class='ocrx_word' id='word_1_116' title='bbox 354 879 402 904; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_117' title='bbox 413 878 528 904; x_wconf 92'>esistano</span>
+      <span class='ocrx_word' id='word_1_118' title='bbox 543 880 557 890; x_wconf 90'>“</span>
+      <span class='ocrx_word' id='word_1_119' title='bbox 573 877 631 910; x_wconf 88'>capi</span>
+      <span class='ocrx_word' id='word_1_120' title='bbox 645 896 659 906; x_wconf 93'>,,</span>
+      <span class='ocrx_word' id='word_1_121' title='bbox 681 875 749 901; x_wconf 90'>fuori</span>
+      <span class='ocrx_word' id='word_1_122' title='bbox 764 875 833 900; x_wconf 92'>della</span>
+     </span>
+     <span class='ocr_line' id='line_1_20' title="bbox 196 914 833 950; baseline -0.009 -6; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_123' title='bbox 196 919 280 944; x_wconf 92'>classe</span>
+      <span class='ocrx_word' id='word_1_124' title='bbox 301 918 416 950; x_wconf 90'>operaia,</span>
+      <span class='ocrx_word' id='word_1_125' title='bbox 432 917 480 942; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_126' title='bbox 491 916 606 941; x_wconf 92'>esistano</span>
+      <span class='ocrx_word' id='word_1_127' title='bbox 622 914 681 947; x_wconf 91'>capi</span>
+      <span class='ocrx_word' id='word_1_128' title='bbox 694 922 833 939; x_wconf 91'>non-mar-</span>
+     </span>
+     <span class='ocr_line' id='line_1_21' title="bbox 195 953 833 989; baseline -0.009 -7; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_129' title='bbox 195 956 263 986; x_wconf 90'>xisti,</span>
+      <span class='ocrx_word' id='word_1_130' title='bbox 286 956 293 980; x_wconf 82'>i1</span>
+      <span class='ocrx_word' id='word_1_131' title='bbox 314 955 384 989; x_wconf 91'>quali</span>
+      <span class='ocrx_word' id='word_1_132' title='bbox 406 964 458 980; x_wconf 91'>non</span>
+      <span class='ocrx_word' id='word_1_133' title='bbox 470 954 544 979; x_wconf 91'>siano</span>
+      <span class='ocrx_word' id='word_1_134' title='bbox 559 953 639 987; x_wconf 92'>legati</span>
+      <span class='ocrx_word' id='word_1_135' title='bbox 653 957 833 978; x_wconf 90'>strettamente</span>
+     </span>
+     <span class='ocr_line' id='line_1_22' title="bbox 196 991 835 1024; baseline -0.009 -4; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_136' title='bbox 196 995 247 1020; x_wconf 92'>alla</span>
+      <span class='ocrx_word' id='word_1_137' title='bbox 268 994 352 1019; x_wconf 92'>classe</span>
+      <span class='ocrx_word' id='word_1_138' title='bbox 373 994 421 1019; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_139' title='bbox 442 993 549 1018; x_wconf 91'>incarna</span>
+      <span class='ocrx_word' id='word_1_140' title='bbox 577 992 601 1017; x_wconf 91'>lo</span>
+      <span class='ocrx_word' id='word_1_141' title='bbox 632 991 754 1024; x_wconf 91'>sviluppo</span>
+      <span class='ocrx_word' id='word_1_142' title='bbox 776 999 835 1023; x_wconf 92'>pro-</span>
+     </span>
+     <span class='ocr_line' id='line_1_23' title="bbox 195 1029 832 1066; baseline -0.008 -8; x_size 33; x_descenders 9; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_143' title='bbox 195 1033 314 1066; x_wconf 91'>gressivo</span>
+      <span class='ocrx_word' id='word_1_144' title='bbox 336 1031 362 1057; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_145' title='bbox 383 1037 449 1057; x_wconf 90'>tutto</span>
+      <span class='ocrx_word' id='word_1_146' title='bbox 470 1031 487 1055; x_wconf 90'>il</span>
+      <span class='ocrx_word' id='word_1_147' title='bbox 511 1039 608 1064; x_wconf 91'>genere</span>
+      <span class='ocrx_word' id='word_1_148' title='bbox 639 1029 755 1054; x_wconf 89'>umano?</span>
+      <span class='ocrx_word' id='word_1_149' title='bbox 776 1029 832 1053; x_wconf 92'>Ab-</span>
+     </span>
+     <span class='ocr_line' id='line_1_24' title="bbox 196 1067 834 1102; baseline -0.008 -6; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_150' title='bbox 196 1071 285 1096; x_wconf 92'>biamo</span>
+      <span class='ocrx_word' id='word_1_151' title='bbox 306 1071 331 1095; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_152' title='bbox 348 1070 421 1095; x_wconf 91'>Italia</span>
+      <span class='ocrx_word' id='word_1_153' title='bbox 436 1069 453 1094; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_154' title='bbox 464 1069 565 1102; x_wconf 92'>regime</span>
+      <span class='ocrx_word' id='word_1_155' title='bbox 579 1068 695 1097; x_wconf 92'>fascista,</span>
+      <span class='ocrx_word' id='word_1_156' title='bbox 711 1067 834 1092; x_wconf 92'>abbiamo</span>
+     </span>
+     <span class='ocr_line' id='line_1_25' title="bbox 196 1105 835 1142; baseline -0.008 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_157' title='bbox 196 1118 211 1134; x_wconf 92'>a</span>
+      <span class='ocrx_word' id='word_1_158' title='bbox 232 1118 299 1142; x_wconf 92'>capo</span>
+      <span class='ocrx_word' id='word_1_159' title='bbox 321 1109 363 1133; x_wconf 91'>del</span>
+      <span class='ocrx_word' id='word_1_160' title='bbox 384 1107 508 1133; x_wconf 92'>fascismo</span>
+      <span class='ocrx_word' id='word_1_161' title='bbox 523 1107 615 1139; x_wconf 92'>Benito</span>
+      <span class='ocrx_word' id='word_1_162' title='bbox 630 1105 777 1134; x_wconf 91'>Mussolini,</span>
+      <span class='ocrx_word' id='word_1_163' title='bbox 793 1105 835 1130; x_wconf 93'>ab-</span>
+     </span>
+     <span class='ocr_line' id='line_1_26' title="bbox 197 1142 835 1178; baseline -0.008 -6; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_164' title='bbox 197 1148 286 1173; x_wconf 91'>biamo</span>
+      <span class='ocrx_word' id='word_1_165' title='bbox 317 1155 369 1171; x_wconf 92'>una</span>
+      <span class='ocrx_word' id='word_1_166' title='bbox 400 1145 534 1178; x_wconf 89'>ideologia</span>
+      <span class='ocrx_word' id='word_1_167' title='bbox 564 1144 675 1169; x_wconf 89'>ufficiale</span>
+      <span class='ocrx_word' id='word_1_168' title='bbox 705 1144 729 1168; x_wconf 90'>in</span>
+      <span class='ocrx_word' id='word_1_169' title='bbox 755 1142 796 1168; x_wconf 92'>cui</span>
+      <span class='ocrx_word' id='word_1_170' title='bbox 818 1143 835 1167; x_wconf 92'>il</span>
+     </span>
+     <span class='ocr_line' id='line_1_27' title="bbox 198 1181 834 1218; baseline -0.008 -8; x_size 30; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_171' title='bbox 198 1189 212 1199; x_wconf 68'>“</span>
+      <span class='ocrx_word' id='word_1_172' title='bbox 228 1194 295 1218; x_wconf 80'>capo</span>
+      <span class='ocrx_word' id='word_1_173' title='bbox 311 1205 326 1214; x_wconf 96'>,,</span>
+      <span class='ocrx_word' id='word_1_174' title='bbox 348 1185 361 1209; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_175' title='bbox 383 1183 548 1212; x_wconf 92'>divinizzato,</span>
+      <span class='ocrx_word' id='word_1_176' title='bbox 570 1183 583 1207; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_177' title='bbox 599 1182 745 1207; x_wconf 92'>dichiarato</span>
+      <span class='ocrx_word' id='word_1_178' title='bbox 760 1181 834 1206; x_wconf 92'>infal-</span>
+     </span>
+     <span class='ocr_line' id='line_1_28' title="bbox 197 1219 835 1256; baseline -0.006 -8; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_179' title='bbox 197 1223 277 1252; x_wconf 91'>libile,</span>
+      <span class='ocrx_word' id='word_1_180' title='bbox 299 1223 312 1247; x_wconf 92'>è</span>
+      <span class='ocrx_word' id='word_1_181' title='bbox 334 1222 516 1256; x_wconf 91'>preconizzato</span>
+      <span class='ocrx_word' id='word_1_182' title='bbox 535 1220 732 1254; x_wconf 91'>organizzatore</span>
+      <span class='ocrx_word' id='word_1_183' title='bbox 746 1228 760 1244; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_184' title='bbox 774 1219 835 1252; x_wconf 91'>ispi-</span>
+     </span>
+     <span class='ocr_line' id='line_1_29' title="bbox 197 1259 833 1290; baseline -0.006 -4; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_185' title='bbox 197 1268 282 1286; x_wconf 91'>ratore</span>
+      <span class='ocrx_word' id='word_1_186' title='bbox 303 1261 329 1285; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_187' title='bbox 344 1270 378 1285; x_wconf 91'>un</span>
+      <span class='ocrx_word' id='word_1_188' title='bbox 394 1261 479 1285; x_wconf 91'>rinato</span>
+      <span class='ocrx_word' id='word_1_189' title='bbox 490 1259 572 1284; x_wconf 92'>Sacro</span>
+      <span class='ocrx_word' id='word_1_190' title='bbox 588 1259 709 1284; x_wconf 93'>Romano</span>
+      <span class='ocrx_word' id='word_1_191' title='bbox 721 1259 833 1290; x_wconf 89'>Impero.</span>
+     </span>
+     <span class='ocr_line' id='line_1_30' title="bbox 197 1296 833 1331; baseline -0.006 -7; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_192' title='bbox 197 1300 464 1331; x_wconf 83'>Vediamostampato</span>
+      <span class='ocrx_word' id='word_1_193' title='bbox 477 1297 517 1322; x_wconf 91'>nei</span>
+      <span class='ocrx_word' id='word_1_194' title='bbox 525 1297 647 1330; x_wconf 91'>giornali,</span>
+      <span class='ocrx_word' id='word_1_195' title='bbox 660 1296 722 1330; x_wconf 92'>ogni</span>
+      <span class='ocrx_word' id='word_1_196' title='bbox 731 1296 833 1329; x_wconf 91'>giorno,</span>
+     </span>
+     <span class='ocr_line' id='line_1_31' title="bbox 198 1334 834 1368; baseline -0.008 -5; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_197' title='bbox 198 1337 301 1363; x_wconf 92'>diecine</span>
+      <span class='ocrx_word' id='word_1_198' title='bbox 322 1346 336 1362; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_199' title='bbox 367 1336 498 1362; x_wconf 91'>centinaia</span>
+      <span class='ocrx_word' id='word_1_200' title='bbox 519 1336 544 1360; x_wconf 89'>di</span>
+      <span class='ocrx_word' id='word_1_201' title='bbox 575 1334 740 1368; x_wconf 89'>telegrammi</span>
+      <span class='ocrx_word' id='word_1_202' title='bbox 755 1334 781 1358; x_wconf 88'>di</span>
+      <span class='ocrx_word' id='word_1_203' title='bbox 809 1342 834 1358; x_wconf 88'>o-</span>
+     </span>
+     <span class='ocr_line' id='line_1_32' title="bbox 198 1372 834 1409; baseline -0.006 -9; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_204' title='bbox 198 1375 306 1409; x_wconf 91'>maggio</span>
+      <span class='ocrx_word' id='word_1_205' title='bbox 318 1375 386 1400; x_wconf 92'>delle</span>
+      <span class='ocrx_word' id='word_1_206' title='bbox 401 1380 473 1399; x_wconf 92'>vaste</span>
+      <span class='ocrx_word' id='word_1_207' title='bbox 488 1374 556 1398; x_wconf 92'>tribù</span>
+      <span class='ocrx_word' id='word_1_208' title='bbox 572 1372 797 1405; x_wconf 0'>localitaltcapo</span>
+     </span>
+     <span class='ocr_line' id='line_1_33' title="bbox 197 1409 836 1445; baseline -0.006 -7; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_209' title='bbox 197 1414 326 1438; x_wconf 91'>Vediamo</span>
+      <span class='ocrx_word' id='word_1_210' title='bbox 348 1413 371 1437; x_wconf 91'>le</span>
+      <span class='ocrx_word' id='word_1_211' title='bbox 392 1412 538 1445; x_wconf 91'>fotografie:</span>
+      <span class='ocrx_word' id='word_1_212' title='bbox 555 1411 580 1436; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_213' title='bbox 594 1411 730 1435; x_wconf 92'>maschera</span>
+      <span class='ocrx_word' id='word_1_214' title='bbox 741 1410 784 1443; x_wconf 93'>più</span>
+      <span class='ocrx_word' id='word_1_215' title='bbox 800 1409 836 1434; x_wconf 93'>in-</span>
+     </span>
+     <span class='ocr_line' id='line_1_34' title="bbox 199 1448 833 1482; baseline -0.006 -6; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_216' title='bbox 199 1451 285 1476; x_wconf 92'>durita</span>
+      <span class='ocrx_word' id='word_1_217' title='bbox 305 1450 331 1475; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_218' title='bbox 353 1460 386 1475; x_wconf 92'>un</span>
+      <span class='ocrx_word' id='word_1_219' title='bbox 408 1450 464 1475; x_wconf 90'>viso</span>
+      <span class='ocrx_word' id='word_1_220' title='bbox 485 1450 533 1474; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_221' title='bbox 554 1449 598 1482; x_wconf 91'>già</span>
+      <span class='ocrx_word' id='word_1_222' title='bbox 622 1448 745 1473; x_wconf 92'>abbiamo</span>
+      <span class='ocrx_word' id='word_1_223' title='bbox 766 1448 833 1472; x_wconf 89'>visto</span>
+     </span>
+     <span class='ocr_line' id='line_1_35' title="bbox 198 1485 835 1519; baseline -0.006 -5; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_224' title='bbox 198 1490 239 1514; x_wconf 90'>nei</span>
+      <span class='ocrx_word' id='word_1_225' title='bbox 273 1488 366 1514; x_wconf 90'>comizi</span>
+      <span class='ocrx_word' id='word_1_226' title='bbox 400 1487 534 1513; x_wconf 71'>socialisti.</span>
+      <span class='ocrx_word' id='word_1_227' title='bbox 569 1486 744 1512; x_wconf 89'>Conosciamo</span>
+      <span class='ocrx_word' id='word_1_228' title='bbox 775 1485 835 1519; x_wconf 90'>quel</span>
+     </span>
+     <span class='ocr_line' id='line_1_36' title="bbox 198 1524 836 1558; baseline -0.006 -6; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_229' title='bbox 198 1528 267 1552; x_wconf 92'>viso:</span>
+      <span class='ocrx_word' id='word_1_230' title='bbox 291 1526 460 1551; x_wconf 92'>conosciamo</span>
+      <span class='ocrx_word' id='word_1_231' title='bbox 481 1525 542 1558; x_wconf 91'>quel</span>
+      <span class='ocrx_word' id='word_1_232' title='bbox 570 1530 672 1550; x_wconf 91'>roteare</span>
+      <span class='ocrx_word' id='word_1_233' title='bbox 702 1524 772 1557; x_wconf 92'>degli</span>
+      <span class='ocrx_word' id='word_1_234' title='bbox 795 1532 836 1548; x_wconf 90'>oc-</span>
+     </span>
+     <span class='ocr_line' id='line_1_37' title="bbox 198 1562 833 1595; baseline -0.006 -5; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_235' title='bbox 198 1565 240 1590; x_wconf 92'>chi</span>
+      <span class='ocrx_word' id='word_1_236' title='bbox 262 1563 331 1590; x_wconf 92'>nelle</span>
+      <span class='ocrx_word' id='word_1_237' title='bbox 352 1564 435 1589; x_wconf 92'>orbite</span>
+      <span class='ocrx_word' id='word_1_238' title='bbox 450 1564 498 1588; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_239' title='bbox 513 1563 555 1588; x_wconf 92'>nel</span>
+      <span class='ocrx_word' id='word_1_240' title='bbox 570 1568 675 1595; x_wconf 93'>passato</span>
+      <span class='ocrx_word' id='word_1_241' title='bbox 688 1562 833 1590; x_wconf 92'>dovevano,</span>
+     </span>
+     <span class='ocr_line' id='line_1_38' title="bbox 198 1599 834 1629; baseline -0.006 -1; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_242' title='bbox 198 1612 248 1628; x_wconf 92'>con</span>
+      <span class='ocrx_word' id='word_1_243' title='bbox 270 1603 295 1627; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_244' title='bbox 315 1602 370 1627; x_wconf 92'>loro</span>
+      <span class='ocrx_word' id='word_1_245' title='bbox 392 1601 490 1627; x_wconf 91'>ferocia</span>
+      <span class='ocrx_word' id='word_1_246' title='bbox 511 1600 669 1629; x_wconf 91'>meccanica,</span>
+      <span class='ocrx_word' id='word_1_247' title='bbox 691 1600 731 1625; x_wconf 91'>far</span>
+      <span class='ocrx_word' id='word_1_248' title='bbox 746 1599 834 1624; x_wconf 91'>venire</span>
+     </span>
+     <span class='ocr_line' id='line_1_39' title="bbox 198 1637 836 1672; baseline -0.005 -7; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_249' title='bbox 198 1641 205 1665; x_wconf 92'>i</span>
+      <span class='ocrx_word' id='word_1_250' title='bbox 227 1640 308 1665; x_wconf 91'>vermi</span>
+      <span class='ocrx_word' id='word_1_251' title='bbox 330 1640 380 1664; x_wconf 90'>alla</span>
+      <span class='ocrx_word' id='word_1_252' title='bbox 401 1639 543 1672; x_wconf 90'>borghesia</span>
+      <span class='ocrx_word' id='word_1_253' title='bbox 563 1648 577 1663; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_254' title='bbox 598 1638 660 1671; x_wconf 92'>oggi</span>
+      <span class='ocrx_word' id='word_1_255' title='bbox 680 1638 704 1662; x_wconf 93'>al</span>
+      <span class='ocrx_word' id='word_1_256' title='bbox 724 1637 836 1671; x_wconf 92'>proleta-</span>
+     </span>
+     <span class='ocr_line' id='line_1_40' title="bbox 199 1677 836 1710; baseline -0.006 -7; x_size 33; x_descenders 9; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_257' title='bbox 199 1679 273 1703; x_wconf 88'>riato.</span>
+      <span class='ocrx_word' id='word_1_258' title='bbox 305 1677 480 1703; x_wconf 88'>Conosciamo</span>
+      <span class='ocrx_word' id='word_1_259' title='bbox 514 1677 573 1710; x_wconf 90'>quel</span>
+      <span class='ocrx_word' id='word_1_260' title='bbox 608 1685 698 1709; x_wconf 90'>pugno</span>
+      <span class='ocrx_word' id='word_1_261' title='bbox 732 1684 836 1708; x_wconf 91'>sempre</span>
+     </span>
+     <span class='ocr_line' id='line_1_41' title="bbox 198 1713 836 1742; baseline -0.006 -1; x_size 33.217312; x_descenders 8.2173128; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_262' title='bbox 198 1716 290 1742; x_wconf 91'>chiuso</span>
+      <span class='ocrx_word' id='word_1_263' title='bbox 315 1716 366 1740; x_wconf 90'>alla</span>
+      <span class='ocrx_word' id='word_1_264' title='bbox 398 1715 534 1740; x_wconf 86'>minaccia.</span>
+      <span class='ocrx_word' id='word_1_265' title='bbox 566 1713 742 1739; x_wconf 92'>Conosciamo</span>
+      <span class='ocrx_word' id='word_1_266' title='bbox 769 1718 836 1738; x_wconf 87'>tutto</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_2' title="bbox 197 1753 837 1787">
+    <p class='ocr_par' id='par_1_2' lang='ita' title="bbox 197 1753 837 1787">
+     <span class='ocr_caption' id='line_1_42' title="bbox 197 1753 837 1787; baseline -0.006 -8; x_size 29; x_descenders 9; x_ascenders 5">
+      <span class='ocrx_word' id='word_1_267' title='bbox 197 1759 290 1787; x_wconf 90'>questo</span>
+      <span class='ocrx_word' id='word_1_268' title='bbox 322 1753 507 1781; x_wconf 91'>meccanismo,</span>
+      <span class='ocrx_word' id='word_1_269' title='bbox 540 1757 605 1777; x_wconf 91'>tutto</span>
+      <span class='ocrx_word' id='word_1_270' title='bbox 636 1757 729 1785; x_wconf 91'>questo</span>
+      <span class='ocrx_word' id='word_1_271' title='bbox 754 1760 837 1776; x_wconf 92'>arma-</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_3' title="bbox 192 1790 835 3460">
+    <p class='ocr_par' id='par_1_3' lang='ita' title="bbox 192 1790 835 2835">
+     <span class='ocr_line' id='line_1_43' title="bbox 197 1790 835 1823; baseline -0.005 -7; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_272' title='bbox 197 1792 325 1817; x_wconf 92'>mentario</span>
+      <span class='ocrx_word' id='word_1_273' title='bbox 347 1800 360 1816; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_274' title='bbox 381 1800 433 1816; x_wconf 91'>non</span>
+      <span class='ocrx_word' id='word_1_275' title='bbox 454 1790 673 1823; x_wconf 91'>comprendiamo</span>
+      <span class='ocrx_word' id='word_1_276' title='bbox 701 1790 749 1814; x_wconf 90'>che</span>
+      <span class='ocrx_word' id='word_1_277' title='bbox 776 1797 835 1814; x_wconf 92'>esso</span>
+     </span>
+     <span class='ocr_line' id='line_1_44' title="bbox 196 1827 834 1863; baseline -0.006 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_278' title='bbox 196 1839 275 1863; x_wconf 92'>possa</span>
+      <span class='ocrx_word' id='word_1_279' title='bbox 297 1828 529 1861; x_wconf 91'>impressionare</span>
+      <span class='ocrx_word' id='word_1_280' title='bbox 513 1823 542 1867; x_wconf 61'>è</span>
+      <span class='ocrx_word' id='word_1_281' title='bbox 549 1827 691 1852; x_wconf 92'>muovere</span>
+      <span class='ocrx_word' id='word_1_282' title='bbox 673 1823 701 1867; x_wconf 86'>1</span>
+      <span class='ocrx_word' id='word_1_283' title='bbox 713 1827 834 1859; x_wconf 86'>precordi</span>
+     </span>
+     <span class='ocr_line' id='line_1_45' title="bbox 196 1865 834 1900; baseline -0.005 -8; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_284' title='bbox 196 1868 247 1892; x_wconf 91'>alla</span>
+      <span class='ocrx_word' id='word_1_285' title='bbox 267 1867 393 1900; x_wconf 75'>gioventù</span>
+      <span class='ocrx_word' id='word_1_286' title='bbox 415 1866 483 1891; x_wconf 92'>delle</span>
+      <span class='ocrx_word' id='word_1_287' title='bbox 504 1866 593 1891; x_wconf 91'>scuole</span>
+      <span class='ocrx_word' id='word_1_288' title='bbox 614 1865 753 1898; x_wconf 88'>borghesi;</span>
+      <span class='ocrx_word' id='word_1_289' title='bbox 776 1873 834 1890; x_wconf 91'>esso</span>
+     </span>
+     <span class='ocr_line' id='line_1_46' title="bbox 195 1902 835 1937; baseline -0.003 -7; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_290' title='bbox 195 1905 209 1930; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_291' title='bbox 231 1910 381 1930; x_wconf 91'>veramente</span>
+      <span class='ocrx_word' id='word_1_292' title='bbox 410 1904 633 1937; x_wconf 90'>impressionante</span>
+      <span class='ocrx_word' id='word_1_293' title='bbox 663 1903 747 1928; x_wconf 90'>anche</span>
+      <span class='ocrx_word' id='word_1_294' title='bbox 769 1902 835 1928; x_wconf 91'>visto</span>
+     </span>
+     <span class='ocr_line' id='line_1_47' title="bbox 196 1941 835 1974; baseline -0.002 -7; x_size 33; x_descenders 7; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_295' title='bbox 196 1943 229 1967; x_wconf 91'>da</span>
+      <span class='ocrx_word' id='word_1_296' title='bbox 250 1942 336 1968; x_wconf 92'>vicino</span>
+      <span class='ocrx_word' id='word_1_297' title='bbox 351 1951 366 1967; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_298' title='bbox 386 1942 412 1967; x_wconf 92'>fa</span>
+      <span class='ocrx_word' id='word_1_299' title='bbox 426 1941 534 1974; x_wconf 91'>stupire.</span>
+      <span class='ocrx_word' id='word_1_300' title='bbox 549 1941 594 1967; x_wconf 92'>Ma</span>
+      <span class='ocrx_word' id='word_1_301' title='bbox 609 1944 624 1954; x_wconf 73'>“</span>
+      <span class='ocrx_word' id='word_1_302' title='bbox 639 1949 706 1973; x_wconf 90'>capo</span>
+      <span class='ocrx_word' id='word_1_303' title='bbox 722 1961 737 1970; x_wconf 86'>,,</span>
+      <span class='ocrx_word' id='word_1_304' title='bbox 750 1941 759 1965; x_wconf 76'>°</span>
+      <span class='ocrx_word' id='word_1_305' title='bbox 783 1942 835 1966; x_wconf 90'>Ab-</span>
+     </span>
+     <span class='ocr_line' id='line_1_48' title="bbox 197 1978 835 2012; baseline -0.003 -7; x_size 35; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_306' title='bbox 197 1981 285 2006; x_wconf 42'>biamo</span>
+      <span class='ocrx_word' id='word_1_307' title='bbox 307 1978 374 2005; x_wconf 91'>visto</span>
+      <span class='ocrx_word' id='word_1_308' title='bbox 395 1980 420 2004; x_wconf 88'>la</span>
+      <span class='ocrx_word' id='word_1_309' title='bbox 440 1979 581 2007; x_wconf 91'>settimana</span>
+      <span class='ocrx_word' id='word_1_310' title='bbox 611 1987 684 2004; x_wconf 91'>rossa</span>
+      <span class='ocrx_word' id='word_1_311' title='bbox 712 1978 756 2004; x_wconf 91'>del</span>
+      <span class='ocrx_word' id='word_1_312' title='bbox 779 1979 835 2012; x_wconf 92'>giu-</span>
+     </span>
+     <span class='ocr_line' id='line_1_49' title="bbox 197 2015 835 2051; baseline -0.002 -9; x_size 34; x_descenders 8; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_313' title='bbox 197 2026 251 2051; x_wconf 90'>gno</span>
+      <span class='ocrx_word' id='word_1_314' title='bbox 275 2024 353 2050; x_wconf 89'>1914.</span>
+      <span class='ocrx_word' id='word_1_315' title='bbox 370 2017 417 2042; x_wconf 91'>Più</span>
+      <span class='ocrx_word' id='word_1_316' title='bbox 438 2017 464 2042; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_317' title='bbox 478 2022 517 2042; x_wconf 91'>tre</span>
+      <span class='ocrx_word' id='word_1_318' title='bbox 539 2015 642 2042; x_wconf 22'>milioni</span>
+      <span class='ocrx_word' id='word_1_319' title='bbox 656 2017 682 2041; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_320' title='bbox 694 2016 835 2041; x_wconf 90'>lavoratori</span>
+     </span>
+     <span class='ocr_line' id='line_1_50' title="bbox 196 2054 835 2088; baseline -0.003 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_321' title='bbox 196 2064 277 2080; x_wconf 91'>erano</span>
+      <span class='ocrx_word' id='word_1_322' title='bbox 298 2055 323 2079; x_wconf 92'>in</span>
+      <span class='ocrx_word' id='word_1_323' title='bbox 345 2055 443 2088; x_wconf 91'>piazza,</span>
+      <span class='ocrx_word' id='word_1_324' title='bbox 465 2054 532 2080; x_wconf 92'>scesi</span>
+      <span class='ocrx_word' id='word_1_325' title='bbox 563 2054 715 2087; x_wconf 91'>all’appello</span>
+      <span class='ocrx_word' id='word_1_326' title='bbox 736 2054 763 2078; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_327' title='bbox 789 2054 835 2079; x_wconf 92'>Be-</span>
+     </span>
+     <span class='ocr_line' id='line_1_51' title="bbox 196 2091 831 2121; baseline -0.003 -3; x_size 30; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_328' title='bbox 196 2093 251 2118; x_wconf 91'>nito</span>
+      <span class='ocrx_word' id='word_1_329' title='bbox 272 2092 421 2121; x_wconf 91'>Mussolini,</span>
+      <span class='ocrx_word' id='word_1_330' title='bbox 452 2092 501 2117; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_331' title='bbox 521 2092 556 2117; x_wconf 92'>da</span>
+      <span class='ocrx_word' id='word_1_332' title='bbox 586 2101 619 2116; x_wconf 91'>un</span>
+      <span class='ocrx_word' id='word_1_333' title='bbox 654 2101 724 2117; x_wconf 91'>anno</span>
+      <span class='ocrx_word' id='word_1_334' title='bbox 754 2091 831 2121; x_wconf 91'>circa,</span>
+     </span>
+     <span class='ocr_line' id='line_1_52' title="bbox 196 2129 833 2163; baseline -0.002 -8; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_335' title='bbox 196 2130 361 2155; x_wconf 90'>dall’eccidio</span>
+      <span class='ocrx_word' id='word_1_336' title='bbox 382 2130 408 2155; x_wconf 90'>di</span>
+      <span class='ocrx_word' id='word_1_337' title='bbox 430 2130 613 2163; x_wconf 91'>Roccagorga,</span>
+      <span class='ocrx_word' id='word_1_338' title='bbox 636 2129 653 2154; x_wconf 77'>li</span>
+      <span class='ocrx_word' id='word_1_339' title='bbox 674 2138 756 2154; x_wconf 92'>aveva</span>
+      <span class='ocrx_word' id='word_1_340' title='bbox 777 2138 833 2162; x_wconf 92'>pre-</span>
+     </span>
+     <span class='ocr_line' id='line_1_53' title="bbox 197 2167 830 2201; baseline -0.003 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_341' title='bbox 197 2168 280 2201; x_wconf 92'>parati</span>
+      <span class='ocrx_word' id='word_1_342' title='bbox 302 2168 353 2193; x_wconf 92'>alla</span>
+      <span class='ocrx_word' id='word_1_343' title='bbox 372 2168 473 2201; x_wconf 92'>grande</span>
+      <span class='ocrx_word' id='word_1_344' title='bbox 503 2167 633 2200; x_wconf 91'>giornata,</span>
+      <span class='ocrx_word' id='word_1_345' title='bbox 664 2176 714 2192; x_wconf 91'>con</span>
+      <span class='ocrx_word' id='word_1_346' title='bbox 745 2167 803 2192; x_wconf 89'>tutti</span>
+      <span class='ocrx_word' id='word_1_347' title='bbox 825 2167 830 2191; x_wconf 96'>i</span>
+     </span>
+     <span class='ocr_line' id='line_1_54' title="bbox 195 2204 834 2237; baseline -0.002 -7; x_size 33; x_descenders 8; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_348' title='bbox 195 2206 273 2230; x_wconf 90'>mezzi</span>
+      <span class='ocrx_word' id='word_1_349' title='bbox 295 2205 427 2231; x_wconf 91'>tribunizii</span>
+      <span class='ocrx_word' id='word_1_350' title='bbox 448 2214 462 2230; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_351' title='bbox 482 2204 656 2237; x_wconf 92'>giornalistici</span>
+      <span class='ocrx_word' id='word_1_352' title='bbox 678 2214 693 2229; x_wconf 68'>a_</span>
+      <span class='ocrx_word' id='word_1_353' title='bbox 722 2205 834 2237; x_wconf 71'>disposi-</span>
+     </span>
+     <span class='ocr_line' id='line_1_55' title="bbox 195 2242 833 2275; baseline -0.002 -7; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_354' title='bbox 195 2245 269 2268; x_wconf 93'>zione</span>
+      <span class='ocrx_word' id='word_1_355' title='bbox 290 2243 333 2268; x_wconf 93'>del</span>
+      <span class='ocrx_word' id='word_1_356' title='bbox 355 2247 369 2256; x_wconf 77'>“</span>
+      <span class='ocrx_word' id='word_1_357' title='bbox 385 2251 452 2275; x_wconf 85'>capo</span>
+      <span class='ocrx_word' id='word_1_358' title='bbox 465 2262 480 2272; x_wconf 93'>,,</span>
+      <span class='ocrx_word' id='word_1_359' title='bbox 502 2243 544 2267; x_wconf 90'>del</span>
+      <span class='ocrx_word' id='word_1_360' title='bbox 566 2243 664 2267; x_wconf 92'>Partito</span>
+      <span class='ocrx_word' id='word_1_361' title='bbox 693 2242 833 2267; x_wconf 91'>Socialista</span>
+     </span>
+     <span class='ocr_line' id='line_1_56' title="bbox 194 2279 833 2310; baseline -0.002 -5; x_size 30; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_362' title='bbox 194 2281 221 2306; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_363' title='bbox 242 2281 332 2310; x_wconf 91'>allora,</span>
+      <span class='ocrx_word' id='word_1_364' title='bbox 355 2280 380 2305; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_365' title='bbox 402 2280 495 2305; x_wconf 92'>Benito</span>
+      <span class='ocrx_word' id='word_1_366' title='bbox 521 2279 675 2305; x_wconf 91'>Mussolini:</span>
+      <span class='ocrx_word' id='word_1_367' title='bbox 707 2280 777 2304; x_wconf 91'>dalla</span>
+      <span class='ocrx_word' id='word_1_368' title='bbox 798 2280 833 2304; x_wconf 91'>vi-</span>
+     </span>
+     <span class='ocr_line' id='line_1_57' title="bbox 194 2317 833 2352; baseline -0.002 -9; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_369' title='bbox 194 2323 285 2352; x_wconf 91'>gnetta</span>
+      <span class='ocrx_word' id='word_1_370' title='bbox 316 2318 342 2342; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_371' title='bbox 373 2317 501 2347; x_wconf 75'>Scalarinj</span>
+      <span class='ocrx_word' id='word_1_372' title='bbox 522 2318 545 2342; x_wconf 92'>al</span>
+      <span class='ocrx_word' id='word_1_373' title='bbox 576 2318 678 2350; x_wconf 91'>grande</span>
+      <span class='ocrx_word' id='word_1_374' title='bbox 709 2326 833 2349; x_wconf 88'>processo</span>
+     </span>
+     <span class='ocr_line' id='line_1_58' title="bbox 194 2353 834 2381; baseline -0.002 -1; x_size 34.961346; x_descenders 7.9613447; x_ascenders 11">
+      <span class='ocrx_word' id='word_1_375' title='bbox 194 2356 245 2381; x_wconf 90'>alle</span>
+      <span class='ocrx_word' id='word_1_376' title='bbox 266 2356 351 2381; x_wconf 92'>Assisi</span>
+      <span class='ocrx_word' id='word_1_377' title='bbox 373 2356 399 2380; x_wconf 89'>di</span>
+      <span class='ocrx_word' id='word_1_378' title='bbox 421 2355 529 2380; x_wconf 89'>Milano.</span>
+      <span class='ocrx_word' id='word_1_379' title='bbox 553 2353 609 2381; x_wconf 85'>Tre</span>
+      <span class='ocrx_word' id='word_1_380' title='bbox 630 2355 730 2379; x_wconf 92'>milioni</span>
+      <span class='ocrx_word' id='word_1_381' title='bbox 752 2355 778 2379; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_382' title='bbox 800 2355 834 2379; x_wconf 92'>la-</span>
+     </span>
+     <span class='ocr_line' id='line_1_59' title="bbox 193 2393 832 2425; baseline -0.002 -7; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_383' title='bbox 193 2393 306 2418; x_wconf 89'>voratori</span>
+      <span class='ocrx_word' id='word_1_384' title='bbox 329 2402 409 2417; x_wconf 91'>erano</span>
+      <span class='ocrx_word' id='word_1_385' title='bbox 430 2393 497 2418; x_wconf 91'>scesi</span>
+      <span class='ocrx_word' id='word_1_386' title='bbox 519 2393 544 2417; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_387' title='bbox 567 2393 669 2425; x_wconf 92'>piazza:</span>
+      <span class='ocrx_word' id='word_1_388' title='bbox 700 2393 794 2417; x_wconf 91'>mancò</span>
+      <span class='ocrx_word' id='word_1_389' title='bbox 816 2393 832 2417; x_wconf 92'>il</span>
+     </span>
+     <span class='ocr_line' id='line_1_60' title="bbox 194 2430 832 2463; baseline -0.003 -7; x_size 31; x_descenders 7; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_390' title='bbox 194 2435 209 2444; x_wconf 37'>““</span>
+      <span class='ocrx_word' id='word_1_391' title='bbox 221 2440 288 2463; x_wconf 82'>capo</span>
+      <span class='ocrx_word' id='word_1_392' title='bbox 302 2450 315 2460; x_wconf 11'>,,</span>
+      <span class='ocrx_word' id='word_1_393' title='bbox 327 2450 332 2459; x_wconf 11'>,</span>
+      <span class='ocrx_word' id='word_1_394' title='bbox 348 2431 396 2455; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_395' title='bbox 411 2439 455 2455; x_wconf 91'>era</span>
+      <span class='ocrx_word' id='word_1_396' title='bbox 467 2430 560 2455; x_wconf 92'>Benito</span>
+      <span class='ocrx_word' id='word_1_397' title='bbox 572 2430 721 2455; x_wconf 91'>Mussolini.</span>
+      <span class='ocrx_word' id='word_1_398' title='bbox 737 2430 832 2454; x_wconf 91'>Mancò</span>
+     </span>
+     <span class='ocr_line' id='line_1_61' title="bbox 192 2467 833 2500; baseline -0.005 -6; x_size 30; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_399' title='bbox 192 2477 268 2494; x_wconf 92'>come</span>
+      <span class='ocrx_word' id='word_1_400' title='bbox 290 2472 305 2481; x_wconf 42'>‘</span>
+      <span class='ocrx_word' id='word_1_401' title='bbox 321 2477 388 2500; x_wconf 74'>capo</span>
+      <span class='ocrx_word' id='word_1_402' title='bbox 401 2488 416 2497; x_wconf 92'>,,</span>
+      <span class='ocrx_word' id='word_1_403' title='bbox 439 2476 489 2492; x_wconf 91'>non</span>
+      <span class='ocrx_word' id='word_1_404' title='bbox 512 2476 588 2492; x_wconf 91'>come</span>
+      <span class='ocrx_word' id='word_1_405' title='bbox 609 2467 755 2496; x_wconf 91'>individuo,</span>
+      <span class='ocrx_word' id='word_1_406' title='bbox 777 2476 833 2499; x_wconf 92'>per-</span>
+     </span>
+     <span class='ocr_line' id='line_1_62' title="bbox 192 2504 831 2538; baseline -0.002 -8; x_size 33; x_descenders 9; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_407' title='bbox 192 2506 241 2531; x_wconf 93'>chè</span>
+      <span class='ocrx_word' id='word_1_408' title='bbox 262 2510 422 2530; x_wconf 92'>raccontano</span>
+      <span class='ocrx_word' id='word_1_409' title='bbox 443 2506 492 2530; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_410' title='bbox 513 2505 565 2538; x_wconf 89'>egli</span>
+      <span class='ocrx_word' id='word_1_411' title='bbox 587 2514 662 2529; x_wconf 90'>come</span>
+      <span class='ocrx_word' id='word_1_412' title='bbox 693 2504 831 2529; x_wconf 90'>individuo</span>
+     </span>
+     <span class='ocr_line' id='line_1_63' title="bbox 192 2542 831 2575; baseline -0.003 -7; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_413' title='bbox 192 2544 263 2568; x_wconf 91'>fosse</span>
+      <span class='ocrx_word' id='word_1_414' title='bbox 294 2543 452 2575; x_wconf 91'>coraggioso</span>
+      <span class='ocrx_word' id='word_1_415' title='bbox 481 2551 494 2567; x_wconf 96'>e</span>
+      <span class='ocrx_word' id='word_1_416' title='bbox 516 2552 531 2567; x_wconf 91'>a</span>
+      <span class='ocrx_word' id='word_1_417' title='bbox 561 2542 661 2566; x_wconf 91'>Milano</span>
+      <span class='ocrx_word' id='word_1_418' title='bbox 694 2542 831 2567; x_wconf 92'>sfidasse</span>
+      <span class='ocrx_word' id='word_1_419' title='bbox 808 2538 834 2579; x_wconf 96'>i</span>
+     </span>
+     <span class='ocr_line' id='line_1_64' title="bbox 193 2579 831 2606; baseline -0.003 -1; x_size 32.961346; x_descenders 7.9613447; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_420' title='bbox 193 2580 303 2606; x_wconf 92'>cordoni</span>
+      <span class='ocrx_word' id='word_1_421' title='bbox 338 2589 352 2605; x_wconf 96'>e</span>
+      <span class='ocrx_word' id='word_1_422' title='bbox 385 2580 392 2604; x_wconf 93'>i</span>
+      <span class='ocrx_word' id='word_1_423' title='bbox 424 2580 563 2604; x_wconf 88'>moschetti</span>
+      <span class='ocrx_word' id='word_1_424' title='bbox 594 2579 636 2604; x_wconf 91'>dei</span>
+      <span class='ocrx_word' id='word_1_425' title='bbox 667 2579 831 2604; x_wconf 92'>carabinieri.</span>
+     </span>
+     <span class='ocr_line' id='line_1_65' title="bbox 193 2617 833 2649; baseline -0.003 -7; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_426' title='bbox 193 2618 289 2642; x_wconf 92'>Mancò</span>
+      <span class='ocrx_word' id='word_1_427' title='bbox 311 2626 386 2642; x_wconf 91'>come</span>
+      <span class='ocrx_word' id='word_1_428' title='bbox 416 2628 426 2638; x_wconf 71'>«</span>
+      <span class='ocrx_word' id='word_1_429' title='bbox 442 2625 509 2649; x_wconf 71'>capo</span>
+      <span class='ocrx_word' id='word_1_430' title='bbox 525 2628 555 2648; x_wconf 90'>»,</span>
+      <span class='ocrx_word' id='word_1_431' title='bbox 587 2617 684 2649; x_wconf 92'>perchè</span>
+      <span class='ocrx_word' id='word_1_432' title='bbox 715 2625 766 2641; x_wconf 90'>non</span>
+      <span class='ocrx_word' id='word_1_433' title='bbox 789 2625 833 2641; x_wconf 90'>era</span>
+     </span>
+     <span class='ocr_line' id='line_1_66' title="bbox 192 2653 833 2686; baseline -0.003 -7; x_size 29; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_434' title='bbox 192 2655 252 2684; x_wconf 92'>tale,</span>
+      <span class='ocrx_word' id='word_1_435' title='bbox 275 2655 380 2686; x_wconf 53'>perchè,</span>
+      <span class='ocrx_word' id='word_1_436' title='bbox 385 2649 396 2690; x_wconf 44'>.</span>
+      <span class='ocrx_word' id='word_1_437' title='bbox 402 2663 417 2678; x_wconf 87'>a</span>
+      <span class='ocrx_word' id='word_1_438' title='bbox 431 2663 478 2679; x_wconf 92'>sua</span>
+      <span class='ocrx_word' id='word_1_439' title='bbox 493 2659 577 2679; x_wconf 91'>stessa</span>
+      <span class='ocrx_word' id='word_1_440' title='bbox 598 2653 774 2682; x_wconf 91'>confessione,</span>
+      <span class='ocrx_word' id='word_1_441' title='bbox 791 2654 833 2678; x_wconf 92'>nel</span>
+     </span>
+     <span class='ocr_line' id='line_1_67' title="bbox 192 2690 832 2719; baseline -0.003 -2; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_442' title='bbox 192 2701 256 2717; x_wconf 88'>seno</span>
+      <span class='ocrx_word' id='word_1_443' title='bbox 278 2692 348 2716; x_wconf 91'>della</span>
+      <span class='ocrx_word' id='word_1_444' title='bbox 359 2692 501 2716; x_wconf 91'>Direzione</span>
+      <span class='ocrx_word' id='word_1_445' title='bbox 516 2691 558 2715; x_wconf 93'>del</span>
+      <span class='ocrx_word' id='word_1_446' title='bbox 570 2691 669 2716; x_wconf 91'>Partito</span>
+      <span class='ocrx_word' id='word_1_447' title='bbox 683 2690 832 2719; x_wconf 90'>Socialista,</span>
+     </span>
+     <span class='ocr_line' id='line_1_68' title="bbox 194 2727 833 2760; baseline -0.002 -7; x_size 32; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_448' title='bbox 194 2738 246 2754; x_wconf 91'>non</span>
+      <span class='ocrx_word' id='word_1_449' title='bbox 267 2729 381 2753; x_wconf 88'>riusciva</span>
+      <span class='ocrx_word' id='word_1_450' title='bbox 402 2728 521 2753; x_wconf 88'>neanche</span>
+      <span class='ocrx_word' id='word_1_451' title='bbox 542 2728 575 2753; x_wconf 92'>ad</span>
+      <span class='ocrx_word' id='word_1_452' title='bbox 590 2737 652 2752; x_wconf 93'>aver</span>
+      <span class='ocrx_word' id='word_1_453' title='bbox 666 2728 776 2760; x_wconf 92'>ragione</span>
+      <span class='ocrx_word' id='word_1_454' title='bbox 791 2727 833 2752; x_wconf 91'>dei</span>
+     </span>
+     <span class='ocr_line' id='line_1_69' title="bbox 194 2764 833 2799; baseline -0.003 -8; x_size 34; x_descenders 9; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_455' title='bbox 194 2766 337 2799; x_wconf 92'>miserabili</span>
+      <span class='ocrx_word' id='word_1_456' title='bbox 366 2765 475 2798; x_wconf 91'>intrighi</span>
+      <span class='ocrx_word' id='word_1_457' title='bbox 497 2765 523 2790; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_458' title='bbox 554 2766 653 2790; x_wconf 91'>Arturo</span>
+      <span class='ocrx_word' id='word_1_459' title='bbox 674 2765 750 2789; x_wconf 92'>Vella</span>
+      <span class='ocrx_word' id='word_1_460' title='bbox 771 2773 785 2789; x_wconf 92'>o</span>
+      <span class='ocrx_word' id='word_1_461' title='bbox 807 2764 833 2788; x_wconf 92'>di</span>
+     </span>
+     <span class='ocr_line' id='line_1_70' title="bbox 194 2802 500 2835; baseline -0.003 -8; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_462' title='bbox 194 2803 326 2835; x_wconf 91'>Angelica</span>
+      <span class='ocrx_word' id='word_1_463' title='bbox 346 2802 500 2827; x_wconf 91'>Balabanof.</span>
+     </span>
+    </p>
+
+    <p class='ocr_par' id='par_1_4' lang='ita' title="bbox 194 2838 835 3276">
+     <span class='ocr_line' id='line_1_71' title="bbox 251 2838 833 2872; baseline -0.005 -8; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_464' title='bbox 251 2840 311 2872; x_wconf 92'>Egli</span>
+      <span class='ocrx_word' id='word_1_465' title='bbox 332 2848 376 2864; x_wconf 84'>era</span>
+      <span class='ocrx_word' id='word_1_466' title='bbox 406 2839 496 2868; x_wconf 84'>allora,</span>
+      <span class='ocrx_word' id='word_1_467' title='bbox 528 2847 603 2863; x_wconf 90'>come</span>
+      <span class='ocrx_word' id='word_1_468' title='bbox 634 2838 707 2871; x_wconf 91'>oggi,</span>
+      <span class='ocrx_word' id='word_1_469' title='bbox 739 2838 756 2861; x_wconf 90'>il</span>
+      <span class='ocrx_word' id='word_1_470' title='bbox 778 2838 833 2869; x_wconf 91'>tipo</span>
+     </span>
+     <span class='ocr_line' id='line_1_72' title="bbox 195 2874 832 2908; baseline -0.005 -7; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_471' title='bbox 195 2882 365 2901; x_wconf 90'>concentrato</span>
+      <span class='ocrx_word' id='word_1_472' title='bbox 386 2876 428 2900; x_wconf 92'>del</span>
+      <span class='ocrx_word' id='word_1_473' title='bbox 450 2876 553 2908; x_wconf 91'>piccolo</span>
+      <span class='ocrx_word' id='word_1_474' title='bbox 568 2876 701 2907; x_wconf 92'>borghese</span>
+      <span class='ocrx_word' id='word_1_475' title='bbox 716 2874 832 2903; x_wconf 91'>italiano,</span>
+     </span>
+     <span class='ocr_line' id='line_1_73' title="bbox 194 2911 833 2945; baseline -0.005 -7; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_476' title='bbox 194 2913 326 2942; x_wconf 91'>rabbioso,</span>
+      <span class='ocrx_word' id='word_1_477' title='bbox 349 2913 444 2941; x_wconf 91'>feroce,</span>
+      <span class='ocrx_word' id='word_1_478' title='bbox 467 2913 581 2945; x_wconf 92'>impasto</span>
+      <span class='ocrx_word' id='word_1_479' title='bbox 602 2912 629 2936; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_480' title='bbox 644 2912 703 2936; x_wconf 93'>tutti</span>
+      <span class='ocrx_word' id='word_1_481' title='bbox 724 2912 730 2935; x_wconf 92'>i</span>
+      <span class='ocrx_word' id='word_1_482' title='bbox 746 2911 833 2935; x_wconf 92'>detriti</span>
+     </span>
+     <span class='ocr_line' id='line_1_74' title="bbox 194 2948 833 2975; baseline -0.003 -1; x_size 31.961346; x_descenders 7.9613447; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_483' title='bbox 194 2950 295 2975; x_wconf 82'>lasciati</span>
+      <span class='ocrx_word' id='word_1_484' title='bbox 316 2950 356 2975; x_wconf 92'>sul</span>
+      <span class='ocrx_word' id='word_1_485' title='bbox 377 2950 452 2974; x_wconf 92'>suolo</span>
+      <span class='ocrx_word' id='word_1_486' title='bbox 474 2949 611 2974; x_wconf 92'>nazionale</span>
+      <span class='ocrx_word' id='word_1_487' title='bbox 626 2948 668 2972; x_wconf 92'>dai</span>
+      <span class='ocrx_word' id='word_1_488' title='bbox 684 2948 739 2972; x_wconf 92'>vari</span>
+      <span class='ocrx_word' id='word_1_489' title='bbox 753 2948 833 2972; x_wconf 92'>secoli</span>
+     </span>
+     <span class='ocr_line' id='line_1_75' title="bbox 194 2984 832 3019; baseline -0.003 -8; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_490' title='bbox 194 2987 221 3011; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_491' title='bbox 241 2986 426 3011; x_wconf 92'>dominazione</span>
+      <span class='ocrx_word' id='word_1_492' title='bbox 441 2987 510 3019; x_wconf 91'>degli</span>
+      <span class='ocrx_word' id='word_1_493' title='bbox 536 2985 657 3011; x_wconf 91'>stranieri</span>
+      <span class='ocrx_word' id='word_1_494' title='bbox 671 2993 685 3009; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_495' title='bbox 700 2985 742 3009; x_wconf 93'>dei</span>
+      <span class='ocrx_word' id='word_1_496' title='bbox 757 2984 832 3016; x_wconf 89'>preti:</span>
+     </span>
+     <span class='ocr_line' id='line_1_76' title="bbox 195 3021 833 3055; baseline -0.005 -7; x_size 31; x_descenders 7; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_497' title='bbox 195 3032 247 3048; x_wconf 90'>non</span>
+      <span class='ocrx_word' id='word_1_498' title='bbox 269 3028 365 3055; x_wconf 91'>poteva</span>
+      <span class='ocrx_word' id='word_1_499' title='bbox 378 3031 465 3048; x_wconf 92'>essere</span>
+      <span class='ocrx_word' id='word_1_500' title='bbox 483 3023 499 3047; x_wconf 92'>il</span>
+      <span class='ocrx_word' id='word_1_501' title='bbox 514 3031 581 3055; x_wconf 92'>capo</span>
+      <span class='ocrx_word' id='word_1_502' title='bbox 597 3022 640 3046; x_wconf 91'>del</span>
+      <span class='ocrx_word' id='word_1_503' title='bbox 654 3021 833 3053; x_wconf 91'>proletariato,</span>
+     </span>
+     <span class='ocr_line' id='line_1_77' title="bbox 196 3058 834 3090; baseline -0.005 -6; x_size 32; x_descenders 7; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_504' title='bbox 196 3061 310 3084; x_wconf 91'>divenne</span>
+      <span class='ocrx_word' id='word_1_505' title='bbox 331 3060 348 3083; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_506' title='bbox 368 3059 490 3084; x_wconf 92'>dittatore</span>
+      <span class='ocrx_word' id='word_1_507' title='bbox 511 3060 582 3084; x_wconf 90'>della</span>
+      <span class='ocrx_word' id='word_1_508' title='bbox 612 3058 764 3090; x_wconf 89'>borghesia,</span>
+      <span class='ocrx_word' id='word_1_509' title='bbox 786 3058 834 3082; x_wconf 92'>che</span>
+     </span>
+     <span class='ocr_line' id='line_1_78' title="bbox 195 3094 834 3129; baseline -0.006 -8; x_size 32.46376; x_descenders 7.4637609; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_510' title='bbox 195 3106 256 3122; x_wconf 91'>ama</span>
+      <span class='ocrx_word' id='word_1_511' title='bbox 276 3096 299 3121; x_wconf 91'>le</span>
+      <span class='ocrx_word' id='word_1_512' title='bbox 311 3096 395 3121; x_wconf 92'>faccie</span>
+      <span class='ocrx_word' id='word_1_513' title='bbox 408 3096 490 3121; x_wconf 90'>feroci</span>
+      <span class='ocrx_word' id='word_1_514' title='bbox 510 3096 618 3129; x_wconf 90'>quando</span>
+      <span class='ocrx_word' id='word_1_515' title='bbox 633 3094 761 3119; x_wconf 92'>ridiventa</span>
+      <span class='ocrx_word' id='word_1_516' title='bbox 777 3095 834 3119; x_wconf 91'>bor-</span>
+     </span>
+     <span class='ocr_line' id='line_1_79' title="bbox 195 3131 834 3165; baseline -0.006 -7; x_size 28; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_517' title='bbox 195 3134 301 3162; x_wconf 92'>bonica,</span>
+      <span class='ocrx_word' id='word_1_518' title='bbox 322 3133 371 3157; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_519' title='bbox 390 3141 468 3165; x_wconf 91'>spera</span>
+      <span class='ocrx_word' id='word_1_520' title='bbox 487 3133 514 3157; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_521' title='bbox 534 3133 631 3157; x_wconf 92'>vedere</span>
+      <span class='ocrx_word' id='word_1_522' title='bbox 652 3131 722 3155; x_wconf 91'>nella</span>
+      <span class='ocrx_word' id='word_1_523' title='bbox 751 3131 834 3155; x_wconf 91'>classe</span>
+     </span>
+     <span class='ocr_line' id='line_1_80' title="bbox 197 3167 835 3203; baseline -0.006 -8; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_524' title='bbox 197 3170 305 3203; x_wconf 89'>operaia</span>
+      <span class='ocrx_word' id='word_1_525' title='bbox 326 3170 350 3194; x_wconf 92'>lo</span>
+      <span class='ocrx_word' id='word_1_526' title='bbox 371 3174 455 3194; x_wconf 91'>stesso</span>
+      <span class='ocrx_word' id='word_1_527' title='bbox 475 3175 573 3194; x_wconf 91'>terrore</span>
+      <span class='ocrx_word' id='word_1_528' title='bbox 594 3169 643 3193; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_529' title='bbox 657 3176 717 3192; x_wconf 90'>essa</span>
+      <span class='ocrx_word' id='word_1_530' title='bbox 734 3167 835 3192; x_wconf 92'>sentiva</span>
+     </span>
+     <span class='ocr_line' id='line_1_81' title="bbox 195 3202 835 3239; baseline -0.006 -8; x_size 34; x_descenders 8; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_531' title='bbox 195 3216 242 3239; x_wconf 92'>per</span>
+      <span class='ocrx_word' id='word_1_532' title='bbox 262 3206 323 3239; x_wconf 91'>quel</span>
+      <span class='ocrx_word' id='word_1_533' title='bbox 344 3211 446 3230; x_wconf 91'>roteare</span>
+      <span class='ocrx_word' id='word_1_534' title='bbox 473 3206 544 3238; x_wconf 92'>degli</span>
+      <span class='ocrx_word' id='word_1_535' title='bbox 574 3205 651 3230; x_wconf 92'>occhi</span>
+      <span class='ocrx_word' id='word_1_536' title='bbox 672 3213 686 3229; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_537' title='bbox 707 3202 769 3236; x_wconf 91'>quel</span>
+      <span class='ocrx_word' id='word_1_538' title='bbox 790 3212 835 3236; x_wconf 91'>pu-</span>
+     </span>
+     <span class='ocr_line' id='line_1_82' title="bbox 194 3241 670 3276; baseline -0.006 -7; x_size 32; x_descenders 7; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_539' title='bbox 194 3253 248 3276; x_wconf 90'>gno</span>
+      <span class='ocrx_word' id='word_1_540' title='bbox 269 3243 362 3268; x_wconf 91'>chiuso</span>
+      <span class='ocrx_word' id='word_1_541' title='bbox 383 3247 439 3267; x_wconf 92'>teso</span>
+      <span class='ocrx_word' id='word_1_542' title='bbox 460 3242 512 3266; x_wconf 92'>alla</span>
+      <span class='ocrx_word' id='word_1_543' title='bbox 532 3241 670 3266; x_wconf 92'>minaccia.</span>
+     </span>
+    </p>
+
+    <p class='ocr_par' id='par_1_5' lang='ita' title="bbox 194 3278 835 3460">
+     <span class='ocr_line' id='line_1_83' title="bbox 252 3278 835 3310; baseline -0.009 -5; x_size 32; x_descenders 8; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_544' title='bbox 252 3281 289 3305; x_wconf 92'>La</span>
+      <span class='ocrx_word' id='word_1_545' title='bbox 310 3280 435 3304; x_wconf 92'>dittatura</span>
+      <span class='ocrx_word' id='word_1_546' title='bbox 456 3279 498 3303; x_wconf 92'>del</span>
+      <span class='ocrx_word' id='word_1_547' title='bbox 519 3278 689 3310; x_wconf 91'>proletariato</span>
+      <span class='ocrx_word' id='word_1_548' title='bbox 703 3278 717 3301; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_549' title='bbox 738 3285 835 3308; x_wconf 90'>espan-</span>
+     </span>
+     <span class='ocr_line' id='line_1_84' title="bbox 194 3313 835 3348; baseline -0.009 -6; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_550' title='bbox 194 3317 258 3346; x_wconf 92'>siva,</span>
+      <span class='ocrx_word' id='word_1_551' title='bbox 281 3326 334 3342; x_wconf 92'>non</span>
+      <span class='ocrx_word' id='word_1_552' title='bbox 356 3315 513 3348; x_wconf 90'>repressiva.</span>
+      <span class='ocrx_word' id='word_1_553' title='bbox 534 3315 578 3339; x_wconf 90'>Un</span>
+      <span class='ocrx_word' id='word_1_554' title='bbox 599 3314 726 3339; x_wconf 88'>continuo</span>
+      <span class='ocrx_word' id='word_1_555' title='bbox 754 3313 835 3337; x_wconf 88'>movi-</span>
+     </span>
+     <span class='ocr_line' id='line_1_85' title="bbox 194 3350 833 3378; baseline -0.008 0; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_556' title='bbox 194 3359 284 3378; x_wconf 92'>mento</span>
+      <span class='ocrx_word' id='word_1_557' title='bbox 304 3353 326 3378; x_wconf 88'>si</span>
+      <span class='ocrx_word' id='word_1_558' title='bbox 356 3353 463 3377; x_wconf 91'>verifica</span>
+      <span class='ocrx_word' id='word_1_559' title='bbox 493 3351 537 3376; x_wconf 91'>dal</span>
+      <span class='ocrx_word' id='word_1_560' title='bbox 557 3352 636 3375; x_wconf 91'>basso</span>
+      <span class='ocrx_word' id='word_1_561' title='bbox 661 3350 687 3374; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_562' title='bbox 709 3350 771 3378; x_wconf 91'>alto,</span>
+      <span class='ocrx_word' id='word_1_563' title='bbox 799 3358 833 3373; x_wconf 90'>un</span>
+     </span>
+     <span class='ocr_line' id='line_1_86' title="bbox 194 3386 835 3416; baseline -0.011 0; x_size 31.961346; x_descenders 7.9613447; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_564' title='bbox 194 3390 320 3416; x_wconf 91'>continuo</span>
+      <span class='ocrx_word' id='word_1_565' title='bbox 340 3389 468 3414; x_wconf 90'>ricambio</span>
+      <span class='ocrx_word' id='word_1_566' title='bbox 489 3393 634 3415; x_wconf 92'>attraverso</span>
+      <span class='ocrx_word' id='word_1_567' title='bbox 655 3391 720 3411; x_wconf 91'>tutte</span>
+      <span class='ocrx_word' id='word_1_568' title='bbox 749 3386 774 3410; x_wconf 92'>le</span>
+      <span class='ocrx_word' id='word_1_569' title='bbox 794 3394 835 3410; x_wconf 92'>ca-</span>
+     </span>
+     <span class='ocr_line' id='line_1_87' title="bbox 194 3422 833 3460; baseline -0.009 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_570' title='bbox 194 3427 309 3460; x_wconf 91'>pillarità</span>
+      <span class='ocrx_word' id='word_1_571' title='bbox 328 3426 429 3455; x_wconf 91'>sociali,</span>
+      <span class='ocrx_word' id='word_1_572' title='bbox 451 3430 505 3451; x_wconf 92'>una</span>
+      <span class='ocrx_word' id='word_1_573' title='bbox 518 3423 644 3450; x_wconf 91'>continua</span>
+      <span class='ocrx_word' id='word_1_574' title='bbox 658 3422 833 3448; x_wconf 92'>circolazione</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_4' title="bbox 1059 96 1338 120">
+    <p class='ocr_par' id='par_1_6' lang='ita' title="bbox 1059 96 1338 120">
+     <span class='ocr_line' id='line_1_88' title="bbox 1059 96 1338 120; baseline 0.004 -1; x_size 29.666666; x_descenders 7.4166665; x_ascenders 7.4166665">
+      <span class='ocrx_word' id='word_1_575' title='bbox 1059 96 1212 120; x_wconf 62'>L’ORDINE</span>
+      <span class='ocrx_word' id='word_1_576' title='bbox 1228 97 1338 120; x_wconf 87'>NUOVO</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_5' title="bbox 877 179 1519 564">
+    <p class='ocr_par' id='par_1_7' lang='ita' title="bbox 877 179 1519 564">
+     <span class='ocr_line' id='line_1_89' title="bbox 877 179 1517 217; baseline 0.005 -13; x_size 35; x_descenders 9; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_577' title='bbox 877 179 903 204; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_578' title='bbox 925 180 1035 206; x_wconf 71'>uomini.</span>
+      <span class='ocrx_word' id='word_1_579' title='bbox 1050 180 1069 206; x_wconf 60'>Îl</span>
+      <span class='ocrx_word' id='word_1_580' title='bbox 1081 190 1148 215; x_wconf 92'>capo</span>
+      <span class='ocrx_word' id='word_1_581' title='bbox 1161 182 1209 207; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_582' title='bbox 1228 181 1291 217; x_wconf 89'>oggi</span>
+      <span class='ocrx_word' id='word_1_583' title='bbox 1308 182 1462 216; x_wconf 90'>piangiamo</span>
+      <span class='ocrx_word' id='word_1_584' title='bbox 1484 181 1517 207; x_wconf 91'>ha</span>
+     </span>
+     <span class='ocr_line' id='line_1_90' title="bbox 877 220 1516 254; baseline 0.002 -10; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_585' title='bbox 877 225 980 246; x_wconf 88'>trovato</span>
+      <span class='ocrx_word' id='word_1_586' title='bbox 1012 229 1064 245; x_wconf 88'>una</span>
+      <span class='ocrx_word' id='word_1_587' title='bbox 1095 221 1194 246; x_wconf 92'>società</span>
+      <span class='ocrx_word' id='word_1_588' title='bbox 1220 221 1244 246; x_wconf 86'>in</span>
+      <span class='ocrx_word' id='word_1_589' title='bbox 1276 220 1516 254; x_wconf 86'>decomposizione,</span>
+     </span>
+     <span class='ocr_line' id='line_1_91' title="bbox 878 258 1516 291; baseline 0 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_590' title='bbox 878 267 912 283; x_wconf 91'>un</span>
+      <span class='ocrx_word' id='word_1_591' title='bbox 935 258 1082 291; x_wconf 90'>pulviscolo</span>
+      <span class='ocrx_word' id='word_1_592' title='bbox 1103 269 1209 291; x_wconf 91'>umano,</span>
+      <span class='ocrx_word' id='word_1_593' title='bbox 1232 269 1309 285; x_wconf 91'>senza</span>
+      <span class='ocrx_word' id='word_1_594' title='bbox 1334 259 1426 285; x_wconf 92'>ordine</span>
+      <span class='ocrx_word' id='word_1_595' title='bbox 1447 268 1461 284; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_596' title='bbox 1482 259 1516 284; x_wconf 91'>di-</span>
+     </span>
+     <span class='ocr_line' id='line_1_92' title="bbox 880 297 1518 332; baseline 0 -10; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_597' title='bbox 880 297 1000 330; x_wconf 91'>sciplina,</span>
+      <span class='ocrx_word' id='word_1_598' title='bbox 1023 299 1119 331; x_wconf 92'>perchè</span>
+      <span class='ocrx_word' id='word_1_599' title='bbox 1141 299 1166 324; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_600' title='bbox 1188 297 1285 332; x_wconf 91'>cinque</span>
+      <span class='ocrx_word' id='word_1_601' title='bbox 1300 299 1360 324; x_wconf 91'>anni</span>
+      <span class='ocrx_word' id='word_1_602' title='bbox 1377 298 1402 323; x_wconf 93'>di</span>
+      <span class='ocrx_word' id='word_1_603' title='bbox 1423 306 1518 331; x_wconf 92'>guerra</span>
+     </span>
+     <span class='ocr_line' id='line_1_93' title="bbox 880 336 1516 371; baseline -0.002 -10; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_604' title='bbox 880 336 900 361; x_wconf 83'>si</span>
+      <span class='ocrx_word' id='word_1_605' title='bbox 922 345 966 361; x_wconf 88'>era</span>
+      <span class='ocrx_word' id='word_1_606' title='bbox 987 337 1099 362; x_wconf 91'>essicata</span>
+      <span class='ocrx_word' id='word_1_607' title='bbox 1119 337 1144 363; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_608' title='bbox 1165 337 1326 371; x_wconf 91'>produzione</span>
+      <span class='ocrx_word' id='word_1_609' title='bbox 1347 342 1471 371; x_wconf 91'>sorgente</span>
+      <span class='ocrx_word' id='word_1_610' title='bbox 1492 336 1516 361; x_wconf 92'>di</span>
+     </span>
+     <span class='ocr_line' id='line_1_94' title="bbox 881 375 1518 409; baseline 0 -9; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_611' title='bbox 881 375 944 409; x_wconf 91'>ogni</span>
+      <span class='ocrx_word' id='word_1_612' title='bbox 966 375 1018 400; x_wconf 91'>vita</span>
+      <span class='ocrx_word' id='word_1_613' title='bbox 1039 376 1145 402; x_wconf 89'>sociale.</span>
+      <span class='ocrx_word' id='word_1_614' title='bbox 1167 376 1271 401; x_wconf 92'>Tutto</span>
+      <span class='ocrx_word' id='word_1_615' title='bbox 1245 371 1273 414; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_616' title='bbox 1285 382 1353 402; x_wconf 89'>stato</span>
+      <span class='ocrx_word' id='word_1_617' title='bbox 1375 375 1518 401; x_wconf 89'>riordinato</span>
+     </span>
+     <span class='ocr_line' id='line_1_95' title="bbox 881 414 1518 448; baseline -0.002 -9; x_size 35; x_descenders 9; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_618' title='bbox 881 423 895 439; x_wconf 91'>e</span>
+      <span class='ocrx_word' id='word_1_619' title='bbox 916 414 1073 443; x_wconf 91'>ricostruito,</span>
+      <span class='ocrx_word' id='word_1_620' title='bbox 1097 415 1168 440; x_wconf 90'>dalla</span>
+      <span class='ocrx_word' id='word_1_621' title='bbox 1198 414 1317 440; x_wconf 91'>fabbrica</span>
+      <span class='ocrx_word' id='word_1_622' title='bbox 1348 414 1372 440; x_wconf 92'>al</span>
+      <span class='ocrx_word' id='word_1_623' title='bbox 1392 423 1518 448; x_wconf 91'>governo,</span>
+     </span>
+     <span class='ocr_line' id='line_1_96' title="bbox 882 453 1519 483; baseline -0.002 -5; x_size 30; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_624' title='bbox 882 453 923 478; x_wconf 87'>coi</span>
+      <span class='ocrx_word' id='word_1_625' title='bbox 945 454 1032 483; x_wconf 92'>mezzi,</span>
+      <span class='ocrx_word' id='word_1_626' title='bbox 1055 459 1123 479; x_wconf 91'>sotto</span>
+      <span class='ocrx_word' id='word_1_627' title='bbox 1139 454 1162 479; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_628' title='bbox 1177 453 1309 479; x_wconf 92'>direzione</span>
+      <span class='ocrx_word' id='word_1_629' title='bbox 1324 462 1338 478; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_630' title='bbox 1348 453 1370 478; x_wconf 90'>il</span>
+      <span class='ocrx_word' id='word_1_631' title='bbox 1391 453 1519 478; x_wconf 91'>controllo</span>
+     </span>
+     <span class='ocr_line' id='line_1_97' title="bbox 883 491 1518 525; baseline -0.002 -8; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_632' title='bbox 883 492 926 517; x_wconf 92'>del</span>
+      <span class='ocrx_word' id='word_1_633' title='bbox 947 492 1124 525; x_wconf 91'>proletariato,</span>
+      <span class='ocrx_word' id='word_1_634' title='bbox 1137 493 1162 518; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_635' title='bbox 1185 501 1236 517; x_wconf 91'>una</span>
+      <span class='ocrx_word' id='word_1_636' title='bbox 1248 492 1332 518; x_wconf 91'>classe</span>
+      <span class='ocrx_word' id='word_1_637' title='bbox 1344 501 1438 521; x_wconf 92'>nuova,</span>
+      <span class='ocrx_word' id='word_1_638' title='bbox 1454 491 1518 520; x_wconf 80'>cioè,</span>
+     </span>
+     <span class='ocr_line' id='line_1_98' title="bbox 884 531 1262 564; baseline 0.003 -9; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_639' title='bbox 884 531 907 555; x_wconf 90'>al</span>
+      <span class='ocrx_word' id='word_1_640' title='bbox 928 539 1045 564; x_wconf 91'>governo</span>
+      <span class='ocrx_word' id='word_1_641' title='bbox 1067 540 1081 556; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_642' title='bbox 1102 531 1154 556; x_wconf 92'>alla</span>
+      <span class='ocrx_word' id='word_1_643' title='bbox 1174 531 1262 560; x_wconf 92'>storia,</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_6' title="bbox 885 574 1523 1190">
+    <p class='ocr_par' id='par_1_8' lang='ita' title="bbox 885 574 1523 1023">
+     <span class='ocr_line' id='line_1_99' title="bbox 941 574 1520 608; baseline -0.003 -8; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_644' title='bbox 941 576 1033 600; x_wconf 91'>Benito</span>
+      <span class='ocrx_word' id='word_1_645' title='bbox 1055 575 1194 601; x_wconf 91'>Mussolini</span>
+      <span class='ocrx_word' id='word_1_646' title='bbox 1215 575 1249 600; x_wconf 91'>ha</span>
+      <span class='ocrx_word' id='word_1_647' title='bbox 1263 576 1429 608; x_wconf 93'>conquistato</span>
+      <span class='ocrx_word' id='word_1_648' title='bbox 1445 574 1461 599; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_649' title='bbox 1476 583 1520 607; x_wconf 92'>go-</span>
+     </span>
+     <span class='ocr_line' id='line_1_100' title="bbox 885 612 1520 646; baseline -0.002 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_650' title='bbox 885 623 973 643; x_wconf 91'>verno,</span>
+      <span class='ocrx_word' id='word_1_651' title='bbox 996 622 1009 638; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_652' title='bbox 1031 614 1055 639; x_wconf 92'>lo</span>
+      <span class='ocrx_word' id='word_1_653' title='bbox 1077 614 1209 639; x_wconf 92'>mantiene</span>
+      <span class='ocrx_word' id='word_1_654' title='bbox 1230 623 1279 639; x_wconf 92'>con</span>
+      <span class='ocrx_word' id='word_1_655' title='bbox 1301 614 1325 642; x_wconf 89'>la</span>
+      <span class='ocrx_word' id='word_1_656' title='bbox 1355 612 1520 646; x_wconf 89'>repressione</span>
+     </span>
+     <span class='ocr_line' id='line_1_101' title="bbox 886 647 1521 686; baseline -0.002 -9; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_657' title='bbox 886 652 930 686; x_wconf 93'>più</span>
+      <span class='ocrx_word' id='word_1_658' title='bbox 951 652 1065 677; x_wconf 92'>violenta</span>
+      <span class='ocrx_word' id='word_1_659' title='bbox 1086 661 1099 677; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_660' title='bbox 1111 647 1264 678; x_wconf 86'>arbitraria.</span>
+      <span class='ocrx_word' id='word_1_661' title='bbox 1287 652 1345 685; x_wconf 92'>Egli</span>
+      <span class='ocrx_word' id='word_1_662' title='bbox 1362 661 1413 677; x_wconf 91'>non</span>
+      <span class='ocrx_word' id='word_1_663' title='bbox 1429 651 1462 676; x_wconf 93'>ha</span>
+      <span class='ocrx_word' id='word_1_664' title='bbox 1474 651 1521 676; x_wconf 92'>do-</span>
+     </span>
+     <span class='ocr_line' id='line_1_102' title="bbox 886 689 1521 724; baseline -0.002 -9; x_size 34; x_descenders 9; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_665' title='bbox 886 696 948 715; x_wconf 92'>vuto</span>
+      <span class='ocrx_word' id='word_1_666' title='bbox 969 691 1137 724; x_wconf 91'>organizzare</span>
+      <span class='ocrx_word' id='word_1_667' title='bbox 1158 700 1210 716; x_wconf 91'>una</span>
+      <span class='ocrx_word' id='word_1_668' title='bbox 1240 690 1331 720; x_wconf 91'>classe,</span>
+      <span class='ocrx_word' id='word_1_669' title='bbox 1364 699 1406 715; x_wconf 92'>ma</span>
+      <span class='ocrx_word' id='word_1_670' title='bbox 1426 690 1483 715; x_wconf 90'>solo</span>
+      <span class='ocrx_word' id='word_1_671' title='bbox 1504 689 1521 714; x_wconf 91'>il</span>
+     </span>
+     <span class='ocr_line' id='line_1_103' title="bbox 887 728 1520 762; baseline -0.003 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_672' title='bbox 887 730 1025 762; x_wconf 91'>personale</span>
+      <span class='ocrx_word' id='word_1_673' title='bbox 1036 729 1158 754; x_wconf 90'>d’ordine</span>
+      <span class='ocrx_word' id='word_1_674' title='bbox 1169 729 1195 754; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_675' title='bbox 1210 738 1262 754; x_wconf 92'>una</span>
+      <span class='ocrx_word' id='word_1_676' title='bbox 1273 728 1520 754; x_wconf 91'>amministrazione.</span>
+     </span>
+     <span class='ocr_line' id='line_1_104' title="bbox 888 766 1521 801; baseline -0.002 -9; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_677' title='bbox 888 768 930 793; x_wconf 91'>Ha</span>
+      <span class='ocrx_word' id='word_1_678' title='bbox 944 773 1075 793; x_wconf 92'>smontato</span>
+      <span class='ocrx_word' id='word_1_679' title='bbox 1087 768 1199 801; x_wconf 92'>qualche</span>
+      <span class='ocrx_word' id='word_1_680' title='bbox 1208 776 1348 801; x_wconf 91'>congegno</span>
+      <span class='ocrx_word' id='word_1_681' title='bbox 1360 766 1430 791; x_wconf 91'>dello</span>
+      <span class='ocrx_word' id='word_1_682' title='bbox 1438 767 1521 795; x_wconf 91'>Stato,</span>
+     </span>
+     <span class='ocr_line' id='line_1_105' title="bbox 888 804 1522 839; baseline -0.003 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_683' title='bbox 888 806 931 839; x_wconf 92'>più</span>
+      <span class='ocrx_word' id='word_1_684' title='bbox 954 815 1000 839; x_wconf 92'>per</span>
+      <span class='ocrx_word' id='word_1_685' title='bbox 1020 806 1115 831; x_wconf 92'>vedere</span>
+      <span class='ocrx_word' id='word_1_686' title='bbox 1139 807 1253 831; x_wconf 92'>com’era</span>
+      <span class='ocrx_word' id='word_1_687' title='bbox 1283 806 1348 830; x_wconf 93'>fatto</span>
+      <span class='ocrx_word' id='word_1_688' title='bbox 1369 814 1382 830; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_689' title='bbox 1404 804 1522 838; x_wconf 91'>imprati-</span>
+     </span>
+     <span class='ocr_line' id='line_1_106' title="bbox 888 843 1523 877; baseline -0.002 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_690' title='bbox 888 844 966 870; x_wconf 92'>chirsi</span>
+      <span class='ocrx_word' id='word_1_691' title='bbox 988 844 1030 869; x_wconf 92'>del</span>
+      <span class='ocrx_word' id='word_1_692' title='bbox 1052 844 1173 870; x_wconf 91'>mestiere</span>
+      <span class='ocrx_word' id='word_1_693' title='bbox 1193 845 1241 870; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_694' title='bbox 1262 853 1308 877; x_wconf 91'>per</span>
+      <span class='ocrx_word' id='word_1_695' title='bbox 1328 852 1380 868; x_wconf 93'>una</span>
+      <span class='ocrx_word' id='word_1_696' title='bbox 1395 843 1523 869; x_wconf 91'>necessità</span>
+     </span>
+     <span class='ocr_line' id='line_1_107' title="bbox 889 881 1523 916; baseline -0.003 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_697' title='bbox 889 883 1040 916; x_wconf 92'>originaria.</span>
+      <span class='ocrx_word' id='word_1_698' title='bbox 1062 883 1099 908; x_wconf 91'>La</span>
+      <span class='ocrx_word' id='word_1_699' title='bbox 1120 892 1167 908; x_wconf 92'>sua</span>
+      <span class='ocrx_word' id='word_1_700' title='bbox 1186 883 1301 908; x_wconf 93'>dottrina</span>
+      <span class='ocrx_word' id='word_1_701' title='bbox 1322 883 1335 907; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_702' title='bbox 1359 887 1425 907; x_wconf 89'>tutta</span>
+      <span class='ocrx_word' id='word_1_703' title='bbox 1455 881 1523 906; x_wconf 89'>nella</span>
+     </span>
+     <span class='ocr_line' id='line_1_108' title="bbox 890 919 1521 953; baseline -0.003 -7; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_704' title='bbox 890 922 1026 947; x_wconf 92'>maschera</span>
+      <span class='ocrx_word' id='word_1_705' title='bbox 1047 921 1126 951; x_wconf 91'>fisica,</span>
+      <span class='ocrx_word' id='word_1_706' title='bbox 1149 922 1190 946; x_wconf 92'>nel</span>
+      <span class='ocrx_word' id='word_1_707' title='bbox 1215 926 1314 946; x_wconf 91'>reteare</span>
+      <span class='ocrx_word' id='word_1_708' title='bbox 1344 920 1414 953; x_wconf 90'>degli</span>
+      <span class='ocrx_word' id='word_1_709' title='bbox 1446 919 1521 945; x_wconf 90'>occhi</span>
+     </span>
+     <span class='ocr_line' id='line_1_109' title="bbox 889 958 1523 993; baseline -0.003 -9; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_710' title='bbox 889 965 963 985; x_wconf 89'>entro</span>
+      <span class='ocrx_word' id='word_1_711' title='bbox 984 959 1095 992; x_wconf 89'>l’orbite,</span>
+      <span class='ocrx_word' id='word_1_712' title='bbox 1117 959 1159 984; x_wconf 92'>nel</span>
+      <span class='ocrx_word' id='word_1_713' title='bbox 1180 968 1270 993; x_wconf 92'>pugno</span>
+      <span class='ocrx_word' id='word_1_714' title='bbox 1298 958 1389 984; x_wconf 92'>chiuso</span>
+      <span class='ocrx_word' id='word_1_715' title='bbox 1420 967 1523 991; x_wconf 91'>sempre</span>
+     </span>
+     <span class='ocr_line' id='line_1_110' title="bbox 889 997 1174 1023; baseline -0.004 0; x_size 33.204643; x_descenders 8.2046432; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_716' title='bbox 889 1004 945 1023; x_wconf 92'>teso</span>
+      <span class='ocrx_word' id='word_1_717' title='bbox 967 998 1018 1023; x_wconf 91'>alla</span>
+      <span class='ocrx_word' id='word_1_718' title='bbox 1039 997 1174 1023; x_wconf 92'>minaccia.</span>
+     </span>
+    </p>
+
+    <p class='ocr_par' id='par_1_9' lang='ita' title="bbox 890 1040 1523 1190">
+     <span class='ocr_line' id='line_1_111' title="bbox 947 1040 1523 1074; baseline -0.003 -7; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_719' title='bbox 947 1043 1031 1068; x_wconf 90'>Roma</span>
+      <span class='ocrx_word' id='word_1_720' title='bbox 1052 1051 1103 1067; x_wconf 90'>non</span>
+      <span class='ocrx_word' id='word_1_721' title='bbox 1125 1043 1138 1067; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_722' title='bbox 1160 1051 1246 1067; x_wconf 92'>nuova</span>
+      <span class='ocrx_word' id='word_1_723' title='bbox 1267 1051 1281 1067; x_wconf 90'>a</span>
+      <span class='ocrx_word' id='word_1_724' title='bbox 1307 1041 1390 1074; x_wconf 90'>questi</span>
+      <span class='ocrx_word' id='word_1_725' title='bbox 1422 1040 1523 1066; x_wconf 91'>scenari</span>
+     </span>
+     <span class='ocr_line' id='line_1_112' title="bbox 890 1079 1523 1114; baseline -0.003 -8; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_726' title='bbox 890 1080 1029 1114; x_wconf 91'>polverosi.</span>
+      <span class='ocrx_word' id='word_1_727' title='bbox 1052 1081 1094 1105; x_wconf 89'>Ha</span>
+      <span class='ocrx_word' id='word_1_728' title='bbox 1115 1081 1182 1106; x_wconf 89'>visto</span>
+      <span class='ocrx_word' id='word_1_729' title='bbox 1203 1080 1325 1109; x_wconf 90'>Romolo,</span>
+      <span class='ocrx_word' id='word_1_730' title='bbox 1348 1079 1381 1104; x_wconf 92'>ha</span>
+      <span class='ocrx_word' id='word_1_731' title='bbox 1396 1079 1462 1105; x_wconf 91'>visto</span>
+      <span class='ocrx_word' id='word_1_732' title='bbox 1477 1079 1523 1104; x_wconf 93'>Ce-</span>
+     </span>
+     <span class='ocr_line' id='line_1_113' title="bbox 890 1119 1523 1152; baseline -0.003 -8; x_size 29; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_733' title='bbox 890 1128 947 1144; x_wconf 91'>sare</span>
+      <span class='ocrx_word' id='word_1_734' title='bbox 968 1120 1089 1152; x_wconf 91'>Augusto</span>
+      <span class='ocrx_word' id='word_1_735' title='bbox 1104 1128 1118 1143; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_736' title='bbox 1133 1119 1166 1144; x_wconf 92'>ha</span>
+      <span class='ocrx_word' id='word_1_737' title='bbox 1180 1119 1255 1150; x_wconf 91'>visto,</span>
+      <span class='ocrx_word' id='word_1_738' title='bbox 1270 1119 1294 1144; x_wconf 91'>al</span>
+      <span class='ocrx_word' id='word_1_739' title='bbox 1315 1126 1363 1143; x_wconf 91'>suo</span>
+      <span class='ocrx_word' id='word_1_740' title='bbox 1384 1123 1523 1146; x_wconf 90'>tramonto,</span>
+     </span>
+     <span class='ocr_line' id='line_1_114' title="bbox 890 1157 1182 1190; baseline 0 -8; x_size 33; x_descenders 8; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_741' title='bbox 890 1157 1003 1183; x_wconf 92'>Romolo</span>
+      <span class='ocrx_word' id='word_1_742' title='bbox 1024 1157 1182 1190; x_wconf 86'>Augustolo.</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_7' title="bbox 898 1242 1523 1249">
+    <p class='ocr_par' id='par_1_10' lang='ita' title="bbox 898 1242 1523 1249">
+     <span class='ocr_line' id='line_1_115' title="bbox 898 1242 1523 1249; baseline 0 0; x_size 3.5; x_descenders -1.75; x_ascenders 1.75">
+      <span class='ocrx_word' id='word_1_743' title='bbox 898 1242 1523 1249; x_wconf 95'> </span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_8' title="bbox 891 1287 1525 2211">
+    <p class='ocr_par' id='par_1_11' lang='ita' title="bbox 891 1287 1525 2211">
+     <span class='ocr_line' id='line_1_116' title="bbox 922 1287 1523 1314; baseline -0.007 -4; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_744' title='bbox 922 1290 1027 1311; x_wconf 91'>Nessuna</span>
+      <span class='ocrx_word' id='word_1_745' title='bbox 1042 1289 1198 1314; x_wconf 91'>proposizione</span>
+      <span class='ocrx_word' id='word_1_746' title='bbox 1214 1288 1325 1313; x_wconf 90'>filosofica</span>
+      <span class='ocrx_word' id='word_1_747' title='bbox 1341 1289 1359 1309; x_wconf 78'>si</span>
+      <span class='ocrx_word' id='word_1_748' title='bbox 1374 1287 1384 1307; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_749' title='bbox 1401 1287 1445 1307; x_wconf 91'>mai</span>
+      <span class='ocrx_word' id='word_1_750' title='bbox 1462 1288 1523 1307; x_wconf 91'>tanto</span>
+     </span>
+     <span class='ocr_line' id='line_1_117' title="bbox 894 1318 1524 1346; baseline -0.008 -2; x_size 26; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_751' title='bbox 894 1324 983 1344; x_wconf 91'>attirata</span>
+      <span class='ocrx_word' id='word_1_752' title='bbox 1001 1323 1021 1343; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_753' title='bbox 1037 1323 1195 1343; x_wconf 91'>riconoscenza</span>
+      <span class='ocrx_word' id='word_1_754' title='bbox 1213 1321 1235 1341; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_755' title='bbox 1250 1321 1345 1346; x_wconf 90'>governi</span>
+      <span class='ocrx_word' id='word_1_756' title='bbox 1361 1320 1429 1346; x_wconf 92'>gretti</span>
+      <span class='ocrx_word' id='word_1_757' title='bbox 1446 1326 1456 1339; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_758' title='bbox 1474 1318 1524 1340; x_wconf 56'>l’iru</span>
+     </span>
+     <span class='ocr_line' id='line_1_118' title="bbox 894 1353 1522 1380; baseline -0.008 -4; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_759' title='bbox 894 1357 916 1376; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_760' title='bbox 931 1356 1060 1376; x_wconf 92'>altrettanto</span>
+      <span class='ocrx_word' id='word_1_761' title='bbox 1075 1355 1144 1380; x_wconf 91'>gretti</span>
+      <span class='ocrx_word' id='word_1_762' title='bbox 1160 1354 1247 1375; x_wconf 91'>liberali</span>
+      <span class='ocrx_word' id='word_1_763' title='bbox 1262 1360 1323 1374; x_wconf 92'>come</span>
+      <span class='ocrx_word' id='word_1_764' title='bbox 1340 1353 1361 1374; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_765' title='bbox 1372 1353 1459 1378; x_wconf 89'>famosa</span>
+      <span class='ocrx_word' id='word_1_766' title='bbox 1474 1353 1522 1377; x_wconf 91'>pro-</span>
+     </span>
+     <span class='ocr_line' id='line_1_119' title="bbox 894 1383 1522 1412; baseline -0.008 -4; x_size 27; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_767' title='bbox 894 1388 1005 1412; x_wconf 92'>posizione</span>
+      <span class='ocrx_word' id='word_1_768' title='bbox 1023 1387 1045 1407; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_769' title='bbox 1061 1384 1149 1412; x_wconf 90'>Hegel:</span>
+      <span class='ocrx_word' id='word_1_770' title='bbox 1171 1394 1180 1406; x_wconf 90'>«</span>
+      <span class='ocrx_word' id='word_1_771' title='bbox 1207 1384 1275 1407; x_wconf 88'>Tutto</span>
+      <span class='ocrx_word' id='word_1_772' title='bbox 1294 1385 1327 1405; x_wconf 92'>ciò</span>
+      <span class='ocrx_word' id='word_1_773' title='bbox 1344 1385 1382 1405; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_774' title='bbox 1401 1384 1410 1404; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_775' title='bbox 1428 1383 1494 1408; x_wconf 92'>reale,</span>
+      <span class='ocrx_word' id='word_1_776' title='bbox 1513 1383 1522 1402; x_wconf 96'>è</span>
+     </span>
+     <span class='ocr_line' id='line_1_120' title="bbox 894 1416 1511 1441; baseline -0.008 0; x_size 25; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_777' title='bbox 894 1420 1003 1441; x_wconf 65'>razionale</span>
+      <span class='ocrx_word' id='word_1_778' title='bbox 1022 1426 1031 1439; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_779' title='bbox 1049 1420 1107 1440; x_wconf 91'>tutto</span>
+      <span class='ocrx_word' id='word_1_780' title='bbox 1127 1418 1159 1439; x_wconf 91'>ciò</span>
+      <span class='ocrx_word' id='word_1_781' title='bbox 1178 1419 1216 1438; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_782' title='bbox 1235 1418 1244 1438; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_783' title='bbox 1262 1416 1382 1441; x_wconf 91'>razionale,</span>
+      <span class='ocrx_word' id='word_1_784' title='bbox 1400 1416 1409 1436; x_wconf 92'>è</span>
+      <span class='ocrx_word' id='word_1_785' title='bbox 1427 1416 1484 1437; x_wconf 91'>reale</span>
+      <span class='ocrx_word' id='word_1_786' title='bbox 1502 1423 1511 1434; x_wconf 92'>»</span>
+     </span>
+     <span class='ocr_line' id='line_1_121' title="bbox 894 1447 1521 1476; baseline -0.005 -5; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_787' title='bbox 894 1451 977 1476; x_wconf 90'>Questo</span>
+      <span class='ocrx_word' id='word_1_788' title='bbox 1000 1458 1037 1472; x_wconf 27'>erna</span>
+      <span class='ocrx_word' id='word_1_789' title='bbox 1060 1450 1237 1471; x_wconf 90'>evidentemente</span>
+      <span class='ocrx_word' id='word_1_790' title='bbox 1261 1450 1280 1470; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_791' title='bbox 1302 1447 1478 1469; x_wconf 90'>divinizzazione</span>
+      <span class='ocrx_word' id='word_1_792' title='bbox 1501 1448 1521 1468; x_wconf 90'>di</span>
+     </span>
+     <span class='ocr_line' id='line_1_122' title="bbox 895 1481 1522 1508; baseline -0.006 -3; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_793' title='bbox 895 1487 952 1505; x_wconf 91'>tutto</span>
+      <span class='ocrx_word' id='word_1_794' title='bbox 970 1484 1003 1504; x_wconf 92'>ciò</span>
+      <span class='ocrx_word' id='word_1_795' title='bbox 1021 1484 1060 1504; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_796' title='bbox 1078 1484 1151 1508; x_wconf 90'>esiste,</span>
+      <span class='ocrx_word' id='word_1_797' title='bbox 1170 1483 1190 1503; x_wconf 90'>la</span>
+      <span class='ocrx_word' id='word_1_798' title='bbox 1208 1482 1377 1503; x_wconf 91'>consacrazione</span>
+      <span class='ocrx_word' id='word_1_799' title='bbox 1396 1482 1431 1502; x_wconf 93'>del</span>
+      <span class='ocrx_word' id='word_1_800' title='bbox 1450 1481 1522 1506; x_wconf 90'>dispo-</span>
+     </span>
+     <span class='ocr_line' id='line_1_123' title="bbox 894 1513 1521 1541; baseline -0.006 -5; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_801' title='bbox 894 1517 967 1541; x_wconf 90'>tismo,</span>
+      <span class='ocrx_word' id='word_1_802' title='bbox 990 1516 1047 1536; x_wconf 92'>dello</span>
+      <span class='ocrx_word' id='word_1_803' title='bbox 1067 1518 1125 1536; x_wconf 88'>statio</span>
+      <span class='ocrx_word' id='word_1_804' title='bbox 1146 1515 1168 1535; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_805' title='bbox 1187 1514 1276 1539; x_wconf 39'>piolizia,</span>
+      <span class='ocrx_word' id='word_1_806' title='bbox 1298 1514 1356 1534; x_wconf 92'>della</span>
+      <span class='ocrx_word' id='word_1_807' title='bbox 1374 1513 1480 1537; x_wconf 78'>giustizia</span>
+      <span class='ocrx_word' id='word_1_808' title='bbox 1500 1513 1521 1532; x_wconf 78'>di</span>
+     </span>
+     <span class='ocr_line' id='line_1_124' title="bbox 892 1545 1521 1574; baseline -0.006 -5; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_809' title='bbox 892 1549 1016 1574; x_wconf 86'>gabinetto,</span>
+      <span class='ocrx_word' id='word_1_810' title='bbox 1035 1548 1093 1568; x_wconf 91'>della</span>
+      <span class='ocrx_word' id='word_1_811' title='bbox 1110 1553 1209 1568; x_wconf 91'>censura.</span>
+      <span class='ocrx_word' id='word_1_812' title='bbox 1228 1546 1247 1566; x_wconf 90'>E</span>
+      <span class='ocrx_word' id='word_1_813' title='bbox 1265 1546 1308 1567; x_wconf 90'>così</span>
+      <span class='ocrx_word' id='word_1_814' title='bbox 1325 1545 1465 1571; x_wconf 88'>l’interpretò</span>
+      <span class='ocrx_word' id='word_1_815' title='bbox 1481 1545 1521 1565; x_wconf 61'>Fe-</span>
+     </span>
+     <span class='ocr_line' id='line_1_125' title="bbox 894 1577 1522 1605; baseline -0.005 -5; x_size 26; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_816' title='bbox 894 1581 967 1602; x_wconf 91'>derico</span>
+      <span class='ocrx_word' id='word_1_817' title='bbox 987 1579 1115 1605; x_wconf 91'>Guglielmo</span>
+      <span class='ocrx_word' id='word_1_818' title='bbox 1134 1579 1178 1604; x_wconf 53'>IIT,</span>
+      <span class='ocrx_word' id='word_1_819' title='bbox 1199 1578 1244 1600; x_wconf 91'>così</span>
+      <span class='ocrx_word' id='word_1_820' title='bbox 1263 1580 1269 1599; x_wconf 92'>i</span>
+      <span class='ocrx_word' id='word_1_821' title='bbox 1286 1580 1336 1600; x_wconf 92'>suoi</span>
+      <span class='ocrx_word' id='word_1_822' title='bbox 1354 1578 1447 1599; x_wconf 86'>sudditi.</span>
+      <span class='ocrx_word' id='word_1_823' title='bbox 1484 1577 1522 1597; x_wconf 60'>Ma</span>
+     </span>
+     <span class='ocr_line' id='line_1_126' title="bbox 894 1607 1522 1638; baseline -0.003 -6; x_size 26; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_824' title='bbox 894 1615 968 1638; x_wconf 91'>presso</span>
+      <span class='ocrx_word' id='word_1_825' title='bbox 985 1611 1058 1637; x_wconf 91'>Hegel</span>
+      <span class='ocrx_word' id='word_1_826' title='bbox 1078 1614 1135 1633; x_wconf 81'>tutto</span>
+      <span class='ocrx_word' id='word_1_827' title='bbox 1155 1611 1188 1632; x_wconf 91'>ciò</span>
+      <span class='ocrx_word' id='word_1_828' title='bbox 1208 1612 1247 1632; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_829' title='bbox 1267 1612 1330 1631; x_wconf 92'>esiste</span>
+      <span class='ocrx_word' id='word_1_830' title='bbox 1349 1617 1394 1631; x_wconf 87'>non</span>
+      <span class='ocrx_word' id='word_1_831' title='bbox 1414 1610 1423 1630; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_832' title='bbox 1441 1607 1522 1636; x_wconf 88'>punto,</span>
+     </span>
+     <span class='ocr_line' id='line_1_127' title="bbox 894 1643 1523 1669; baseline -0.006 -3; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_833' title='bbox 894 1645 1020 1669; x_wconf 90'>senz’altro,</span>
+      <span class='ocrx_word' id='word_1_834' title='bbox 1041 1645 1110 1665; x_wconf 90'>anche</span>
+      <span class='ocrx_word' id='word_1_835' title='bbox 1131 1644 1195 1664; x_wconf 92'>reale.</span>
+      <span class='ocrx_word' id='word_1_836' title='bbox 1218 1643 1356 1664; x_wconf 90'>L’attributo</span>
+      <span class='ocrx_word' id='word_1_837' title='bbox 1377 1643 1435 1663; x_wconf 91'>della</span>
+      <span class='ocrx_word' id='word_1_838' title='bbox 1454 1643 1523 1663; x_wconf 91'>realtà</span>
+     </span>
+     <span class='ocr_line' id='line_1_128' title="bbox 894 1675 1523 1702; baseline -0.005 -5; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_839' title='bbox 894 1678 903 1698; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_840' title='bbox 919 1678 1016 1702; x_wconf 90'>proprio,</span>
+      <span class='ocrx_word' id='word_1_841' title='bbox 1032 1679 1106 1701; x_wconf 92'>presso</span>
+      <span class='ocrx_word' id='word_1_842' title='bbox 1122 1677 1160 1700; x_wconf 86'>lui,</span>
+      <span class='ocrx_word' id='word_1_843' title='bbox 1176 1677 1223 1697; x_wconf 91'>solo</span>
+      <span class='ocrx_word' id='word_1_844' title='bbox 1238 1676 1260 1697; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_845' title='bbox 1276 1676 1308 1696; x_wconf 0'>iò</span>
+      <span class='ocrx_word' id='word_1_846' title='bbox 1324 1676 1363 1695; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_847' title='bbox 1380 1675 1398 1699; x_wconf 93'>è,</span>
+      <span class='ocrx_word' id='word_1_848' title='bbox 1414 1675 1435 1695; x_wconf 92'>al</span>
+      <span class='ocrx_word' id='word_1_849' title='bbox 1448 1676 1523 1699; x_wconf 92'>tempo</span>
+     </span>
+     <span class='ocr_line' id='line_1_129' title="bbox 893 1708 1523 1734; baseline -0.005 -4; x_size 23; x_descenders 3; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_850' title='bbox 893 1712 971 1734; x_wconf 90'>stesso,</span>
+      <span class='ocrx_word' id='word_1_851' title='bbox 991 1710 1124 1732; x_wconf 91'>necessario;</span>
+      <span class='ocrx_word' id='word_1_852' title='bbox 1145 1717 1153 1728; x_wconf 51'>«</span>
+      <span class='ocrx_word' id='word_1_853' title='bbox 1166 1709 1186 1729; x_wconf 51'>la</span>
+      <span class='ocrx_word' id='word_1_854' title='bbox 1204 1708 1274 1729; x_wconf 90'>realtà</span>
+      <span class='ocrx_word' id='word_1_855' title='bbox 1291 1708 1310 1728; x_wconf 82'>si</span>
+      <span class='ocrx_word' id='word_1_856' title='bbox 1328 1710 1412 1728; x_wconf 90'>mostra</span>
+      <span class='ocrx_word' id='word_1_857' title='bbox 1428 1708 1465 1728; x_wconf 88'>nel</span>
+      <span class='ocrx_word' id='word_1_858' title='bbox 1483 1714 1523 1727; x_wconf 92'>suo</span>
+     </span>
+     <span class='ocr_line' id='line_1_130' title="bbox 893 1739 1523 1767; baseline -0.005 -5; x_size 26; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_859' title='bbox 893 1740 1042 1767; x_wconf 90'>svolgimento</span>
+      <span class='ocrx_word' id='word_1_860' title='bbox 1059 1747 1119 1761; x_wconf 92'>come</span>
+      <span class='ocrx_word' id='word_1_861' title='bbox 1137 1740 1247 1761; x_wconf 90'>necessità</span>
+      <span class='ocrx_word' id='word_1_862' title='bbox 1256 1747 1275 1765; x_wconf 80'>»;</span>
+      <span class='ocrx_word' id='word_1_863' title='bbox 1292 1748 1338 1761; x_wconf 90'>una</span>
+      <span class='ocrx_word' id='word_1_864' title='bbox 1351 1739 1469 1760; x_wconf 90'>arbitraria</span>
+      <span class='ocrx_word' id='word_1_865' title='bbox 1484 1739 1523 1759; x_wconf 90'>mi-</span>
+     </span>
+     <span class='ocr_line' id='line_1_131' title="bbox 892 1771 1523 1799; baseline -0.005 -5; x_size 26; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_866' title='bbox 892 1781 944 1794; x_wconf 91'>sura</span>
+      <span class='ocrx_word' id='word_1_867' title='bbox 963 1774 985 1793; x_wconf 90'>di</span>
+      <span class='ocrx_word' id='word_1_868' title='bbox 1003 1780 1102 1799; x_wconf 91'>governo</span>
+      <span class='ocrx_word' id='word_1_869' title='bbox 1122 1785 1150 1787; x_wconf 93'>—</span>
+      <span class='ocrx_word' id='word_1_870' title='bbox 1170 1771 1244 1798; x_wconf 90'>Hegel</span>
+      <span class='ocrx_word' id='word_1_871' title='bbox 1262 1774 1328 1798; x_wconf 91'>porta</span>
+      <span class='ocrx_word' id='word_1_872' title='bbox 1346 1772 1417 1793; x_wconf 90'>anche</span>
+      <span class='ocrx_word' id='word_1_873' title='bbox 1438 1771 1523 1791; x_wconf 91'>l’esem-</span>
+     </span>
+     <span class='ocr_line' id='line_1_132' title="bbox 893 1804 1523 1830; baseline 0 -6; x_size 26; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_874' title='bbox 893 1807 928 1830; x_wconf 91'>pio</span>
+      <span class='ocrx_word' id='word_1_875' title='bbox 950 1814 958 1824; x_wconf 84'>«</span>
+      <span class='ocrx_word' id='word_1_876' title='bbox 971 1806 993 1825; x_wconf 89'>di</span>
+      <span class='ocrx_word' id='word_1_877' title='bbox 1012 1813 1042 1826; x_wconf 90'>un</span>
+      <span class='ocrx_word' id='word_1_878' title='bbox 1062 1805 1122 1826; x_wconf 65'>certo</span>
+      <span class='ocrx_word' id='word_1_879' title='bbox 1141 1805 1233 1826; x_wconf 92'>sistema</span>
+      <span class='ocrx_word' id='word_1_880' title='bbox 1252 1804 1274 1825; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_881' title='bbox 1292 1805 1408 1829; x_wconf 89'>imposta»</span>
+      <span class='ocrx_word' id='word_1_882' title='bbox 1430 1815 1459 1817; x_wconf 92'>—</span>
+      <span class='ocrx_word' id='word_1_883' title='bbox 1478 1807 1523 1824; x_wconf 89'>non</span>
+     </span>
+     <span class='ocr_line' id='line_1_133' title="bbox 892 1830 1523 1863; baseline -0.005 -4; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_884' title='bbox 892 1839 940 1859; x_wconf 88'>vale</span>
+      <span class='ocrx_word' id='word_1_885' title='bbox 960 1838 1042 1863; x_wconf 92'>perciò,</span>
+      <span class='ocrx_word' id='word_1_886' title='bbox 1061 1840 1101 1862; x_wconf 91'>per</span>
+      <span class='ocrx_word' id='word_1_887' title='bbox 1120 1837 1158 1862; x_wconf 89'>lui,</span>
+      <span class='ocrx_word' id='word_1_888' title='bbox 1173 1830 1250 1862; x_wconf 47'><strong><em>‘v‘p&#39;unto</em></strong></span>
+      <span class='ocrx_word' id='word_1_889' title='bbox 1272 1843 1333 1858; x_wconf 90'>come</span>
+      <span class='ocrx_word' id='word_1_890' title='bbox 1352 1837 1410 1857; x_wconf 91'>reale</span>
+      <span class='ocrx_word' id='word_1_891' title='bbox 1431 1836 1523 1857; x_wconf 90'>senz’al-</span>
+     </span>
+     <span class='ocr_line' id='line_1_134' title="bbox 894 1869 1524 1894; baseline -0.003 -4; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_892' title='bbox 894 1873 934 1891; x_wconf 91'>tro.</span>
+      <span class='ocrx_word' id='word_1_893' title='bbox 952 1869 986 1891; x_wconf 93'>Ma</span>
+      <span class='ocrx_word' id='word_1_894' title='bbox 1003 1870 1035 1890; x_wconf 91'>ciò</span>
+      <span class='ocrx_word' id='word_1_895' title='bbox 1051 1870 1090 1890; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_896' title='bbox 1106 1869 1115 1889; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_897' title='bbox 1133 1870 1264 1894; x_wconf 89'>necessario,</span>
+      <span class='ocrx_word' id='word_1_898' title='bbox 1279 1871 1303 1890; x_wconf 53'>si</span>
+      <span class='ocrx_word' id='word_1_899' title='bbox 1314 1869 1390 1893; x_wconf 90'>rivela,</span>
+      <span class='ocrx_word' id='word_1_900' title='bbox 1406 1869 1429 1890; x_wconf 92'>in</span>
+      <span class='ocrx_word' id='word_1_901' title='bbox 1444 1869 1524 1889; x_wconf 89'>ultima</span>
+     </span>
+     <span class='ocr_line' id='line_1_135' title="bbox 894 1901 1523 1926; baseline 0.002 -5; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_902' title='bbox 894 1902 985 1926; x_wconf 91'>istanza,</span>
+      <span class='ocrx_word' id='word_1_903' title='bbox 1006 1902 1076 1923; x_wconf 90'>anche</span>
+      <span class='ocrx_word' id='word_1_904' title='bbox 1098 1908 1158 1922; x_wconf 92'>come</span>
+      <span class='ocrx_word' id='word_1_905' title='bbox 1179 1901 1298 1924; x_wconf 91'>razionale;</span>
+      <span class='ocrx_word' id='word_1_906' title='bbox 1319 1908 1329 1921; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_907' title='bbox 1349 1901 1463 1926; x_wconf 76'>applicata</span>
+      <span class='ocrx_word' id='word_1_908' title='bbox 1481 1901 1523 1922; x_wconf 76'>allo</span>
+     </span>
+     <span class='ocr_line' id='line_1_136' title="bbox 892 1931 1524 1959; baseline -0.003 -5; x_size 28; x_descenders 5; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_909' title='bbox 892 1931 955 1955; x_wconf 90'>Stato</span>
+      <span class='ocrx_word' id='word_1_910' title='bbox 973 1934 1090 1959; x_wconf 91'>prussiano</span>
+      <span class='ocrx_word' id='word_1_911' title='bbox 1108 1933 1209 1958; x_wconf 90'>d’allora,</span>
+      <span class='ocrx_word' id='word_1_912' title='bbox 1229 1934 1250 1955; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_913' title='bbox 1266 1931 1421 1958; x_wconf 90'>proposizione</span>
+      <span class='ocrx_word' id='word_1_914' title='bbox 1440 1932 1462 1952; x_wconf 90'>di</span>
+      <span class='ocrx_word' id='word_1_915' title='bbox 1478 1932 1524 1952; x_wconf 90'>He-</span>
+     </span>
+     <span class='ocr_line' id='line_1_137' title="bbox 892 1964 1523 1991; baseline -0.002 -4; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_916' title='bbox 892 1967 928 1991; x_wconf 74'>gel</span>
+      <span class='ocrx_word' id='word_1_917' title='bbox 946 1967 1000 1987; x_wconf 87'>vuol</span>
+      <span class='ocrx_word' id='word_1_918' title='bbox 1020 1966 1074 1990; x_wconf 89'>dire,</span>
+      <span class='ocrx_word' id='word_1_919' title='bbox 1097 1966 1183 1991; x_wconf 89'>quindi,</span>
+      <span class='ocrx_word' id='word_1_920' title='bbox 1203 1966 1314 1986; x_wconf 91'>soltanto</span>
+      <span class='ocrx_word' id='word_1_921' title='bbox 1303 1960 1317 1995; x_wconf 93'>:</span>
+      <span class='ocrx_word' id='word_1_922' title='bbox 1338 1967 1421 1990; x_wconf 91'>questo.</span>
+      <span class='ocrx_word' id='word_1_923' title='bbox 1435 1967 1493 1986; x_wconf 92'>stato</span>
+      <span class='ocrx_word' id='word_1_924' title='bbox 1514 1964 1523 1984; x_wconf 95'>è</span>
+     </span>
+     <span class='ocr_line' id='line_1_138' title="bbox 893 1997 1524 2023; baseline -0.002 -5; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_925' title='bbox 893 1998 1011 2022; x_wconf 90'>razionale,</span>
+      <span class='ocrx_word' id='word_1_926' title='bbox 1032 1997 1176 2023; x_wconf 92'>rispondente</span>
+      <span class='ocrx_word' id='word_1_927' title='bbox 1195 1998 1240 2021; x_wconf 92'>alla</span>
+      <span class='ocrx_word' id='word_1_928' title='bbox 1257 1998 1348 2022; x_wconf 90'>ragione</span>
+      <span class='ocrx_word' id='word_1_929' title='bbox 1368 1998 1391 2018; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_930' title='bbox 1411 1999 1494 2022; x_wconf 92'>quanto</span>
+      <span class='ocrx_word' id='word_1_931' title='bbox 1514 1997 1524 2017; x_wconf 96'>è</span>
+     </span>
+     <span class='ocr_line' id='line_1_139' title="bbox 893 2029 1523 2055; baseline 0 -5; x_size 23; x_descenders 5; x_ascenders 5">
+      <span class='ocrx_word' id='word_1_932' title='bbox 893 2031 1028 2052; x_wconf 83'>necessario;</span>
+      <span class='ocrx_word' id='word_1_933' title='bbox 1052 2038 1062 2051; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_934' title='bbox 1085 2037 1116 2054; x_wconf 92'>se,</span>
+      <span class='ocrx_word' id='word_1_935' title='bbox 1143 2031 1245 2055; x_wconf 82'>tuttavia,</span>
+      <span class='ocrx_word' id='word_1_936' title='bbox 1270 2030 1339 2050; x_wconf 92'>riesce</span>
+      <span class='ocrx_word' id='word_1_937' title='bbox 1363 2029 1455 2054; x_wconf 92'>cattivo,</span>
+      <span class='ocrx_word' id='word_1_938' title='bbox 1479 2036 1523 2053; x_wconf 92'>ma,</span>
+     </span>
+     <span class='ocr_line' id='line_1_140' title="bbox 893 2060 1524 2088; baseline 0 -6; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_939' title='bbox 893 2062 1008 2088; x_wconf 91'>malgrado</span>
+      <span class='ocrx_word' id='word_1_940' title='bbox 1025 2062 1040 2082; x_wconf 92'>il</span>
+      <span class='ocrx_word' id='word_1_941' title='bbox 1057 2070 1097 2082; x_wconf 91'>suo</span>
+      <span class='ocrx_word' id='word_1_942' title='bbox 1111 2061 1180 2086; x_wconf 63'>wizio,</span>
+      <span class='ocrx_word' id='word_1_943' title='bbox 1197 2062 1286 2087; x_wconf 90'>seguita</span>
+      <span class='ocrx_word' id='word_1_944' title='bbox 1301 2062 1329 2082; x_wconf 91'>ad</span>
+      <span class='ocrx_word' id='word_1_945' title='bbox 1346 2062 1444 2086; x_wconf 91'>esistere,</span>
+      <span class='ocrx_word' id='word_1_946' title='bbox 1461 2062 1477 2083; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_947' title='bbox 1492 2060 1524 2082; x_wconf 83'>vi-</span>
+     </span>
+     <span class='ocr_line' id='line_1_141' title="bbox 892 2094 1524 2119; baseline -0.002 -4; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_948' title='bbox 892 2095 926 2115; x_wconf 88'>zio</span>
+      <span class='ocrx_word' id='word_1_949' title='bbox 948 2094 984 2114; x_wconf 88'>del</span>
+      <span class='ocrx_word' id='word_1_950' title='bbox 1002 2100 1103 2119; x_wconf 88'>governo</span>
+      <span class='ocrx_word' id='word_1_951' title='bbox 1123 2096 1186 2115; x_wconf 89'>trova</span>
+      <span class='ocrx_word' id='word_1_952' title='bbox 1207 2095 1227 2115; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_953' title='bbox 1247 2101 1289 2116; x_wconf 91'>sua</span>
+      <span class='ocrx_word' id='word_1_954' title='bbox 1307 2094 1450 2119; x_wconf 91'>spiegazione</span>
+      <span class='ocrx_word' id='word_1_955' title='bbox 1472 2102 1482 2115; x_wconf 91'>e</span>
+      <span class='ocrx_word' id='word_1_956' title='bbox 1504 2094 1524 2114; x_wconf 91'>la</span>
+     </span>
+     <span class='ocr_line' id='line_1_142' title="bbox 892 2126 1525 2151; baseline 0 -4; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_957' title='bbox 892 2134 930 2148; x_wconf 92'>sua</span>
+      <span class='ocrx_word' id='word_1_958' title='bbox 951 2126 1129 2151; x_wconf 91'>giustificazione</span>
+      <span class='ocrx_word' id='word_1_959' title='bbox 1150 2127 1187 2147; x_wconf 91'>nel</span>
+      <span class='ocrx_word' id='word_1_960' title='bbox 1206 2126 1390 2150; x_wconf 91'>corrispondente</span>
+      <span class='ocrx_word' id='word_1_961' title='bbox 1410 2126 1469 2147; x_wconf 60'>vizio</span>
+      <span class='ocrx_word' id='word_1_962' title='bbox 1490 2127 1525 2147; x_wconf 90'>dei</span>
+     </span>
+     <span class='ocr_line' id='line_1_143' title="bbox 891 2155 1524 2184; baseline 0 -6; x_size 28; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_963' title='bbox 891 2158 984 2179; x_wconf 91'>sudditi.</span>
+      <span class='ocrx_word' id='word_1_964' title='bbox 1007 2158 1019 2178; x_wconf 75'>I</span>
+      <span class='ocrx_word' id='word_1_965' title='bbox 1038 2155 1151 2183; x_wconf 48'>Pprussiani</span>
+      <span class='ocrx_word' id='word_1_966' title='bbox 1172 2158 1263 2179; x_wconf 91'>d’allora</span>
+      <span class='ocrx_word' id='word_1_967' title='bbox 1283 2165 1369 2180; x_wconf 90'>avevan</span>
+      <span class='ocrx_word' id='word_1_968' title='bbox 1389 2158 1405 2179; x_wconf 88'>il</span>
+      <span class='ocrx_word' id='word_1_969' title='bbox 1425 2165 1524 2184; x_wconf 80'>governo</span>
+     </span>
+     <span class='ocr_line' id='line_1_144' title="bbox 893 2189 1127 2211; baseline 0 -1; x_size 26.749762; x_descenders 5.7497621; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_970' title='bbox 893 2191 931 2211; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_971' title='bbox 951 2192 966 2211; x_wconf 91'>si</span>
+      <span class='ocrx_word' id='word_1_972' title='bbox 982 2189 1127 2210; x_wconf 90'>meritavano.</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_9' title="bbox 891 2226 1527 3385">
+    <p class='ocr_par' id='par_1_12' lang='ita' title="bbox 891 2226 1527 3385">
+     <span class='ocr_line' id='line_1_145' title="bbox 921 2226 1524 2253; baseline 0 -6; x_size 26; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_973' title='bbox 921 2228 959 2249; x_wconf 91'>Ma</span>
+      <span class='ocrx_word' id='word_1_974' title='bbox 975 2229 995 2248; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_975' title='bbox 1009 2228 1087 2252; x_wconf 91'>realtà,</span>
+      <span class='ocrx_word' id='word_1_976' title='bbox 1104 2228 1200 2249; x_wconf 92'>secondo</span>
+      <span class='ocrx_word' id='word_1_977' title='bbox 1217 2226 1299 2253; x_wconf 92'>Hegel,</span>
+      <span class='ocrx_word' id='word_1_978' title='bbox 1317 2235 1362 2250; x_wconf 92'>non</span>
+      <span class='ocrx_word' id='word_1_979' title='bbox 1379 2228 1388 2248; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_980' title='bbox 1405 2229 1477 2252; x_wconf 90'>punto</span>
+      <span class='ocrx_word' id='word_1_981' title='bbox 1493 2235 1524 2247; x_wconf 91'>un</span>
+     </span>
+     <span class='ocr_line' id='line_1_146' title="bbox 891 2260 1524 2286; baseline 0 -6; x_size 26; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_982' title='bbox 891 2260 1001 2281; x_wconf 89'>attributo</span>
+      <span class='ocrx_word' id='word_1_983' title='bbox 1020 2261 1059 2280; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_984' title='bbox 1079 2267 1196 2286; x_wconf 91'>convenga</span>
+      <span class='ocrx_word' id='word_1_985' title='bbox 1213 2260 1241 2281; x_wconf 92'>ad</span>
+      <span class='ocrx_word' id='word_1_986' title='bbox 1258 2268 1305 2281; x_wconf 91'>una</span>
+      <span class='ocrx_word' id='word_1_987' title='bbox 1323 2261 1375 2282; x_wconf 92'>data</span>
+      <span class='ocrx_word' id='word_1_988' title='bbox 1392 2260 1524 2281; x_wconf 91'>condizione</span>
+     </span>
+     <span class='ocr_line' id='line_1_147' title="bbox 892 2292 1524 2317; baseline -0.002 -4; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_989' title='bbox 892 2293 914 2313; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_990' title='bbox 935 2300 983 2313; x_wconf 91'>cose</span>
+      <span class='ocrx_word' id='word_1_991' title='bbox 1005 2292 1085 2313; x_wconf 91'>sociale</span>
+      <span class='ocrx_word' id='word_1_992' title='bbox 1107 2300 1116 2313; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_993' title='bbox 1137 2292 1236 2317; x_wconf 92'>politica,</span>
+      <span class='ocrx_word' id='word_1_994' title='bbox 1258 2295 1318 2314; x_wconf 80'>sotto</span>
+      <span class='ocrx_word' id='word_1_995' title='bbox 1338 2294 1395 2313; x_wconf 90'>tutte</span>
+      <span class='ocrx_word' id='word_1_996' title='bbox 1418 2292 1435 2313; x_wconf 91'>le</span>
+      <span class='ocrx_word' id='word_1_997' title='bbox 1457 2292 1524 2313; x_wconf 83'>circo-</span>
+     </span>
+     <span class='ocr_line' id='line_1_148' title="bbox 891 2323 1522 2348; baseline 0 -4; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_998' title='bbox 891 2327 967 2346; x_wconf 90'>stanze</span>
+      <span class='ocrx_word' id='word_1_999' title='bbox 984 2325 1010 2344; x_wconf 90'>ed</span>
+      <span class='ocrx_word' id='word_1_1000' title='bbox 1025 2324 1048 2344; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_1001' title='bbox 1065 2325 1118 2345; x_wconf 90'>tutti</span>
+      <span class='ocrx_word' id='word_1_1002' title='bbox 1133 2326 1140 2345; x_wconf 89'>i</span>
+      <span class='ocrx_word' id='word_1_1003' title='bbox 1157 2325 1232 2348; x_wconf 87'>tempi.</span>
+      <span class='ocrx_word' id='word_1_1004' title='bbox 1250 2324 1281 2345; x_wconf 20'>Aì</span>
+      <span class='ocrx_word' id='word_1_1005' title='bbox 1298 2325 1416 2345; x_wconf 91'>contrario.</span>
+      <span class='ocrx_word' id='word_1_1006' title='bbox 1435 2324 1467 2345; x_wconf 92'>La</span>
+      <span class='ocrx_word' id='word_1_1007' title='bbox 1483 2323 1522 2344; x_wconf 92'>Re-</span>
+     </span>
+     <span class='ocr_line' id='line_1_149' title="bbox 893 2353 1524 2380; baseline 0.002 -5; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1008' title='bbox 893 2353 997 2380; x_wconf 88'>pubblica</span>
+      <span class='ocrx_word' id='word_1_1009' title='bbox 1015 2355 1116 2376; x_wconf 90'>Romana</span>
+      <span class='ocrx_word' id='word_1_1010' title='bbox 1132 2363 1167 2376; x_wconf 91'>era</span>
+      <span class='ocrx_word' id='word_1_1011' title='bbox 1182 2356 1250 2380; x_wconf 90'>reale,</span>
+      <span class='ocrx_word' id='word_1_1012' title='bbox 1266 2363 1302 2377; x_wconf 92'>ma</span>
+      <span class='ocrx_word' id='word_1_1013' title='bbox 1319 2356 1426 2380; x_wconf 83'>l’Impero</span>
+      <span class='ocrx_word' id='word_1_1014' title='bbox 1443 2355 1524 2376; x_wconf 88'>Roma-</span>
+     </span>
+     <span class='ocr_line' id='line_1_150' title="bbox 891 2387 1523 2413; baseline -0.002 -4; x_size 23; x_descenders 3; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1015' title='bbox 891 2395 920 2409; x_wconf 90'>no</span>
+      <span class='ocrx_word' id='word_1_1016' title='bbox 940 2388 979 2408; x_wconf 90'>che</span>
+      <span class='ocrx_word' id='word_1_1017' title='bbox 998 2395 1024 2408; x_wconf 91'>ne</span>
+      <span class='ocrx_word' id='word_1_1018' title='bbox 1044 2389 1106 2411; x_wconf 92'>prese</span>
+      <span class='ocrx_word' id='word_1_1019' title='bbox 1125 2388 1141 2408; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_1020' title='bbox 1158 2390 1223 2413; x_wconf 89'>posto</span>
+      <span class='ocrx_word' id='word_1_1021' title='bbox 1241 2389 1320 2409; x_wconf 91'>anche.</span>
+      <span class='ocrx_word' id='word_1_1022' title='bbox 1341 2387 1375 2409; x_wconf 93'>La</span>
+      <span class='ocrx_word' id='word_1_1023' title='bbox 1391 2388 1523 2409; x_wconf 92'>Monarchia</span>
+     </span>
+     <span class='ocr_line' id='line_1_151' title="bbox 893 2419 1525 2444; baseline 0 -4; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1024' title='bbox 893 2420 992 2440; x_wconf 86'>francese</span>
+      <span class='ocrx_word' id='word_1_1025' title='bbox 1013 2426 1049 2440; x_wconf 90'>era</span>
+      <span class='ocrx_word' id='word_1_1026' title='bbox 1068 2419 1176 2440; x_wconf 91'>divenuta</span>
+      <span class='ocrx_word' id='word_1_1027' title='bbox 1195 2420 1216 2440; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_1028' title='bbox 1234 2420 1357 2444; x_wconf 92'>negazione</span>
+      <span class='ocrx_word' id='word_1_1029' title='bbox 1378 2420 1436 2441; x_wconf 92'>della</span>
+      <span class='ocrx_word' id='word_1_1030' title='bbox 1455 2420 1525 2441; x_wconf 92'>realtà</span>
+     </span>
+     <span class='ocr_line' id='line_1_152' title="bbox 893 2449 1525 2476; baseline 0.002 -6; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1031' title='bbox 893 2451 928 2471; x_wconf 91'>nel</span>
+      <span class='ocrx_word' id='word_1_1032' title='bbox 947 2449 1007 2474; x_wconf 90'>1789,</span>
+      <span class='ocrx_word' id='word_1_1033' title='bbox 1026 2450 1072 2471; x_wconf 91'>cioè</span>
+      <span class='ocrx_word' id='word_1_1034' title='bbox 1090 2450 1133 2471; x_wconf 90'>così</span>
+      <span class='ocrx_word' id='word_1_1035' title='bbox 1151 2450 1216 2475; x_wconf 92'>priva</span>
+      <span class='ocrx_word' id='word_1_1036' title='bbox 1233 2451 1255 2471; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_1037' title='bbox 1273 2452 1326 2476; x_wconf 81'>ogni</span>
+      <span class='ocrx_word' id='word_1_1038' title='bbox 1343 2452 1461 2476; x_wconf 91'>necessità,</span>
+      <span class='ocrx_word' id='word_1_1039' title='bbox 1480 2451 1525 2471; x_wconf 45'>così</span>
+     </span>
+     <span class='ocr_line' id='line_1_153' title="bbox 892 2483 1525 2512; baseline 0.002 -9; x_size 23; x_descenders 3; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1040' title='bbox 892 2483 1031 2506; x_wconf 91'>irrazionale,</span>
+      <span class='ocrx_word' id='word_1_1041' title='bbox 1050 2484 1089 2504; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_1042' title='bbox 1108 2483 1194 2512; x_wconf 29'><em>dya&#39;vﬂ&#39;l)a</em></span>
+      <span class='ocrx_word' id='word_1_1043' title='bbox 1225 2491 1295 2504; x_wconf 32'>essere</span>
+      <span class='ocrx_word' id='word_1_1044' title='bbox 1328 2484 1435 2504; x_wconf 78'>distrutta</span>
+      <span class='ocrx_word' id='word_1_1045' title='bbox 1467 2484 1525 2504; x_wconf 78'>dalla</span>
+     </span>
+     <span class='ocr_line' id='line_1_154' title="bbox 893 2512 1525 2540; baseline 0.003 -6; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1046' title='bbox 893 2514 976 2537; x_wconf 90'>grande</span>
+      <span class='ocrx_word' id='word_1_1047' title='bbox 996 2514 1152 2539; x_wconf 90'>Rivoluzione,</span>
+      <span class='ocrx_word' id='word_1_1048' title='bbox 1173 2514 1195 2536; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_1049' title='bbox 1214 2516 1249 2535; x_wconf 36'>cuiì</span>
+      <span class='ocrx_word' id='word_1_1050' title='bbox 1267 2514 1342 2539; x_wconf 91'>Hegel</span>
+      <span class='ocrx_word' id='word_1_1051' title='bbox 1359 2516 1422 2540; x_wconf 90'>parla</span>
+      <span class='ocrx_word' id='word_1_1052' title='bbox 1438 2512 1525 2540; x_wconf 77'>sempre</span>
+     </span>
+     <span class='ocr_line' id='line_1_155' title="bbox 893 2545 1525 2572; baseline 0 -5; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1053' title='bbox 893 2554 934 2567; x_wconf 91'>con</span>
+      <span class='ocrx_word' id='word_1_1054' title='bbox 955 2545 969 2566; x_wconf 67'>iîl</span>
+      <span class='ocrx_word' id='word_1_1055' title='bbox 990 2546 1026 2570; x_wconf 89'>più</span>
+      <span class='ocrx_word' id='word_1_1056' title='bbox 1049 2547 1093 2569; x_wconf 91'>alto</span>
+      <span class='ocrx_word' id='word_1_1057' title='bbox 1115 2547 1259 2567; x_wconf 91'>entusiasmo.</span>
+      <span class='ocrx_word' id='word_1_1058' title='bbox 1284 2546 1361 2571; x_wconf 89'>Quivi,</span>
+      <span class='ocrx_word' id='word_1_1059' title='bbox 1383 2547 1483 2572; x_wconf 91'>dunque,</span>
+      <span class='ocrx_word' id='word_1_1060' title='bbox 1506 2548 1525 2567; x_wconf 92'>la</span>
+     </span>
+     <span class='ocr_line' id='line_1_156' title="bbox 893 2577 1521 2603; baseline 0.002 -6; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1061' title='bbox 893 2577 1023 2598; x_wconf 91'>Monarchia</span>
+      <span class='ocrx_word' id='word_1_1062' title='bbox 1043 2584 1080 2598; x_wconf 89'>era</span>
+      <span class='ocrx_word' id='word_1_1063' title='bbox 1098 2579 1118 2600; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_1064' title='bbox 1134 2579 1257 2603; x_wconf 92'>negazione</span>
+      <span class='ocrx_word' id='word_1_1065' title='bbox 1275 2579 1335 2599; x_wconf 89'>della</span>
+      <span class='ocrx_word' id='word_1_1066' title='bbox 1352 2579 1429 2603; x_wconf 91'>realtà,</span>
+      <span class='ocrx_word' id='word_1_1067' title='bbox 1450 2579 1470 2599; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_1068' title='bbox 1488 2578 1521 2598; x_wconf 84'>Ri-</span>
+     </span>
+     <span class='ocr_line' id='line_1_157' title="bbox 892 2609 1521 2634; baseline 0.003 -5; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1069' title='bbox 892 2609 1010 2630; x_wconf 90'>voluzione</span>
+      <span class='ocrx_word' id='word_1_1070' title='bbox 1028 2610 1044 2630; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_1071' title='bbox 1061 2610 1126 2630; x_wconf 90'>reale.</span>
+      <span class='ocrx_word' id='word_1_1072' title='bbox 1147 2609 1165 2629; x_wconf 92'>E</span>
+      <span class='ocrx_word' id='word_1_1073' title='bbox 1185 2609 1238 2634; x_wconf 90'>così,</span>
+      <span class='ocrx_word' id='word_1_1074' title='bbox 1257 2612 1294 2632; x_wconf 90'>nel</span>
+      <span class='ocrx_word' id='word_1_1075' title='bbox 1312 2617 1375 2632; x_wconf 90'>corso</span>
+      <span class='ocrx_word' id='word_1_1076' title='bbox 1394 2610 1521 2631; x_wconf 50'>dell’evolu-</span>
+     </span>
+     <span class='ocr_line' id='line_1_158' title="bbox 893 2641 1525 2666; baseline 0.005 -6; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1077' title='bbox 893 2642 964 2665; x_wconf 89'>zione,</span>
+      <span class='ocrx_word' id='word_1_1078' title='bbox 983 2643 1040 2661; x_wconf 90'>tutto</span>
+      <span class='ocrx_word' id='word_1_1079' title='bbox 1056 2641 1089 2661; x_wconf 90'>ciò</span>
+      <span class='ocrx_word' id='word_1_1080' title='bbox 1105 2642 1144 2662; x_wconf 85'>che.</span>
+      <span class='ocrx_word' id='word_1_1081' title='bbox 1160 2642 1233 2666; x_wconf 91'>prima</span>
+      <span class='ocrx_word' id='word_1_1082' title='bbox 1247 2641 1257 2661; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_1083' title='bbox 1272 2643 1329 2663; x_wconf 92'>reale</span>
+      <span class='ocrx_word' id='word_1_1084' title='bbox 1346 2642 1438 2663; x_wconf 90'>diventa</span>
+      <span class='ocrx_word' id='word_1_1085' title='bbox 1454 2643 1475 2663; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_1086' title='bbox 1489 2649 1525 2662; x_wconf 92'>ne-</span>
+     </span>
+     <span class='ocr_line' id='line_1_159' title="bbox 892 2672 1526 2698; baseline 0.003 -6; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1087' title='bbox 892 2673 985 2696; x_wconf 87'>gazione</span>
+      <span class='ocrx_word' id='word_1_1088' title='bbox 1008 2672 1065 2693; x_wconf 92'>della</span>
+      <span class='ocrx_word' id='word_1_1089' title='bbox 1084 2673 1162 2696; x_wconf 90'>realtà,</span>
+      <span class='ocrx_word' id='word_1_1090' title='bbox 1184 2673 1251 2697; x_wconf 91'>perde</span>
+      <span class='ocrx_word' id='word_1_1091' title='bbox 1272 2674 1352 2694; x_wconf 31'>la°sua</span>
+      <span class='ocrx_word' id='word_1_1092' title='bbox 1373 2674 1490 2698; x_wconf 90'>necessità,</span>
+      <span class='ocrx_word' id='word_1_1093' title='bbox 1511 2673 1526 2694; x_wconf 92'>il</span>
+     </span>
+     <span class='ocr_line' id='line_1_160' title="bbox 894 2704 1516 2729; baseline 0.005 -6; x_size 24; x_descenders 5; x_ascenders 6">
+      <span class='ocrx_word' id='word_1_1094' title='bbox 894 2711 933 2724; x_wconf 91'>suo</span>
+      <span class='ocrx_word' id='word_1_1095' title='bbox 955 2704 1031 2725; x_wconf 90'>diritto</span>
+      <span class='ocrx_word' id='word_1_1096' title='bbox 1053 2705 1211 2729; x_wconf 90'>all’esistenza,</span>
+      <span class='ocrx_word' id='word_1_1097' title='bbox 1231 2706 1247 2725; x_wconf 89'>il</span>
+      <span class='ocrx_word' id='word_1_1098' title='bbox 1267 2712 1307 2726; x_wconf 89'>suo</span>
+      <span class='ocrx_word' id='word_1_1099' title='bbox 1330 2707 1436 2726; x_wconf 92'>carattere</span>
+      <span class='ocrx_word' id='word_1_1100' title='bbox 1457 2704 1516 2727; x_wconf 88'>razio</span>
+     </span>
+     <span class='ocr_line' id='line_1_161' title="bbox 894 2735 1525 2761; baseline 0.006 -7; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1101' title='bbox 894 2735 952 2756; x_wconf 92'>nale;</span>
+      <span class='ocrx_word' id='word_1_1102' title='bbox 976 2736 996 2755; x_wconf 88'>al</span>
+      <span class='ocrx_word' id='word_1_1103' title='bbox 1019 2737 1082 2759; x_wconf 92'>posto</span>
+      <span class='ocrx_word' id='word_1_1104' title='bbox 1105 2736 1140 2757; x_wconf 91'>del</span>
+      <span class='ocrx_word' id='word_1_1105' title='bbox 1164 2736 1221 2757; x_wconf 91'>reale</span>
+      <span class='ocrx_word' id='word_1_1106' title='bbox 1245 2736 1285 2756; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_1107' title='bbox 1309 2743 1394 2761; x_wconf 89'>muore,</span>
+      <span class='ocrx_word' id='word_1_1108' title='bbox 1418 2737 1525 2758; x_wconf 39'>suhbentro</span>
+     </span>
+     <span class='ocr_line' id='line_1_162' title="bbox 895 2767 1526 2792; baseline 0.005 -6; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1109' title='bbox 895 2774 939 2786; x_wconf 90'>una</span>
+      <span class='ocrx_word' id='word_1_1110' title='bbox 949 2774 1031 2791; x_wconf 90'>nuova,</span>
+      <span class='ocrx_word' id='word_1_1111' title='bbox 1043 2768 1111 2788; x_wconf 91'>vitale</span>
+      <span class='ocrx_word' id='word_1_1112' title='bbox 1124 2768 1194 2788; x_wconf 89'>realtà</span>
+      <span class='ocrx_word' id='word_1_1113' title='bbox 1204 2779 1231 2782; x_wconf 93'>—</span>
+      <span class='ocrx_word' id='word_1_1114' title='bbox 1243 2767 1421 2792; x_wconf 91'>pacificamente,</span>
+      <span class='ocrx_word' id='word_1_1115' title='bbox 1435 2776 1457 2790; x_wconf 90'>se</span>
+      <span class='ocrx_word' id='word_1_1116' title='bbox 1472 2769 1526 2789; x_wconf 67'>l’an-</span>
+     </span>
+     <span class='ocr_line' id='line_1_163' title="bbox 896 2798 1526 2822; baseline 0.006 -5; x_size 24; x_descenders 3; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1117' title='bbox 896 2799 938 2818; x_wconf 92'>tico</span>
+      <span class='ocrx_word' id='word_1_1118' title='bbox 959 2798 968 2818; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_1119' title='bbox 988 2798 1124 2819; x_wconf 85'>abbastanza</span>
+      <span class='ocrx_word' id='word_1_1120' title='bbox 1161 2799 1303 2822; x_wconf 75'>intelligente</span>
+      <span class='ocrx_word' id='word_1_1121' title='bbox 1340 2800 1368 2821; x_wconf 75'>da</span>
+      <span class='ocrx_word' id='word_1_1122' title='bbox 1403 2801 1526 2821; x_wconf 88'>andarsene</span>
+     </span>
+     <span class='ocr_line' id='line_1_164' title="bbox 894 2829 1525 2854; baseline 0.005 -6; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1123' title='bbox 894 2836 959 2849; x_wconf 92'>senza</span>
+      <span class='ocrx_word' id='word_1_1124' title='bbox 975 2829 1113 2850; x_wconf 91'>recalcitrare</span>
+      <span class='ocrx_word' id='word_1_1125' title='bbox 1128 2832 1206 2851; x_wconf 92'>contro</span>
+      <span class='ocrx_word' id='word_1_1126' title='bbox 1222 2830 1242 2850; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_1127' title='bbox 1256 2832 1336 2854; x_wconf 91'>morte,</span>
+      <span class='ocrx_word' id='word_1_1128' title='bbox 1352 2831 1525 2851; x_wconf 92'>violentemente</span>
+     </span>
+     <span class='ocr_line' id='line_1_165' title="bbox 895 2860 1517 2885; baseline 0.005 -5; x_size 24; x_descenders 5; x_ascenders 6">
+      <span class='ocrx_word' id='word_1_1129' title='bbox 895 2868 916 2881; x_wconf 81'>se</span>
+      <span class='ocrx_word' id='word_1_1130' title='bbox 939 2861 1065 2885; x_wconf 80'>s’impenna</span>
+      <span class='ocrx_word' id='word_1_1131' title='bbox 1078 2864 1166 2883; x_wconf 72'>,contro</span>
+      <span class='ocrx_word' id='word_1_1132' title='bbox 1190 2863 1269 2885; x_wconf 90'>questa</span>
+      <span class='ocrx_word' id='word_1_1133' title='bbox 1289 2862 1406 2882; x_wconf 41'>necessità.</span>
+      <span class='ocrx_word' id='word_1_1134' title='bbox 1432 2862 1448 2882; x_wconf 87'>E</span>
+      <span class='ocrx_word' id='word_1_1135' title='bbox 1472 2860 1517 2885; x_wconf 87'>così</span>
+     </span>
+     <span class='ocr_line' id='line_1_166' title="bbox 895 2891 1527 2918; baseline 0.008 -8; x_size 27; x_descenders 4; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_1136' title='bbox 895 2893 933 2913; x_wconf 92'>per</span>
+      <span class='ocrx_word' id='word_1_1137' title='bbox 957 2892 974 2911; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_1138' title='bbox 999 2892 1158 2914; x_wconf 82'>dialettica,</span>
+      <span class='ocrx_word' id='word_1_1139' title='bbox 1131 2887 1171 2922; x_wconf 89'>di</span>
+      <span class='ocrx_word' id='word_1_1140' title='bbox 1180 2891 1263 2917; x_wconf 91'>Hegel,</span>
+      <span class='ocrx_word' id='word_1_1141' title='bbox 1288 2893 1306 2913; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_1142' title='bbox 1330 2891 1486 2918; x_wconf 60'>proPosizione</span>
+      <span class='ocrx_word' id='word_1_1143' title='bbox 1508 2896 1527 2915; x_wconf 61'>sî</span>
+     </span>
+     <span class='ocr_line' id='line_1_167' title="bbox 894 2923 1526 2947; baseline 0.005 -5; x_size 24; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1144' title='bbox 894 2923 959 2946; x_wconf 80'>volge</span>
+      <span class='ocrx_word' id='word_1_1145' title='bbox 977 2923 1034 2945; x_wconf 91'>nella</span>
+      <span class='ocrx_word' id='word_1_1146' title='bbox 1053 2931 1095 2943; x_wconf 90'>sua</span>
+      <span class='ocrx_word' id='word_1_1147' title='bbox 1112 2926 1182 2945; x_wconf 91'>stessa</span>
+      <span class='ocrx_word' id='word_1_1148' title='bbox 1201 2924 1304 2944; x_wconf 90'>antitesi:</span>
+      <span class='ocrx_word' id='word_1_1149' title='bbox 1327 2927 1385 2945; x_wconf 91'>tutto</span>
+      <span class='ocrx_word' id='word_1_1150' title='bbox 1404 2925 1437 2945; x_wconf 93'>ciò</span>
+      <span class='ocrx_word' id='word_1_1151' title='bbox 1457 2927 1496 2947; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_1152' title='bbox 1517 2927 1526 2945; x_wconf 95'>è</span>
+     </span>
+     <span class='ocr_line' id='line_1_168' title="bbox 896 2954 1526 2980; baseline 0.006 -6; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1153' title='bbox 896 2954 952 2974; x_wconf 63'>reale</span>
+      <span class='ocrx_word' id='word_1_1154' title='bbox 983 2954 1124 2975; x_wconf 63'>nell’ambito</span>
+      <span class='ocrx_word' id='word_1_1155' title='bbox 1142 2955 1200 2976; x_wconf 91'>della</span>
+      <span class='ocrx_word' id='word_1_1156' title='bbox 1230 2956 1299 2975; x_wconf 88'>storia</span>
+      <span class='ocrx_word' id='word_1_1157' title='bbox 1329 2963 1420 2980; x_wconf 89'>umana,</span>
+      <span class='ocrx_word' id='word_1_1158' title='bbox 1438 2957 1526 2978; x_wconf 93'>diviene</span>
+     </span>
+     <span class='ocr_line' id='line_1_169' title="bbox 896 2983 1526 3012; baseline 0.01 -8; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1159' title='bbox 896 2988 929 3007; x_wconf 91'>col</span>
+      <span class='ocrx_word' id='word_1_1160' title='bbox 948 2987 1023 3009; x_wconf 92'>tempo</span>
+      <span class='ocrx_word' id='word_1_1161' title='bbox 1041 2985 1181 3009; x_wconf 91'>irrazionale,</span>
+      <span class='ocrx_word' id='word_1_1162' title='bbox 1203 2986 1212 3005; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_1163' title='bbox 1233 2987 1319 3011; x_wconf 90'>quindi,</span>
+      <span class='ocrx_word' id='word_1_1164' title='bbox 1338 2983 1375 3011; x_wconf 91'>già</span>
+      <span class='ocrx_word' id='word_1_1165' title='bbox 1392 2990 1431 3012; x_wconf 91'>per</span>
+      <span class='ocrx_word' id='word_1_1166' title='bbox 1449 2989 1470 3010; x_wconf 90'>la</span>
+      <span class='ocrx_word' id='word_1_1167' title='bbox 1487 2996 1526 3010; x_wconf 90'>sua</span>
+     </span>
+     <span class='ocr_line' id='line_1_170' title="bbox 896 3015 1526 3043; baseline 0.008 -7; x_size 23; x_descenders 3; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1168' title='bbox 896 3015 1092 3040; x_wconf 90'>determinazione,</span>
+      <span class='ocrx_word' id='word_1_1169' title='bbox 1108 3011 1126 3047; x_wconf 92'>-</span>
+      <span class='ocrx_word' id='word_1_1170' title='bbox 1133 3017 1275 3041; x_wconf 90'>irrazionale,</span>
+      <span class='ocrx_word' id='word_1_1171' title='bbox 1297 3018 1307 3037; x_wconf 92'>è</span>
+      <span class='ocrx_word' id='word_1_1172' title='bbox 1328 3019 1526 3043; x_wconf 92'>anticipatamente</span>
+     </span>
+     <span class='ocr_line' id='line_1_171' title="bbox 896 3044 1517 3073; baseline 0.01 -6; x_size 25.342937; x_descenders 5.3429379; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1173' title='bbox 896 3047 1002 3068; x_wconf 87'>donvinto</span>
+      <span class='ocrx_word' id='word_1_1174' title='bbox 1019 3044 1204 3070; x_wconf 91'>d’irrazionalità;</span>
+      <span class='ocrx_word' id='word_1_1175' title='bbox 1222 3056 1232 3069; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_1176' title='bbox 1249 3050 1307 3070; x_wconf 92'>tutto</span>
+      <span class='ocrx_word' id='word_1_1177' title='bbox 1325 3050 1358 3070; x_wconf 92'>ciò</span>
+      <span class='ocrx_word' id='word_1_1178' title='bbox 1375 3051 1414 3072; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_1179' title='bbox 1431 3050 1441 3071; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_1180' title='bbox 1457 3053 1517 3073; x_wconf 91'>razio</span>
+     </span>
+     <span class='ocr_line' id='line_1_172' title="bbox 895 3078 1526 3105; baseline 0.01 -7; x_size 24; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1181' title='bbox 895 3079 943 3098; x_wconf 91'>nale</span>
+      <span class='ocrx_word' id='word_1_1182' title='bbox 954 3078 1011 3098; x_wconf 91'>nelle</span>
+      <span class='ocrx_word' id='word_1_1183' title='bbox 1024 3082 1078 3099; x_wconf 92'>teste</span>
+      <span class='ocrx_word' id='word_1_1184' title='bbox 1090 3079 1151 3103; x_wconf 92'>degli</span>
+      <span class='ocrx_word' id='word_1_1185' title='bbox 1161 3080 1248 3099; x_wconf 91'>uomini</span>
+      <span class='ocrx_word' id='word_1_1186' title='bbox 1260 3080 1270 3099; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_1187' title='bbox 1283 3081 1392 3102; x_wconf 91'>destinato</span>
+      <span class='ocrx_word' id='word_1_1188' title='bbox 1405 3090 1417 3103; x_wconf 93'>a</span>
+      <span class='ocrx_word' id='word_1_1189' title='bbox 1427 3083 1526 3105; x_wconf 90'>divenire</span>
+     </span>
+     <span class='ocr_line' id='line_1_173' title="bbox 896 3110 1525 3138; baseline 0.01 -9; x_size 23; x_descenders 4; x_ascenders 6">
+      <span class='ocrx_word' id='word_1_1190' title='bbox 896 3110 961 3133; x_wconf 80'>reale,</span>
+      <span class='ocrx_word' id='word_1_1191' title='bbox 977 3112 1016 3134; x_wconf 90'>per</span>
+      <span class='ocrx_word' id='word_1_1192' title='bbox 1032 3112 1116 3134; x_wconf 90'>quanto</span>
+      <span class='ocrx_word' id='word_1_1193' title='bbox 1131 3112 1196 3134; x_wconf 91'>possa</span>
+      <span class='ocrx_word' id='word_1_1194' title='bbox 1211 3111 1331 3136; x_wconf 91'>ripugnare</span>
+      <span class='ocrx_word' id='word_1_1195' title='bbox 1347 3113 1391 3134; x_wconf 92'>alla</span>
+      <span class='ocrx_word' id='word_1_1196' title='bbox 1405 3116 1525 3138; x_wconf 90'>apparente</span>
+     </span>
+     <span class='ocr_line' id='line_1_174' title="bbox 896 3140 1527 3167; baseline 0.011 -7; x_size 23; x_descenders 3; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1197' title='bbox 896 3141 964 3161; x_wconf 91'>realtà</span>
+      <span class='ocrx_word' id='word_1_1198' title='bbox 979 3142 1091 3161; x_wconf 92'>esistente.</span>
+      <span class='ocrx_word' id='word_1_1199' title='bbox 1108 3140 1141 3161; x_wconf 92'>La</span>
+      <span class='ocrx_word' id='word_1_1200' title='bbox 1153 3142 1309 3166; x_wconf 92'>proposizione</span>
+      <span class='ocrx_word' id='word_1_1201' title='bbox 1324 3144 1382 3166; x_wconf 92'>della</span>
+      <span class='ocrx_word' id='word_1_1202' title='bbox 1395 3146 1527 3167; x_wconf 91'>razionalità</span>
+     </span>
+     <span class='ocr_line' id='line_1_175' title="bbox 896 3172 1526 3199; baseline 0.013 -8; x_size 25.342937; x_descenders 5.3429379; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1203' title='bbox 896 3172 918 3192; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_1204' title='bbox 929 3174 987 3193; x_wconf 92'>tutto</span>
+      <span class='ocrx_word' id='word_1_1205' title='bbox 1000 3172 1033 3192; x_wconf 91'>ciò</span>
+      <span class='ocrx_word' id='word_1_1206' title='bbox 1046 3173 1085 3192; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_1207' title='bbox 1098 3172 1108 3192; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_1208' title='bbox 1120 3173 1186 3195; x_wconf 91'>reale,</span>
+      <span class='ocrx_word' id='word_1_1209' title='bbox 1189 3168 1219 3203; x_wconf 88'>si</span>
+      <span class='ocrx_word' id='word_1_1210' title='bbox 1227 3173 1316 3198; x_wconf 86'>risolve,</span>
+      <span class='ocrx_word' id='word_1_1211' title='bbox 1329 3177 1425 3197; x_wconf 91'>secondo</span>
+      <span class='ocrx_word' id='word_1_1212' title='bbox 1439 3179 1495 3198; x_wconf 83'>tutte</span>
+      <span class='ocrx_word' id='word_1_1213' title='bbox 1508 3179 1526 3199; x_wconf 90'>le</span>
+     </span>
+     <span class='ocr_line' id='line_1_176' title="bbox 896 3203 1523 3231; baseline 0.008 -8; x_size 24; x_descenders 3; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1214' title='bbox 896 3203 969 3225; x_wconf 78'>regole</span>
+      <span class='ocrx_word' id='word_1_1215' title='bbox 990 3204 1025 3223; x_wconf 89'>del</span>
+      <span class='ocrx_word' id='word_1_1216' title='bbox 1046 3203 1136 3224; x_wconf 92'>metodo</span>
+      <span class='ocrx_word' id='word_1_1217' title='bbox 1158 3204 1229 3225; x_wconf 91'>logico</span>
+      <span class='ocrx_word' id='word_1_1218' title='bbox 1251 3205 1376 3231; x_wconf 90'>hegehano,</span>
+      <span class='ocrx_word' id='word_1_1219' title='bbox 1398 3208 1523 3229; x_wconf 90'>nell’altra</span>
+      <span class='ocrx_word' id='word_1_1220' title='bbox 1508 3199 1522 3235; x_wconf 96'>:</span>
+     </span>
+     <span class='ocr_line' id='line_1_177' title="bbox 897 3234 1525 3264; baseline 0.01 -10; x_size 27; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1221' title='bbox 897 3236 954 3254; x_wconf 91'>tutto</span>
+      <span class='ocrx_word' id='word_1_1222' title='bbox 969 3234 1002 3254; x_wconf 91'>ciò</span>
+      <span class='ocrx_word' id='word_1_1223' title='bbox 1018 3235 1058 3255; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_1224' title='bbox 1073 3235 1138 3255; x_wconf 92'>esiste</span>
+      <span class='ocrx_word' id='word_1_1225' title='bbox 1153 3234 1163 3254; x_wconf 93'>è</span>
+      <span class='ocrx_word' id='word_1_1226' title='bbox 1179 3234 1251 3260; x_wconf 92'>degno</span>
+      <span class='ocrx_word' id='word_1_1227' title='bbox 1266 3236 1289 3257; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_1228' title='bbox 1303 3238 1381 3261; x_wconf 87'>perire.</span>
+      <span class='ocrx_word' id='word_1_1229' title='bbox 1398 3239 1425 3259; x_wconf 90'>In</span>
+      <span class='ocrx_word' id='word_1_1230' title='bbox 1440 3241 1525 3264; x_wconf 91'>questo,</span>
+     </span>
+     <span class='ocr_line' id='line_1_178' title="bbox 895 3266 1526 3292; baseline 0.003 -7; x_size 23; x_descenders 4; x_ascenders 6">
+      <span class='ocrx_word' id='word_1_1231' title='bbox 895 3267 1004 3288; x_wconf 90'>appunto,</span>
+      <span class='ocrx_word' id='word_1_1232' title='bbox 1017 3268 1081 3286; x_wconf 88'>stava</span>
+      <span class='ocrx_word' id='word_1_1233' title='bbox 1092 3268 1112 3288; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_1234' title='bbox 1122 3273 1176 3286; x_wconf 92'>vera</span>
+      <span class='ocrx_word' id='word_1_1235' title='bbox 1185 3266 1325 3290; x_wconf 90'>importanza</span>
+      <span class='ocrx_word' id='word_1_1236' title='bbox 1334 3275 1344 3288; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_1237' title='bbox 1353 3269 1370 3289; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_1238' title='bbox 1381 3273 1487 3292; x_wconf 91'>carattere</span>
+      <span class='ocrx_word' id='word_1_1239' title='bbox 1500 3270 1526 3291; x_wconf 95'>ri-</span>
+     </span>
+     <span class='ocr_line' id='line_1_179' title="bbox 896 3296 1526 3323; baseline 0.003 -7; x_size 24; x_descenders 3; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1240' title='bbox 896 3296 1049 3317; x_wconf 91'>voluzionario</span>
+      <span class='ocrx_word' id='word_1_1241' title='bbox 1063 3297 1122 3319; x_wconf 92'>della</span>
+      <span class='ocrx_word' id='word_1_1242' title='bbox 1133 3296 1230 3321; x_wconf 91'>filosofia</span>
+      <span class='ocrx_word' id='word_1_1243' title='bbox 1243 3297 1266 3317; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_1244' title='bbox 1278 3297 1364 3323; x_wconf 90'>Hegel:</span>
+      <span class='ocrx_word' id='word_1_1245' title='bbox 1382 3301 1422 3321; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_1246' title='bbox 1436 3308 1485 3323; x_wconf 92'>essa</span>
+      <span class='ocrx_word' id='word_1_1247' title='bbox 1497 3302 1526 3323; x_wconf 91'>fa-</span>
+     </span>
+     <span class='ocr_line' id='line_1_180' title="bbox 897 3328 1523 3358; baseline 0.011 -11; x_size 27; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1248' title='bbox 897 3334 950 3347; x_wconf 91'>ceva</span>
+      <span class='ocrx_word' id='word_1_1249' title='bbox 969 3328 987 3347; x_wconf 92'>la</span>
+      <span class='ocrx_word' id='word_1_1250' title='bbox 1006 3328 1065 3351; x_wconf 91'>festa</span>
+      <span class='ocrx_word' id='word_1_1251' title='bbox 1083 3328 1103 3347; x_wconf 91'>al</span>
+      <span class='ocrx_word' id='word_1_1252' title='bbox 1123 3330 1230 3349; x_wconf 90'>carattere</span>
+      <span class='ocrx_word' id='word_1_1253' title='bbox 1251 3329 1367 3351; x_wconf 90'>definitivo</span>
+      <span class='ocrx_word' id='word_1_1254' title='bbox 1387 3331 1409 3353; x_wconf 90'>di</span>
+      <span class='ocrx_word' id='word_1_1255' title='bbox 1429 3335 1482 3358; x_wconf 91'>ogni</span>
+      <span class='ocrx_word' id='word_1_1256' title='bbox 1500 3335 1523 3354; x_wconf 90'>ri.</span>
+     </span>
+     <span class='ocr_line' id='line_1_181' title="bbox 895 3358 1524 3385; baseline 0.011 -8; x_size 24; x_descenders 3; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1257' title='bbox 895 3358 978 3380; x_wconf 92'>sultato</span>
+      <span class='ocrx_word' id='word_1_1258' title='bbox 992 3358 1027 3379; x_wconf 92'>del</span>
+      <span class='ocrx_word' id='word_1_1259' title='bbox 1039 3358 1142 3382; x_wconf 70'>pensîero</span>
+      <span class='ocrx_word' id='word_1_1260' title='bbox 1157 3366 1166 3380; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_1261' title='bbox 1181 3359 1325 3380; x_wconf 90'>dell’attività</span>
+      <span class='ocrx_word' id='word_1_1262' title='bbox 1337 3363 1424 3385; x_wconf 91'>pratica</span>
+      <span class='ocrx_word' id='word_1_1263' title='bbox 1435 3370 1524 3385; x_wconf 91'>umana.</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_10' title="bbox 1269 3428 1497 3458">
+    <p class='ocr_par' id='par_1_13' lang='ita' title="bbox 1269 3428 1497 3458">
+     <span class='ocr_line' id='line_1_182' title="bbox 1269 3428 1497 3458; baseline 0.013 -7; x_size 29; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1264' title='bbox 1269 3428 1388 3452; x_wconf 90'>Federico</span>
+      <span class='ocrx_word' id='word_1_1265' title='bbox 1405 3430 1497 3458; x_wconf 92'>Engels</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_11' title="bbox 1576 174 2211 318">
+    <p class='ocr_par' id='par_1_14' lang='ita' title="bbox 1576 174 2211 318">
+     <span class='ocr_line' id='line_1_183' title="bbox 1576 174 2211 236; baseline -0.016 -1; x_size 61.263889; x_descenders 8.2638884; x_ascenders 18">
+      <span class='ocrx_word' id='word_1_1266' title='bbox 1576 179 2048 236; x_wconf 57'>V]jadimiro</span>
+      <span class='ocrx_word' id='word_1_1267' title='bbox 2076 174 2211 226; x_wconf 84'>llic</span>
+     </span>
+     <span class='ocr_line' id='line_1_184' title="bbox 1725 259 2066 318; baseline -0.021 0; x_size 63.736111; x_descenders 8.7361107; x_ascenders 18">
+      <span class='ocrx_word' id='word_1_1268' title='bbox 1725 259 2066 318; x_wconf 89'>Ulianof</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_12' title="bbox 1793 370 1989 402">
+    <p class='ocr_par' id='par_1_15' lang='ita' title="bbox 1793 370 1989 402">
+     <span class='ocr_line' id='line_1_185' title="bbox 1793 370 1989 402; baseline -0.02 -6; x_size 32; x_descenders 7; x_ascenders 6">
+      <span class='ocrx_word' id='word_1_1269' title='bbox 1793 371 1826 396; x_wconf 91'>La</span>
+      <span class='ocrx_word' id='word_1_1270' title='bbox 1846 370 1989 402; x_wconf 90'>giovinezza</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_13' title="bbox 1578 424 2221 3111">
+    <p class='ocr_par' id='par_1_16' lang='ita' title="bbox 1578 424 2216 851">
+     <span class='ocr_line' id='line_1_186' title="bbox 1606 424 2212 454; baseline -0.017 0; x_size 26; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1271' title='bbox 1606 432 1733 454; x_wconf 38'>Viladimiro</span>
+      <span class='ocrx_word' id='word_1_1272' title='bbox 1752 430 1793 453; x_wconf 89'>Ilic</span>
+      <span class='ocrx_word' id='word_1_1273' title='bbox 1813 429 1907 450; x_wconf 91'>Ulianof</span>
+      <span class='ocrx_word' id='word_1_1274' title='bbox 1929 426 2020 453; x_wconf 91'>(Lenin)</span>
+      <span class='ocrx_word' id='word_1_1275' title='bbox 2043 431 2130 450; x_wconf 92'>nacque</span>
+      <span class='ocrx_word' id='word_1_1276' title='bbox 2152 424 2166 446; x_wconf 90'>il</span>
+      <span class='ocrx_word' id='word_1_1277' title='bbox 2188 431 2212 449; x_wconf 96'>23</span>
+     </span>
+     <span class='ocr_line' id='line_1_187' title="bbox 1578 457 2212 492; baseline -0.016 -5; x_size 27; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1278' title='bbox 1578 466 1648 492; x_wconf 92'>aprile</span>
+      <span class='ocrx_word' id='word_1_1279' title='bbox 1666 464 1720 490; x_wconf 93'>1870</span>
+      <span class='ocrx_word' id='word_1_1280' title='bbox 1738 462 1796 487; x_wconf 90'>nella</span>
+      <span class='ocrx_word' id='word_1_1281' title='bbox 1815 462 1869 483; x_wconf 91'>città</span>
+      <span class='ocrx_word' id='word_1_1282' title='bbox 1887 461 1910 482; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_1283' title='bbox 1928 459 2049 481; x_wconf 92'>Simbirsk.</span>
+      <span class='ocrx_word' id='word_1_1284' title='bbox 2070 458 2118 480; x_wconf 89'>Suo</span>
+      <span class='ocrx_word' id='word_1_1285' title='bbox 2134 457 2212 483; x_wconf 89'>padre,</span>
+     </span>
+     <span class='ocr_line' id='line_1_188' title="bbox 1579 489 2213 520; baseline -0.017 0; x_size 27; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1286' title='bbox 1579 499 1619 520; x_wconf 71'>Ilia</span>
+      <span class='ocrx_word' id='word_1_1287' title='bbox 1639 495 1778 520; x_wconf 89'>Nicolaievic</span>
+      <span class='ocrx_word' id='word_1_1288' title='bbox 1798 494 1899 520; x_wconf 77'>Ulianof,</span>
+      <span class='ocrx_word' id='word_1_1289' title='bbox 1920 492 2020 515; x_wconf 89'>oriundo</span>
+      <span class='ocrx_word' id='word_1_1290' title='bbox 2037 492 2060 513; x_wconf 89'>di</span>
+      <span class='ocrx_word' id='word_1_1291' title='bbox 2082 497 2127 511; x_wconf 89'>una</span>
+      <span class='ocrx_word' id='word_1_1292' title='bbox 2150 489 2213 511; x_wconf 89'>fami-</span>
+     </span>
+     <span class='ocr_line' id='line_1_189' title="bbox 1578 522 2213 558; baseline -0.017 -6; x_size 27; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1293' title='bbox 1578 532 1624 558; x_wconf 80'>glia</span>
+      <span class='ocrx_word' id='word_1_1294' title='bbox 1645 529 1765 551; x_wconf 80'>contadina</span>
+      <span class='ocrx_word' id='word_1_1295' title='bbox 1807 527 1865 549; x_wconf 48'> della</span>
+      <span class='ocrx_word' id='word_1_1296' title='bbox 1888 525 2004 552; x_wconf 90'>provincia</span>
+      <span class='ocrx_word' id='word_1_1297' title='bbox 2027 524 2050 545; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_1298' title='bbox 2073 522 2213 547; x_wconf 91'>Astrakhan,</span>
+     </span>
+     <span class='ocr_line' id='line_1_190' title="bbox 1579 555 2214 586; baseline -0.017 0; x_size 26; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1299' title='bbox 1579 571 1615 586; x_wconf 87'>era</span>
+      <span class='ocrx_word' id='word_1_1300' title='bbox 1633 563 1740 585; x_wconf 91'>direttore</span>
+      <span class='ocrx_word' id='word_1_1301' title='bbox 1758 561 1815 582; x_wconf 86'>dellle</span>
+      <span class='ocrx_word' id='word_1_1302' title='bbox 1832 560 1910 582; x_wconf 90'>scuole</span>
+      <span class='ocrx_word' id='word_1_1303' title='bbox 1926 559 2029 586; x_wconf 91'>popolari</span>
+      <span class='ocrx_word' id='word_1_1304' title='bbox 2047 557 2107 579; x_wconf 89'>della</span>
+      <span class='ocrx_word' id='word_1_1305' title='bbox 2124 555 2214 581; x_wconf 90'>provin-</span>
+     </span>
+     <span class='ocr_line' id='line_1_191' title="bbox 1580 590 2210 619; baseline -0.016 -1; x_size 26; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1306' title='bbox 1580 597 1613 619; x_wconf 90'>cia</span>
+      <span class='ocrx_word' id='word_1_1307' title='bbox 1632 596 1655 617; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_1308' title='bbox 1672 594 1793 619; x_wconf 92'>Simbirsk;</span>
+      <span class='ocrx_word' id='word_1_1309' title='bbox 1812 596 1892 615; x_wconf 42'>onmesto</span>
+      <span class='ocrx_word' id='word_1_1310' title='bbox 1910 599 1921 613; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_1311' title='bbox 1940 590 2062 616; x_wconf 92'>laborioso,</span>
+      <span class='ocrx_word' id='word_1_1312' title='bbox 2082 590 2210 614; x_wconf 52'>appartene</span>
+     </span>
+     <span class='ocr_line' id='line_1_192' title="bbox 1580 621 2214 654; baseline -0.016 -3; x_size 26; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1313' title='bbox 1580 638 1606 651; x_wconf 93'>va</span>
+      <span class='ocrx_word' id='word_1_1314' title='bbox 1625 637 1637 651; x_wconf 92'>a</span>
+      <span class='ocrx_word' id='word_1_1315' title='bbox 1657 628 1731 654; x_wconf 92'>quella</span>
+      <span class='ocrx_word' id='word_1_1316' title='bbox 1751 628 1822 653; x_wconf 84'>prima</span>
+      <span class='ocrx_word' id='word_1_1317' title='bbox 1841 625 1991 653; x_wconf 85'>gemerazione</span>
+      <span class='ocrx_word' id='word_1_1318' title='bbox 2009 623 2033 645; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_1319' title='bbox 2053 621 2214 644; x_wconf 90'>rivoluzionari</span>
+     </span>
+     <span class='ocr_line' id='line_1_193' title="bbox 1579 655 2215 687; baseline -0.016 -3; x_size 28; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1320' title='bbox 1579 656 1675 687; x_wconf 0'>russi</span>
+      <span class='ocrx_word' id='word_1_1321' title='bbox 1650 651 1680 691; x_wconf 57'>la</span>
+      <span class='ocrx_word' id='word_1_1322' title='bbox 1691 661 1729 683; x_wconf 92'>cui</span>
+      <span class='ocrx_word' id='word_1_1323' title='bbox 1745 660 1823 687; x_wconf 92'>parola</span>
+      <span class='ocrx_word' id='word_1_1324' title='bbox 1841 658 1947 680; x_wconf 90'>d’ordine</span>
+      <span class='ocrx_word' id='word_1_1325' title='bbox 1963 664 2013 679; x_wconf 84'>era:</span>
+      <span class='ocrx_word' id='word_1_1326' title='bbox 2035 656 2121 677; x_wconf 92'>andare</span>
+      <span class='ocrx_word' id='word_1_1327' title='bbox 2137 655 2159 676; x_wconf 83'>al</span>
+      <span class='ocrx_word' id='word_1_1328' title='bbox 2175 661 2215 681; x_wconf 92'>po-</span>
+     </span>
+     <span class='ocr_line' id='line_1_194' title="bbox 1581 681 2215 721; baseline -0.017 -4; x_size 26; x_descenders 5; x_ascenders 6">
+      <span class='ocrx_word' id='word_1_1329' title='bbox 1581 696 1640 721; x_wconf 68'>polo,</span>
+      <span class='ocrx_word' id='word_1_1330' title='bbox 1659 700 1735 715; x_wconf 90'>amare</span>
+      <span class='ocrx_word' id='word_1_1331' title='bbox 1759 700 1772 714; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_1332' title='bbox 1798 691 1927 713; x_wconf 91'>illuminare</span>
+      <span class='ocrx_word' id='word_1_1333' title='bbox 1953 690 1974 711; x_wconf 88'>le</span>
+      <span class='ocrx_word' id='word_1_1334' title='bbox 1999 695 2074 710; x_wconf 82'>masse</span>
+      <span class='ocrx_word' id='word_1_1335' title='bbox 2098 681 2215 716; x_wconf 91'>lavoratri-</span>
+     </span>
+     <span class='ocr_line' id='line_1_195' title="bbox 1580 719 2216 753; baseline -0.016 -4; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1336' title='bbox 1580 728 1599 749; x_wconf 91'>ci</span>
+      <span class='ocrx_word' id='word_1_1337' title='bbox 1620 733 1726 753; x_wconf 92'>oppresse</span>
+      <span class='ocrx_word' id='word_1_1338' title='bbox 1745 732 1757 746; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_1339' title='bbox 1777 726 1883 747; x_wconf 89'>sfruttate</span>
+      <span class='ocrx_word' id='word_1_1340' title='bbox 1902 721 2103 744; x_wconf 86'>dall’aristoorazia</span>
+      <span class='ocrx_word' id='word_1_1341' title='bbox 2124 719 2216 740; x_wconf 91'>terriera</span>
+     </span>
+     <span class='ocr_line' id='line_1_196' title="bbox 1580 752 2216 784; baseline -0.017 -2; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1342' title='bbox 1580 768 1591 781; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_1343' title='bbox 1604 761 1665 782; x_wconf 79'>dallo</span>
+      <span class='ocrx_word' id='word_1_1344' title='bbox 1679 759 1781 783; x_wconf 91'>zarismo;</span>
+      <span class='ocrx_word' id='word_1_1345' title='bbox 1796 765 1835 784; x_wconf 92'>per</span>
+      <span class='ocrx_word' id='word_1_1346' title='bbox 1849 759 1870 779; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_1347' title='bbox 1883 763 1924 778; x_wconf 91'>sua</span>
+      <span class='ocrx_word' id='word_1_1348' title='bbox 1939 754 2056 777; x_wconf 91'>iniziativa</span>
+      <span class='ocrx_word' id='word_1_1349' title='bbox 2070 753 2152 774; x_wconf 92'>furono</span>
+      <span class='ocrx_word' id='word_1_1350' title='bbox 2168 752 2216 773; x_wconf 92'>fon-</span>
+     </span>
+     <span class='ocr_line' id='line_1_197' title="bbox 1581 785 2216 817; baseline -0.016 -3; x_size 26; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1351' title='bbox 1581 794 1632 815; x_wconf 92'>date</span>
+      <span class='ocrx_word' id='word_1_1352' title='bbox 1648 792 1706 813; x_wconf 92'>nella</span>
+      <span class='ocrx_word' id='word_1_1353' title='bbox 1724 789 1839 817; x_wconf 91'>provincia</span>
+      <span class='ocrx_word' id='word_1_1354' title='bbox 1857 790 1881 811; x_wconf 70'>di</span>
+      <span class='ocrx_word' id='word_1_1355' title='bbox 1895 788 2008 811; x_wconf 90'>Simbirsk</span>
+      <span class='ocrx_word' id='word_1_1356' title='bbox 2026 792 2067 812; x_wconf 93'>434</span>
+      <span class='ocrx_word' id='word_1_1357' title='bbox 2084 785 2162 807; x_wconf 67'>scuole</span>
+      <span class='ocrx_word' id='word_1_1358' title='bbox 2178 791 2216 809; x_wconf 39'>po-</span>
+     </span>
+     <span class='ocr_line' id='line_1_198' title="bbox 1582 821 1915 851; baseline -0.015 -4; x_size 27; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1359' title='bbox 1582 824 1652 851; x_wconf 92'>polari</span>
+      <span class='ocrx_word' id='word_1_1360' title='bbox 1671 831 1711 845; x_wconf 92'>con</span>
+      <span class='ocrx_word' id='word_1_1361' title='bbox 1734 829 1812 843; x_wconf 87'>20.000</span>
+      <span class='ocrx_word' id='word_1_1362' title='bbox 1831 821 1915 843; x_wconf 90'>allievi.</span>
+     </span>
+    </p>
+
+    <p class='ocr_par' id='par_1_17' lang='ita' title="bbox 1581 849 2221 2554">
+     <span class='ocr_line' id='line_1_199' title="bbox 1611 849 2216 880; baseline -0.01 -2; x_size 28; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_1363' title='bbox 1611 856 1736 878; x_wconf 28'>Vladimiro</span>
+      <span class='ocrx_word' id='word_1_1364' title='bbox 1752 855 1794 878; x_wconf 91'>Ilic</span>
+      <span class='ocrx_word' id='word_1_1365' title='bbox 1811 854 1886 880; x_wconf 82'>compì</span>
+      <span class='ocrx_word' id='word_1_1366' title='bbox 1904 855 1910 876; x_wconf 93'>i</span>
+      <span class='ocrx_word' id='word_1_1367' title='bbox 1927 854 1977 875; x_wconf 90'>suoi</span>
+      <span class='ocrx_word' id='word_1_1368' title='bbox 1994 851 2061 879; x_wconf 51'>pritmi</span>
+      <span class='ocrx_word' id='word_1_1369' title='bbox 2078 849 2141 871; x_wconf 91'>studi</span>
+      <span class='ocrx_word' id='word_1_1370' title='bbox 2157 849 2216 870; x_wconf 91'>nella</span>
+     </span>
+     <span class='ocr_line' id='line_1_200' title="bbox 1581 882 2218 912; baseline -0.016 -1; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1371' title='bbox 1581 890 1635 911; x_wconf 92'>città</span>
+      <span class='ocrx_word' id='word_1_1372' title='bbox 1649 889 1723 910; x_wconf 92'>natale</span>
+      <span class='ocrx_word' id='word_1_1373' title='bbox 1736 896 1749 910; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_1374' title='bbox 1762 889 1799 909; x_wconf 92'>nel</span>
+      <span class='ocrx_word' id='word_1_1375' title='bbox 1815 887 1868 912; x_wconf 92'>1887</span>
+      <span class='ocrx_word' id='word_1_1376' title='bbox 1883 885 1925 908; x_wconf 92'>finì</span>
+      <span class='ocrx_word' id='word_1_1377' title='bbox 1939 887 1956 908; x_wconf 85'>il</span>
+      <span class='ocrx_word' id='word_1_1378' title='bbox 1969 886 2033 907; x_wconf 91'>liceo.</span>
+      <span class='ocrx_word' id='word_1_1379' title='bbox 2050 884 2071 906; x_wconf 67'>IÎl</span>
+      <span class='ocrx_word' id='word_1_1380' title='bbox 2085 889 2109 904; x_wconf 93'>21</span>
+      <span class='ocrx_word' id='word_1_1381' title='bbox 2126 882 2218 907; x_wconf 92'>maggio</span>
+     </span>
+     <span class='ocr_line' id='line_1_201' title="bbox 1584 915 2218 948; baseline -0.017 -3; x_size 28; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1382' title='bbox 1584 923 1636 948; x_wconf 93'>1887</span>
+      <span class='ocrx_word' id='word_1_1383' title='bbox 1655 922 1680 943; x_wconf 92'>fu</span>
+      <span class='ocrx_word' id='word_1_1384' title='bbox 1695 920 1827 947; x_wconf 91'>giustiziato</span>
+      <span class='ocrx_word' id='word_1_1385' title='bbox 1844 927 1884 941; x_wconf 90'>suo</span>
+      <span class='ocrx_word' id='word_1_1386' title='bbox 1903 917 1993 940; x_wconf 91'>fratello</span>
+      <span class='ocrx_word' id='word_1_1387' title='bbox 2009 915 2157 941; x_wconf 90'>Alessandro,</span>
+      <span class='ocrx_word' id='word_1_1388' title='bbox 2177 915 2218 935; x_wconf 90'>che</span>
+     </span>
+     <span class='ocr_line' id='line_1_202' title="bbox 1581 948 2217 981; baseline -0.016 -5; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1389' title='bbox 1581 958 1732 981; x_wconf 91'>apparteneva</span>
+      <span class='ocrx_word' id='word_1_1390' title='bbox 1750 953 1771 973; x_wconf 91'>al</span>
+      <span class='ocrx_word' id='word_1_1391' title='bbox 1790 953 1931 975; x_wconf 91'>movimento</span>
+      <span class='ocrx_word' id='word_1_1392' title='bbox 1949 948 2128 972; x_wconf 83'>rivoluzionario</span>
+      <span class='ocrx_word' id='word_1_1393' title='bbox 2145 954 2217 974; x_wconf 83'>popu-</span>
+     </span>
+     <span class='ocr_line' id='line_1_203' title="bbox 1582 980 2217 1011; baseline -0.013 -3; x_size 25; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1394' title='bbox 1582 988 1631 1009; x_wconf 69'>lista</span>
+      <span class='ocrx_word' id='word_1_1395' title='bbox 1648 987 1674 1008; x_wconf 87'>ed</span>
+      <span class='ocrx_word' id='word_1_1396' title='bbox 1691 994 1727 1008; x_wconf 92'>era</span>
+      <span class='ocrx_word' id='word_1_1397' title='bbox 1743 985 1860 1011; x_wconf 89'>implicato</span>
+      <span class='ocrx_word' id='word_1_1398' title='bbox 1875 984 2045 1006; x_wconf 49'>nell’attentato</span>
+      <span class='ocrx_word' id='word_1_1399' title='bbox 2062 984 2142 1003; x_wconf 92'>contro</span>
+      <span class='ocrx_word' id='word_1_1400' title='bbox 2160 980 2217 1001; x_wconf 91'>l’im-</span>
+     </span>
+     <span class='ocr_line' id='line_1_204' title="bbox 1582 1012 2214 1046; baseline -0.011 -5; x_size 28; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1401' title='bbox 1582 1023 1683 1046; x_wconf 91'>peratore</span>
+      <span class='ocrx_word' id='word_1_1402' title='bbox 1702 1018 1840 1039; x_wconf 57'>Allessandro</span>
+      <span class='ocrx_word' id='word_1_1403' title='bbox 1857 1017 1893 1038; x_wconf 50'>II:</span>
+      <span class='ocrx_word' id='word_1_1404' title='bbox 1917 1018 1922 1038; x_wconf 93'>i</span>
+      <span class='ocrx_word' id='word_1_1405' title='bbox 1941 1016 2007 1042; x_wconf 91'>primi</span>
+      <span class='ocrx_word' id='word_1_1406' title='bbox 2024 1016 2086 1041; x_wconf 88'>passi</span>
+      <span class='ocrx_word' id='word_1_1407' title='bbox 2105 1013 2147 1034; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_1408' title='bbox 2164 1012 2214 1039; x_wconf 75'>Vla-</span>
+     </span>
+     <span class='ocr_line' id='line_1_205' title="bbox 1582 1044 2216 1076; baseline -0.014 -3; x_size 27; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_1409' title='bbox 1582 1052 1663 1073; x_wconf 91'>dimiro</span>
+      <span class='ocrx_word' id='word_1_1410' title='bbox 1684 1051 1725 1076; x_wconf 73'>Ilic</span>
+      <span class='ocrx_word' id='word_1_1411' title='bbox 1747 1051 1823 1072; x_wconf 89'>faceva</span>
+      <span class='ocrx_word' id='word_1_1412' title='bbox 1846 1050 1905 1071; x_wconf 89'>nella</span>
+      <span class='ocrx_word' id='word_1_1413' title='bbox 1925 1049 1971 1070; x_wconf 91'>vita</span>
+      <span class='ocrx_word' id='word_1_1414' title='bbox 1994 1048 2078 1069; x_wconf 91'>furono</span>
+      <span class='ocrx_word' id='word_1_1415' title='bbox 2100 1044 2145 1067; x_wconf 92'>così</span>
+      <span class='ocrx_word' id='word_1_1416' title='bbox 2168 1045 2216 1065; x_wconf 91'>illu-</span>
+     </span>
+     <span class='ocr_line' id='line_1_206' title="bbox 1582 1078 2217 1108; baseline -0.014 -2; x_size 25; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1417' title='bbox 1582 1084 1663 1106; x_wconf 77'>minati</span>
+      <span class='ocrx_word' id='word_1_1418' title='bbox 1678 1083 1715 1105; x_wconf 87'>dai</span>
+      <span class='ocrx_word' id='word_1_1419' title='bbox 1731 1083 1826 1108; x_wconf 92'>bagliori</span>
+      <span class='ocrx_word' id='word_1_1420' title='bbox 1839 1081 1966 1107; x_wconf 77'>‘sanguigni</span>
+      <span class='ocrx_word' id='word_1_1421' title='bbox 1984 1080 2042 1102; x_wconf 90'>della</span>
+      <span class='ocrx_word' id='word_1_1422' title='bbox 2059 1079 2116 1101; x_wconf 50'>lJotta</span>
+      <span class='ocrx_word' id='word_1_1423' title='bbox 2135 1078 2217 1098; x_wconf 89'>rivolu-</span>
+     </span>
+     <span class='ocr_line' id='line_1_207' title="bbox 1582 1109 2218 1138; baseline -0.013 0; x_size 27.453323; x_descenders 5.4533243; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1424' title='bbox 1582 1116 1686 1138; x_wconf 92'>zionaria.</span>
+      <span class='ocrx_word' id='word_1_1425' title='bbox 1705 1115 1782 1136; x_wconf 91'>Finito</span>
+      <span class='ocrx_word' id='word_1_1426' title='bbox 1799 1116 1814 1137; x_wconf 91'>il</span>
+      <span class='ocrx_word' id='word_1_1427' title='bbox 1832 1115 1890 1136; x_wconf 91'>liceo</span>
+      <span class='ocrx_word' id='word_1_1428' title='bbox 1906 1113 1979 1136; x_wconf 91'>Lenin</span>
+      <span class='ocrx_word' id='word_1_1429' title='bbox 1997 1113 2016 1134; x_wconf 91'>si</span>
+      <span class='ocrx_word' id='word_1_1430' title='bbox 2035 1111 2141 1133; x_wconf 89'>inscrisse</span>
+      <span class='ocrx_word' id='word_1_1431' title='bbox 2159 1109 2218 1130; x_wconf 91'>nella</span>
+     </span>
+     <span class='ocr_line' id='line_1_208' title="bbox 1584 1144 2219 1174; baseline -0.013 -4; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1432' title='bbox 1584 1149 1665 1171; x_wconf 75'>facoltà</span>
+      <span class='ocrx_word' id='word_1_1433' title='bbox 1686 1148 1796 1174; x_wconf 89'>giuridica</span>
+      <span class='ocrx_word' id='word_1_1434' title='bbox 1818 1146 2005 1168; x_wconf 73'>dell’Università</span>
+      <span class='ocrx_word' id='word_1_1435' title='bbox 2028 1145 2050 1165; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_1436' title='bbox 2072 1144 2160 1167; x_wconf 44'>Kasan;</span>
+      <span class='ocrx_word' id='word_1_1437' title='bbox 2183 1148 2219 1162; x_wconf 92'>ma</span>
+     </span>
+     <span class='ocr_line' id='line_1_209' title="bbox 1582 1177 2218 1208; baseline -0.013 -5; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1438' title='bbox 1582 1183 1640 1208; x_wconf 90'>dopo</span>
+      <span class='ocrx_word' id='word_1_1439' title='bbox 1660 1188 1692 1202; x_wconf 83'>un</span>
+      <span class='ocrx_word' id='word_1_1440' title='bbox 1710 1188 1771 1201; x_wconf 91'>mese</span>
+      <span class='ocrx_word' id='word_1_1441' title='bbox 1790 1187 1877 1206; x_wconf 59'>appena</span>
+      <span class='ocrx_word' id='word_1_1442' title='bbox 1898 1187 1925 1200; x_wconf 89'>ne</span>
+      <span class='ocrx_word' id='word_1_1443' title='bbox 1947 1179 1972 1200; x_wconf 56'>fu</span>
+      <span class='ocrx_word' id='word_1_1444' title='bbox 1993 1177 2084 1204; x_wconf 90'>espulso</span>
+      <span class='ocrx_word' id='word_1_1445' title='bbox 2106 1182 2145 1202; x_wconf 90'>per</span>
+      <span class='ocrx_word' id='word_1_1446' title='bbox 2165 1182 2218 1196; x_wconf 91'>aver</span>
+     </span>
+     <span class='ocr_line' id='line_1_210' title="bbox 1583 1207 2219 1238; baseline -0.011 -3; x_size 28; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1447' title='bbox 1583 1214 1730 1235; x_wconf 88'>attivamente</span>
+      <span class='ocrx_word' id='word_1_1448' title='bbox 1751 1212 1893 1238; x_wconf 86'>partecipato</span>
+      <span class='ocrx_word' id='word_1_1449' title='bbox 1913 1222 1926 1235; x_wconf 90'>a</span>
+      <span class='ocrx_word' id='word_1_1450' title='bbox 1951 1218 1995 1232; x_wconf 90'>una</span>
+      <span class='ocrx_word' id='word_1_1451' title='bbox 2020 1209 2101 1231; x_wconf 66'>rivolita</span>
+      <span class='ocrx_word' id='word_1_1452' title='bbox 2126 1207 2146 1228; x_wconf 78'>di</span>
+      <span class='ocrx_word' id='word_1_1453' title='bbox 2173 1211 2219 1228; x_wconf 89'>stu-</span>
+     </span>
+     <span class='ocr_line' id='line_1_211' title="bbox 1581 1239 2219 1270; baseline -0.011 -3; x_size 28; x_descenders 7; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1454' title='bbox 1581 1247 1643 1268; x_wconf 92'>denti</span>
+      <span class='ocrx_word' id='word_1_1455' title='bbox 1659 1254 1669 1267; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_1456' title='bbox 1685 1246 1709 1266; x_wconf 92'>fu</span>
+      <span class='ocrx_word' id='word_1_1457' title='bbox 1724 1245 1839 1266; x_wconf 90'>confinato</span>
+      <span class='ocrx_word' id='word_1_1458' title='bbox 1854 1246 1892 1266; x_wconf 90'>nel</span>
+      <span class='ocrx_word' id='word_1_1459' title='bbox 1906 1243 2016 1270; x_wconf 90'>villaggio</span>
+      <span class='ocrx_word' id='word_1_1460' title='bbox 2031 1243 2053 1264; x_wconf 91'>di</span>
+      <span class='ocrx_word' id='word_1_1461' title='bbox 2070 1239 2219 1263; x_wconf 91'>Cocushkino</span>
+     </span>
+     <span class='ocr_line' id='line_1_212' title="bbox 1584 1272 2219 1304; baseline -0.011 -5; x_size 26.453323; x_descenders 5.4533243; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1462' title='bbox 1584 1278 1707 1304; x_wconf 75'>(provincia</span>
+      <span class='ocrx_word' id='word_1_1463' title='bbox 1725 1277 1746 1298; x_wconf 89'>di</span>
+      <span class='ocrx_word' id='word_1_1464' title='bbox 1764 1277 1850 1301; x_wconf 45'>RKasan)</span>
+      <span class='ocrx_word' id='word_1_1465' title='bbox 1871 1276 1929 1297; x_wconf 91'>dove</span>
+      <span class='ocrx_word' id='word_1_1466' title='bbox 1945 1276 1964 1297; x_wconf 92'>si</span>
+      <span class='ocrx_word' id='word_1_1467' title='bbox 1981 1274 2061 1296; x_wconf 90'>dedicò</span>
+      <span class='ocrx_word' id='word_1_1468' title='bbox 2079 1274 2124 1294; x_wconf 90'>allo</span>
+      <span class='ocrx_word' id='word_1_1469' title='bbox 2142 1272 2219 1293; x_wconf 89'>studio</span>
+     </span>
+     <span class='ocr_line' id='line_1_213' title="bbox 1582 1304 2219 1334; baseline -0.009 -3; x_size 28; x_descenders 7; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1470' title='bbox 1582 1308 1604 1331; x_wconf 90'>di</span>
+      <span class='ocrx_word' id='word_1_1471' title='bbox 1625 1310 1699 1334; x_wconf 92'>Marx,</span>
+      <span class='ocrx_word' id='word_1_1472' title='bbox 1722 1309 1895 1330; x_wconf 92'>mantenendosi</span>
+      <span class='ocrx_word' id='word_1_1473' title='bbox 1915 1315 2004 1334; x_wconf 91'>sempre</span>
+      <span class='ocrx_word' id='word_1_1474' title='bbox 2024 1315 2037 1329; x_wconf 92'>a</span>
+      <span class='ocrx_word' id='word_1_1475' title='bbox 2060 1308 2164 1327; x_wconf 90'>contatto</span>
+      <span class='ocrx_word' id='word_1_1476' title='bbox 2184 1304 2219 1325; x_wconf 30'>coi</span>
+     </span>
+     <span class='ocr_line' id='line_1_214' title="bbox 1582 1340 2219 1364; baseline -0.011 0; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1477' title='bbox 1582 1343 1657 1364; x_wconf 89'>circoli</span>
+      <span class='ocrx_word' id='word_1_1478' title='bbox 1677 1342 1844 1364; x_wconf 90'>rivoluzionari.</span>
+      <span class='ocrx_word' id='word_1_1479' title='bbox 1866 1341 1904 1362; x_wconf 90'>Gli</span>
+      <span class='ocrx_word' id='word_1_1480' title='bbox 1924 1342 1947 1362; x_wconf 92'>fu</span>
+      <span class='ocrx_word' id='word_1_1481' title='bbox 1968 1340 2118 1361; x_wconf 91'>recisamente</span>
+      <span class='ocrx_word' id='word_1_1482' title='bbox 2138 1341 2219 1363; x_wconf 91'>negata</span>
+     </span>
+     <span class='ocr_line' id='line_1_215' title="bbox 1582 1371 2219 1401; baseline -0.009 -5; x_size 27; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1483' title='bbox 1582 1376 1601 1396; x_wconf 69'>la</span>
+      <span class='ocrx_word' id='word_1_1484' title='bbox 1625 1374 1804 1401; x_wconf 69'>reintegrazione</span>
+      <span class='ocrx_word' id='word_1_1485' title='bbox 1827 1373 2020 1398; x_wconf 91'>nell’Università,</span>
+      <span class='ocrx_word' id='word_1_1486' title='bbox 2044 1371 2076 1397; x_wconf 91'>gli</span>
+      <span class='ocrx_word' id='word_1_1487' title='bbox 2100 1371 2125 1392; x_wconf 91'>fu</span>
+      <span class='ocrx_word' id='word_1_1488' title='bbox 2149 1377 2219 1395; x_wconf 53'>1impe-</span>
+     </span>
+     <span class='ocr_line' id='line_1_216' title="bbox 1582 1402 2218 1431; baseline -0.009 -3; x_size 27; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1489' title='bbox 1582 1408 1630 1429; x_wconf 92'>dito</span>
+      <span class='ocrx_word' id='word_1_1490' title='bbox 1649 1407 1670 1428; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_1491' title='bbox 1689 1408 1742 1429; x_wconf 91'>dare</span>
+      <span class='ocrx_word' id='word_1_1492' title='bbox 1761 1407 1790 1431; x_wconf 90'>gli</span>
+      <span class='ocrx_word' id='word_1_1493' title='bbox 1812 1406 1889 1431; x_wconf 88'>esami;</span>
+      <span class='ocrx_word' id='word_1_1494' title='bbox 1908 1407 1929 1427; x_wconf 17'>ia</span>
+      <span class='ocrx_word' id='word_1_1495' title='bbox 1949 1405 2031 1431; x_wconf 91'>polizia</span>
+      <span class='ocrx_word' id='word_1_1496' title='bbox 2051 1404 2083 1430; x_wconf 92'>gli</span>
+      <span class='ocrx_word' id='word_1_1497' title='bbox 2104 1402 2176 1429; x_wconf 90'>proibì</span>
+      <span class='ocrx_word' id='word_1_1498' title='bbox 2197 1402 2218 1423; x_wconf 92'>di</span>
+     </span>
+     <span class='ocr_line' id='line_1_217' title="bbox 1583 1434 2219 1463; baseline -0.009 -2; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1499' title='bbox 1583 1440 1663 1461; x_wconf 89'>recarsi</span>
+      <span class='ocrx_word' id='word_1_1500' title='bbox 1680 1439 1806 1460; x_wconf 89'>all’estero</span>
+      <span class='ocrx_word' id='word_1_1501' title='bbox 1795 1430 1810 1468; x_wconf 92'>:</span>
+      <span class='ocrx_word' id='word_1_1502' title='bbox 1827 1440 1875 1460; x_wconf 87'>solo</span>
+      <span class='ocrx_word' id='word_1_1503' title='bbox 1892 1439 1928 1459; x_wconf 91'>nel</span>
+      <span class='ocrx_word' id='word_1_1504' title='bbox 1948 1438 2000 1463; x_wconf 88'>1891</span>
+      <span class='ocrx_word' id='word_1_1505' title='bbox 2019 1438 2053 1463; x_wconf 91'>gli</span>
+      <span class='ocrx_word' id='word_1_1506' title='bbox 2068 1437 2095 1461; x_wconf 87'>fu</span>
+      <span class='ocrx_word' id='word_1_1507' title='bbox 2112 1434 2219 1461; x_wconf 91'>possibile</span>
+     </span>
+     <span class='ocr_line' id='line_1_218' title="bbox 1582 1467 2218 1497; baseline -0.009 -4; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1508' title='bbox 1582 1473 1634 1494; x_wconf 91'>dare</span>
+      <span class='ocrx_word' id='word_1_1509' title='bbox 1654 1472 1684 1497; x_wconf 92'>gli</span>
+      <span class='ocrx_word' id='word_1_1510' title='bbox 1704 1472 1776 1493; x_wconf 91'>esami</span>
+      <span class='ocrx_word' id='word_1_1511' title='bbox 1795 1471 1817 1493; x_wconf 93'>di</span>
+      <span class='ocrx_word' id='word_1_1512' title='bbox 1837 1471 1900 1492; x_wconf 92'>Stato</span>
+      <span class='ocrx_word' id='word_1_1513' title='bbox 1921 1469 1981 1494; x_wconf 89'>nella</span>
+      <span class='ocrx_word' id='word_1_1514' title='bbox 2000 1469 2085 1491; x_wconf 60'>facoltà</span>
+      <span class='ocrx_word' id='word_1_1515' title='bbox 2106 1467 2218 1494; x_wconf 92'>giuridica</span>
+     </span>
+     <span class='ocr_line' id='line_1_219' title="bbox 1582 1501 2217 1529; baseline -0.005 -5; x_size 27; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1516' title='bbox 1582 1503 1768 1525; x_wconf 89'>dell’Università</span>
+      <span class='ocrx_word' id='word_1_1517' title='bbox 1789 1504 1810 1525; x_wconf 90'>di</span>
+      <span class='ocrx_word' id='word_1_1518' title='bbox 1832 1503 1989 1529; x_wconf 30'>Pietrogrado,</span>
+      <span class='ocrx_word' id='word_1_1519' title='bbox 2012 1510 2048 1523; x_wconf 90'>ma</span>
+      <span class='ocrx_word' id='word_1_1520' title='bbox 2089 1501 2132 1526; x_wconf 90'>egli</span>
+      <span class='ocrx_word' id='word_1_1521' title='bbox 2174 1506 2217 1519; x_wconf 68'>non</span>
+     </span>
+     <span class='ocr_line' id='line_1_220' title="bbox 1581 1534 2219 1557; baseline -0.006 0; x_size 26.453323; x_descenders 5.4533243; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1522' title='bbox 1581 1536 1640 1557; x_wconf 90'>volle</span>
+      <span class='ocrx_word' id='word_1_1523' title='bbox 1671 1536 1715 1557; x_wconf 20'>-mai</span>
+      <span class='ocrx_word' id='word_1_1524' title='bbox 1747 1536 1795 1557; x_wconf 92'>fare</span>
+      <span class='ocrx_word' id='word_1_1525' title='bbox 1823 1536 1964 1557; x_wconf 90'>l’avvocato:</span>
+      <span class='ocrx_word' id='word_1_1526' title='bbox 1999 1534 2177 1556; x_wconf 83'>ostinatamente</span>
+      <span class='ocrx_word' id='word_1_1527' title='bbox 2210 1540 2219 1554; x_wconf 18'>©</span>
+     </span>
+     <span class='ocr_line' id='line_1_221' title="bbox 1582 1564 2219 1590; baseline -0.008 -1; x_size 26.453323; x_descenders 5.4533243; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1528' title='bbox 1582 1568 1802 1590; x_wconf 91'>ininterrottamente</span>
+      <span class='ocrx_word' id='word_1_1529' title='bbox 1820 1569 1897 1590; x_wconf 89'>lavora</span>
+      <span class='ocrx_word' id='word_1_1530' title='bbox 1916 1568 1952 1588; x_wconf 92'>nei</span>
+      <span class='ocrx_word' id='word_1_1531' title='bbox 1972 1567 2051 1589; x_wconf 7'>circolii</span>
+      <span class='ocrx_word' id='word_1_1532' title='bbox 2069 1565 2173 1587; x_wconf 85'>marxisti</span>
+      <span class='ocrx_word' id='word_1_1533' title='bbox 2195 1564 2219 1584; x_wconf 85'>il-</span>
+     </span>
+     <span class='ocr_line' id='line_1_222' title="bbox 1582 1597 2219 1627; baseline -0.005 -6; x_size 27; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1534' title='bbox 1582 1601 1657 1626; x_wconf 91'>legali,</span>
+      <span class='ocrx_word' id='word_1_1535' title='bbox 1678 1600 1801 1627; x_wconf 91'>foggiando</span>
+      <span class='ocrx_word' id='word_1_1536' title='bbox 1823 1602 1842 1622; x_wconf 66'>la</span>
+      <span class='ocrx_word' id='word_1_1537' title='bbox 1861 1607 1901 1622; x_wconf 92'>sua</span>
+      <span class='ocrx_word' id='word_1_1538' title='bbox 1922 1600 2031 1626; x_wconf 92'>tagliente</span>
+      <span class='ocrx_word' id='word_1_1539' title='bbox 2052 1607 2063 1621; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_1540' title='bbox 2084 1597 2219 1623; x_wconf 84'>battagliera</span>
+     </span>
+     <span class='ocr_line' id='line_1_223' title="bbox 1581 1628 2218 1654; baseline -0.006 -2; x_size 26.063801; x_descenders 5.0638013; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1541' title='bbox 1581 1633 1716 1654; x_wconf 91'>concezione</span>
+      <span class='ocrx_word' id='word_1_1542' title='bbox 1738 1633 1772 1653; x_wconf 66'>del</span>
+      <span class='ocrx_word' id='word_1_1543' title='bbox 1797 1633 1923 1654; x_wconf 88'>marxismo</span>
+      <span class='ocrx_word' id='word_1_1544' title='bbox 1937 1624 1953 1663; x_wconf 13'>_</span>
+      <span class='ocrx_word' id='word_1_1545' title='bbox 1964 1630 2150 1653; x_wconf 13'>rivolluzionario.</span>
+      <span class='ocrx_word' id='word_1_1546' title='bbox 2175 1628 2218 1649; x_wconf 18'>GÀ</span>
+     </span>
+     <span class='ocr_line' id='line_1_224' title="bbox 1582 1662 2218 1690; baseline -0.002 -5; x_size 27; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1547' title='bbox 1582 1666 1618 1687; x_wconf 91'>nel</span>
+      <span class='ocrx_word' id='word_1_1548' title='bbox 1636 1665 1688 1689; x_wconf 86'>1893</span>
+      <span class='ocrx_word' id='word_1_1549' title='bbox 1705 1672 1716 1686; x_wconf 93'>a</span>
+      <span class='ocrx_word' id='word_1_1550' title='bbox 1730 1664 1830 1690; x_wconf 91'>Samara,</span>
+      <span class='ocrx_word' id='word_1_1551' title='bbox 1848 1665 1906 1686; x_wconf 93'>dove</span>
+      <span class='ocrx_word' id='word_1_1552' title='bbox 1921 1672 1957 1686; x_wconf 92'>era</span>
+      <span class='ocrx_word' id='word_1_1553' title='bbox 1973 1665 2059 1686; x_wconf 91'>andato</span>
+      <span class='ocrx_word' id='word_1_1554' title='bbox 2073 1672 2085 1685; x_wconf 92'>a</span>
+      <span class='ocrx_word' id='word_1_1555' title='bbox 2101 1662 2218 1684; x_wconf 86'>stabilirsi,</span>
+     </span>
+     <span class='ocr_line' id='line_1_225' title="bbox 1582 1694 2218 1724; baseline -0.005 -6; x_size 27; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1556' title='bbox 1582 1697 1701 1723; x_wconf 90'>organizza</span>
+      <span class='ocrx_word' id='word_1_1557' title='bbox 1724 1705 1755 1718; x_wconf 90'>un</span>
+      <span class='ocrx_word' id='word_1_1558' title='bbox 1777 1705 1866 1724; x_wconf 89'>gruppo</span>
+      <span class='ocrx_word' id='word_1_1559' title='bbox 1889 1697 1911 1719; x_wconf 89'>di</span>
+      <span class='ocrx_word' id='word_1_1560' title='bbox 1934 1697 2047 1719; x_wconf 92'>marxisti.</span>
+      <span class='ocrx_word' id='word_1_1561' title='bbox 2072 1694 2218 1717; x_wconf 37'>’Trasferitosi</span>
+     </span>
+     <span class='ocr_line' id='line_1_226' title="bbox 1582 1728 2220 1755; baseline -0.006 -4; x_size 27; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1562' title='bbox 1582 1737 1592 1751; x_wconf 82'>a</span>
+      <span class='ocrx_word' id='word_1_1563' title='bbox 1615 1729 1762 1755; x_wconf 82'>Pietrogrado</span>
+      <span class='ocrx_word' id='word_1_1564' title='bbox 1784 1730 1945 1752; x_wconf 91'>nell’autunno</span>
+      <span class='ocrx_word' id='word_1_1565' title='bbox 1969 1730 2031 1755; x_wconf 66'>1893,</span>
+      <span class='ocrx_word' id='word_1_1566' title='bbox 2056 1728 2137 1750; x_wconf 91'>dedicò</span>
+      <span class='ocrx_word' id='word_1_1567' title='bbox 2159 1730 2220 1748; x_wconf 90'>tutte</span>
+     </span>
+     <span class='ocr_line' id='line_1_227' title="bbox 1583 1761 2217 1787; baseline -0.005 -3; x_size 25; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1568' title='bbox 1583 1762 1603 1784; x_wconf 92'>le</span>
+      <span class='ocrx_word' id='word_1_1569' title='bbox 1617 1769 1658 1783; x_wconf 90'>sue</span>
+      <span class='ocrx_word' id='word_1_1570' title='bbox 1671 1761 1732 1783; x_wconf 90'>forze</span>
+      <span class='ocrx_word' id='word_1_1571' title='bbox 1747 1763 1767 1785; x_wconf 60'>al</span>
+      <span class='ocrx_word' id='word_1_1572' title='bbox 1783 1763 1861 1784; x_wconf 90'>lavoro</span>
+      <span class='ocrx_word' id='word_1_1573' title='bbox 1876 1762 2055 1784; x_wconf 54'>rivoluzionario</span>
+      <span class='ocrx_word' id='word_1_1574' title='bbox 2069 1763 2102 1783; x_wconf 84'>fra</span>
+      <span class='ocrx_word' id='word_1_1575' title='bbox 2118 1761 2150 1787; x_wconf 91'>gli</span>
+      <span class='ocrx_word' id='word_1_1576' title='bbox 2167 1767 2217 1786; x_wconf 90'>ope-</span>
+     </span>
+     <span class='ocr_line' id='line_1_228' title="bbox 1583 1793 2219 1823; baseline -0.002 -9; x_size 27; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1577' title='bbox 1583 1794 1622 1819; x_wconf 90'>rai,</span>
+      <span class='ocrx_word' id='word_1_1578' title='bbox 1645 1794 1743 1815; x_wconf 90'>creando</span>
+      <span class='ocrx_word' id='word_1_1579' title='bbox 1762 1794 1847 1823; x_wconf 54'>circolî</span>
+      <span class='ocrx_word' id='word_1_1580' title='bbox 1871 1794 2020 1821; x_wconf 86'>dirigendone</span>
+      <span class='ocrx_word' id='word_1_1581' title='bbox 2043 1793 2160 1818; x_wconf 78'>l’attività,</span>
+      <span class='ocrx_word' id='word_1_1582' title='bbox 2186 1800 2219 1814; x_wconf 92'>or-</span>
+     </span>
+     <span class='ocr_line' id='line_1_229' title="bbox 1582 1824 2218 1852; baseline -0.002 -6; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1583' title='bbox 1582 1826 1722 1852; x_wconf 90'>ganizzando</span>
+      <span class='ocrx_word' id='word_1_1584' title='bbox 1744 1826 1813 1852; x_wconf 88'>quelli</span>
+      <span class='ocrx_word' id='word_1_1585' title='bbox 1834 1827 1878 1848; x_wconf 89'>che</span>
+      <span class='ocrx_word' id='word_1_1586' title='bbox 1900 1834 1998 1849; x_wconf 90'>saranno</span>
+      <span class='ocrx_word' id='word_1_1587' title='bbox 2017 1828 2023 1848; x_wconf 92'>i</span>
+      <span class='ocrx_word' id='word_1_1588' title='bbox 2047 1827 2116 1852; x_wconf 89'>primi</span>
+      <span class='ocrx_word' id='word_1_1589' title='bbox 2138 1824 2218 1851; x_wconf 39'>quadri</span>
+     </span>
+     <span class='ocr_line' id='line_1_230' title="bbox 1582 1858 2220 1884; baseline -0.002 -4; x_size 27.453323; x_descenders 5.4533243; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1590' title='bbox 1582 1859 1618 1880; x_wconf 87'>del</span>
+      <span class='ocrx_word' id='word_1_1591' title='bbox 1635 1859 1718 1884; x_wconf 64'>partîito</span>
+      <span class='ocrx_word' id='word_1_1592' title='bbox 1733 1860 1826 1884; x_wconf 86'>operaio</span>
+      <span class='ocrx_word' id='word_1_1593' title='bbox 1842 1859 2032 1881; x_wconf 88'>rivoluzionario:</span>
+      <span class='ocrx_word' id='word_1_1594' title='bbox 2055 1861 2089 1881; x_wconf 92'>nel</span>
+      <span class='ocrx_word' id='word_1_1595' title='bbox 2111 1858 2165 1883; x_wconf 93'>1804</span>
+      <span class='ocrx_word' id='word_1_1596' title='bbox 2183 1864 2220 1879; x_wconf 93'>en-</span>
+     </span>
+     <span class='ocr_line' id='line_1_231' title="bbox 1583 1891 2220 1917; baseline 0.006 -6; x_size 26; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1597' title='bbox 1583 1891 1616 1911; x_wconf 91'>trò</span>
+      <span class='ocrx_word' id='word_1_1598' title='bbox 1634 1901 1645 1915; x_wconf 91'>a</span>
+      <span class='ocrx_word' id='word_1_1599' title='bbox 1664 1891 1698 1911; x_wconf 56'>far</span>
+      <span class='ocrx_word' id='word_1_1600' title='bbox 1716 1894 1779 1917; x_wconf 56'>parte</span>
+      <span class='ocrx_word' id='word_1_1601' title='bbox 1794 1892 1833 1915; x_wconf 60'>del</span>
+      <span class='ocrx_word' id='word_1_1602' title='bbox 1849 1892 1933 1914; x_wconf 79'>cincolo</span>
+      <span class='ocrx_word' id='word_1_1603' title='bbox 1950 1891 2077 1914; x_wconf 85'>socialista:</span>
+      <span class='ocrx_word' id='word_1_1604' title='bbox 2103 1900 2112 1912; x_wconf 90'>«</span>
+      <span class='ocrx_word' id='word_1_1605' title='bbox 2122 1891 2220 1917; x_wconf 88'>Gruppo</span>
+     </span>
+     <span class='ocr_line' id='line_1_232' title="bbox 1582 1923 2219 1950; baseline 0.002 -7; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1606' title='bbox 1582 1923 1681 1944; x_wconf 89'>centrale</span>
+      <span class='ocrx_word' id='word_1_1607' title='bbox 1700 1930 1738 1949; x_wconf 90'>per</span>
+      <span class='ocrx_word' id='word_1_1608' title='bbox 1753 1923 1777 1944; x_wconf 89'>Ja</span>
+      <span class='ocrx_word' id='word_1_1609' title='bbox 1797 1924 1912 1946; x_wconf 89'>direzione</span>
+      <span class='ocrx_word' id='word_1_1610' title='bbox 1931 1925 1966 1946; x_wconf 87'>del</span>
+      <span class='ocrx_word' id='word_1_1611' title='bbox 1987 1925 2131 1946; x_wconf 91'>movimento</span>
+      <span class='ocrx_word' id='word_1_1612' title='bbox 2149 1919 2159 1955; x_wconf 39'>_</span>
+      <span class='ocrx_word' id='word_1_1613' title='bbox 2168 1930 2219 1950; x_wconf 39'>ope-</span>
+     </span>
+     <span class='ocr_line' id='line_1_233' title="bbox 1583 1954 2220 1982; baseline 0.005 -7; x_size 28; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_1614' title='bbox 1583 1954 1630 1975; x_wconf 43'>mio</span>
+      <span class='ocrx_word' id='word_1_1615' title='bbox 1639 1962 1658 1975; x_wconf 65'>».</span>
+      <span class='ocrx_word' id='word_1_1616' title='bbox 1680 1954 1722 1976; x_wconf 93'>Già</span>
+      <span class='ocrx_word' id='word_1_1617' title='bbox 1741 1955 1810 1977; x_wconf 90'>allora</span>
+      <span class='ocrx_word' id='word_1_1618' title='bbox 1826 1956 1972 1979; x_wconf 91'>cominciano</span>
+      <span class='ocrx_word' id='word_1_1619' title='bbox 1990 1958 2010 1979; x_wconf 91'>le</span>
+      <span class='ocrx_word' id='word_1_1620' title='bbox 2031 1957 2086 1978; x_wconf 91'>lotte</span>
+      <span class='ocrx_word' id='word_1_1621' title='bbox 2106 1963 2146 1982; x_wconf 91'>per</span>
+      <span class='ocrx_word' id='word_1_1622' title='bbox 2165 1955 2220 1976; x_wconf 90'>libe-</span>
+     </span>
+     <span class='ocr_line' id='line_1_234' title="bbox 1582 1987 2220 2011; baseline 0.002 -4; x_size 27.453323; x_descenders 5.4533243; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1623' title='bbox 1582 1994 1631 2008; x_wconf 89'>rare</span>
+      <span class='ocrx_word' id='word_1_1624' title='bbox 1648 1987 1662 2008; x_wconf 89'>il</span>
+      <span class='ocrx_word' id='word_1_1625' title='bbox 1681 1991 1786 2009; x_wconf 91'>nascente</span>
+      <span class='ocrx_word' id='word_1_1626' title='bbox 1805 1988 1944 2011; x_wconf 91'>movimento</span>
+      <span class='ocrx_word' id='word_1_1627' title='bbox 1964 1989 2142 2011; x_wconf 91'>rivoluzionario</span>
+      <span class='ocrx_word' id='word_1_1628' title='bbox 2161 1988 2220 2009; x_wconf 91'>dalle</span>
+     </span>
+     <span class='ocr_line' id='line_1_235' title="bbox 1583 2019 2219 2047; baseline 0.006 -8; x_size 28; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1629' title='bbox 1583 2019 1693 2040; x_wconf 91'>tendenze</span>
+      <span class='ocrx_word' id='word_1_1630' title='bbox 1713 2019 1755 2041; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_1631' title='bbox 1777 2027 1871 2042; x_wconf 91'>cercano</span>
+      <span class='ocrx_word' id='word_1_1632' title='bbox 1893 2021 2006 2043; x_wconf 66'>deviarlo:</span>
+      <span class='ocrx_word' id='word_1_1633' title='bbox 2033 2021 2109 2047; x_wconf 90'>quella</span>
+      <span class='ocrx_word' id='word_1_1634' title='bbox 2130 2020 2219 2047; x_wconf 91'>populi-</span>
+     </span>
+     <span class='ocr_line' id='line_1_236' title="bbox 1583 2051 2220 2081; baseline 0.005 -10; x_size 26.453323; x_descenders 5.4533243; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1635' title='bbox 1583 2056 1617 2072; x_wconf 89'>sta</span>
+      <span class='ocrx_word' id='word_1_1636' title='bbox 1635 2051 1682 2081; x_wconf 69'>(ded</span>
+      <span class='ocrx_word' id='word_1_1637' title='bbox 1696 2052 1826 2077; x_wconf 91'>narodniki)</span>
+      <span class='ocrx_word' id='word_1_1638' title='bbox 1845 2054 1886 2074; x_wconf 43'>che</span>
+      <span class='ocrx_word' id='word_1_1639' title='bbox 1905 2061 1949 2075; x_wconf 90'>non</span>
+      <span class='ocrx_word' id='word_1_1640' title='bbox 1969 2055 2097 2076; x_wconf 90'>credevano</span>
+      <span class='ocrx_word' id='word_1_1641' title='bbox 2112 2054 2158 2075; x_wconf 85'>allo</span>
+      <span class='ocrx_word' id='word_1_1642' title='bbox 2177 2053 2220 2074; x_wconf 88'>svi-</span>
+     </span>
+     <span class='ocr_line' id='line_1_237' title="bbox 1582 2082 2219 2111; baseline 0.003 -8; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1643' title='bbox 1582 2083 1653 2108; x_wconf 73'>luppo</span>
+      <span class='ocrx_word' id='word_1_1644' title='bbox 1673 2082 1708 2104; x_wconf 90'>del</span>
+      <span class='ocrx_word' id='word_1_1645' title='bbox 1729 2084 1871 2109; x_wconf 91'>capitalismo</span>
+      <span class='ocrx_word' id='word_1_1646' title='bbox 1891 2085 1914 2106; x_wconf 92'>in</span>
+      <span class='ocrx_word' id='word_1_1647' title='bbox 1936 2086 2020 2108; x_wconf 92'>Russia</span>
+      <span class='ocrx_word' id='word_1_1648' title='bbox 2041 2094 2052 2108; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_1649' title='bbox 2073 2085 2154 2111; x_wconf 74'>quindi</span>
+      <span class='ocrx_word' id='word_1_1650' title='bbox 2175 2085 2219 2106; x_wconf 72'>alla</span>
+     </span>
+     <span class='ocr_line' id='line_1_238' title="bbox 1584 2115 2220 2144; baseline 0.002 -7; x_size 28; x_descenders 6; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1651' title='bbox 1584 2115 1720 2136; x_wconf 92'>formazione</span>
+      <span class='ocrx_word' id='word_1_1652' title='bbox 1741 2115 1763 2136; x_wconf 90'>di</span>
+      <span class='ocrx_word' id='word_1_1653' title='bbox 1784 2124 1814 2138; x_wconf 89'>un</span>
+      <span class='ocrx_word' id='word_1_1654' title='bbox 1836 2121 1927 2143; x_wconf 78'>potente</span>
+      <span class='ocrx_word' id='word_1_1655' title='bbox 1947 2127 1961 2140; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_1656' title='bbox 1980 2125 2104 2140; x_wconf 91'>numeroso</span>
+      <span class='ocrx_word' id='word_1_1657' title='bbox 2123 2118 2220 2144; x_wconf 91'>proleta-</span>
+     </span>
+     <span class='ocr_line' id='line_1_239' title="bbox 1584 2146 2219 2173; baseline 0.002 -6; x_size 27.453323; x_descenders 5.4533243; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1658' title='bbox 1584 2146 1641 2168; x_wconf 90'>riato</span>
+      <span class='ocrx_word' id='word_1_1659' title='bbox 1660 2155 1672 2169; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_1660' title='bbox 1692 2147 1765 2173; x_wconf 92'>perciò</span>
+      <span class='ocrx_word' id='word_1_1661' title='bbox 1786 2151 1936 2171; x_wconf 91'>sostenevano</span>
+      <span class='ocrx_word' id='word_1_1662' title='bbox 1957 2151 1999 2172; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_1663' title='bbox 2018 2152 2025 2173; x_wconf 93'>i</span>
+      <span class='ocrx_word' id='word_1_1664' title='bbox 2045 2150 2163 2172; x_wconf 90'>contadini</span>
+      <span class='ocrx_word' id='word_1_1665' title='bbox 2184 2157 2219 2171; x_wconf 92'>co-</span>
+     </span>
+     <span class='ocr_line' id='line_1_240' title="bbox 1585 2179 2220 2204; baseline 0.005 -5; x_size 26.453323; x_descenders 5.4533243; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1666' title='bbox 1585 2179 1718 2200; x_wconf 90'>stituiscono</span>
+      <span class='ocrx_word' id='word_1_1667' title='bbox 1741 2180 1764 2202; x_wconf 57'>lla</span>
+      <span class='ocrx_word' id='word_1_1668' title='bbox 1788 2181 1834 2202; x_wconf 87'>sola</span>
+      <span class='ocrx_word' id='word_1_1669' title='bbox 1860 2182 1931 2203; x_wconf 81'>olasse</span>
+      <span class='ocrx_word' id='word_1_1670' title='bbox 1953 2182 2131 2204; x_wconf 79'>rivoluzionaria</span>
+      <span class='ocrx_word' id='word_1_1671' title='bbox 2157 2195 2186 2197; x_wconf 96'>—</span>
+      <span class='ocrx_word' id='word_1_1672' title='bbox 2209 2189 2220 2202; x_wconf 96'>e</span>
+     </span>
+     <span class='ocr_line' id='line_1_241' title="bbox 1584 2210 2221 2240; baseline 0.008 -9; x_size 26; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1673' title='bbox 1584 2210 1659 2235; x_wconf 90'>quella</span>
+      <span class='ocrx_word' id='word_1_1674' title='bbox 1682 2212 1716 2233; x_wconf 91'>dei</span>
+      <span class='ocrx_word' id='word_1_1675' title='bbox 1741 2212 1843 2235; x_wconf 88'>cosidetti</span>
+      <span class='ocrx_word' id='word_1_1676' title='bbox 1870 2222 1879 2234; x_wconf 91'>«</span>
+      <span class='ocrx_word' id='word_1_1677' title='bbox 1890 2213 1995 2235; x_wconf 92'>marxisti</span>
+      <span class='ocrx_word' id='word_1_1678' title='bbox 2016 2214 2116 2240; x_wconf 54'>legali»,</span>
+      <span class='ocrx_word' id='word_1_1679' title='bbox 2142 2221 2185 2236; x_wconf 92'>con</span>
+      <span class='ocrx_word' id='word_1_1680' title='bbox 2209 2222 2221 2234; x_wconf 76'>u</span>
+     </span>
+     <span class='ocr_line' id='line_1_242' title="bbox 1584 2241 2220 2271; baseline 0 -4; x_size 30; x_descenders 5; x_ascenders 11">
+      <span class='ocrx_word' id='word_1_1681' title='bbox 1584 2248 1640 2267; x_wconf 89'>capo</span>
+      <span class='ocrx_word' id='word_1_1682' title='bbox 1654 2242 1743 2268; x_wconf 75'>Stmuve,</span>
+      <span class='ocrx_word' id='word_1_1683' title='bbox 1760 2241 1851 2270; x_wconf 5'>‘Tugar,</span>
+      <span class='ocrx_word' id='word_1_1684' title='bbox 1869 2246 2009 2267; x_wconf 89'>Baranovski</span>
+      <span class='ocrx_word' id='word_1_1685' title='bbox 2027 2254 2038 2268; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_1686' title='bbox 2055 2246 2107 2267; x_wconf 91'>altri</span>
+      <span class='ocrx_word' id='word_1_1687' title='bbox 2124 2247 2166 2268; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_1688' title='bbox 2181 2253 2220 2271; x_wconf 85'>og-</span>
+     </span>
+     <span class='ocr_line' id='line_1_243' title="bbox 1583 2274 2220 2301; baseline 0.009 -7; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1689' title='bbox 1583 2274 1605 2298; x_wconf 92'>gi</span>
+      <span class='ocrx_word' id='word_1_1690' title='bbox 1621 2281 1676 2296; x_wconf 92'>sono</span>
+      <span class='ocrx_word' id='word_1_1691' title='bbox 1689 2282 1701 2295; x_wconf 93'>a</span>
+      <span class='ocrx_word' id='word_1_1692' title='bbox 1716 2282 1772 2301; x_wconf 91'>capo</span>
+      <span class='ocrx_word' id='word_1_1693' title='bbox 1787 2278 1844 2298; x_wconf 63'>della</span>
+      <span class='ocrx_word' id='word_1_1694' title='bbox 1860 2278 2095 2300; x_wconf 68'>coutrorivoluzione:</span>
+      <span class='ocrx_word' id='word_1_1695' title='bbox 2113 2279 2157 2300; x_wconf 91'>essi</span>
+      <span class='ocrx_word' id='word_1_1696' title='bbox 2174 2285 2220 2300; x_wconf 92'>era-</span>
+     </span>
+     <span class='ocr_line' id='line_1_244' title="bbox 1584 2306 2219 2332; baseline 0.005 -6; x_size 27.453323; x_descenders 5.4533243; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1697' title='bbox 1584 2313 1613 2326; x_wconf 91'>no</span>
+      <span class='ocrx_word' id='word_1_1698' title='bbox 1628 2306 1662 2327; x_wconf 91'>dei</span>
+      <span class='ocrx_word' id='word_1_1699' title='bbox 1679 2306 1764 2327; x_wconf 89'>liberali</span>
+      <span class='ocrx_word' id='word_1_1700' title='bbox 1782 2309 1823 2330; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_1701' title='bbox 1838 2316 1939 2331; x_wconf 78'>avevano</span>
+      <span class='ocrx_word' id='word_1_1702' title='bbox 1954 2310 2055 2332; x_wconf 91'>studiato</span>
+      <span class='ocrx_word' id='word_1_1703' title='bbox 2071 2311 2140 2331; x_wconf 89'>Marx</span>
+      <span class='ocrx_word' id='word_1_1704' title='bbox 2157 2319 2168 2332; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_1705' title='bbox 2185 2309 2219 2330; x_wconf 92'>del</span>
+     </span>
+     <span class='ocr_line' id='line_1_245' title="bbox 1594 2334 2220 2363; baseline 0.006 -6; x_size 26.453323; x_descenders 5.4533243; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1706' title='bbox 1594 2334 1719 2361; x_wconf 38'>marxismlo</span>
+      <span class='ocrx_word' id='word_1_1707' title='bbox 1741 2342 1890 2361; x_wconf 68'>accettavano</span>
+      <span class='ocrx_word' id='word_1_1708' title='bbox 1912 2341 1933 2362; x_wconf 89'>la</span>
+      <span class='ocrx_word' id='word_1_1709' title='bbox 1957 2342 2136 2363; x_wconf 91'>dimostrazione</span>
+      <span class='ocrx_word' id='word_1_1710' title='bbox 2161 2341 2220 2362; x_wconf 87'>della</span>
+     </span>
+     <span class='ocr_line' id='line_1_246' title="bbox 1585 2369 2220 2400; baseline -0.005 -4; x_size 27; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_1711' title='bbox 1585 2369 1693 2390; x_wconf 57'>necessità</span>
+      <span class='ocrx_word' id='word_1_1712' title='bbox 1714 2371 1794 2395; x_wconf 85'>storica</span>
+      <span class='ocrx_word' id='word_1_1713' title='bbox 1817 2372 1858 2394; x_wconf 90'>che</span>
+      <span class='ocrx_word' id='word_1_1714' title='bbox 1879 2373 1895 2394; x_wconf 88'>il</span>
+      <span class='ocrx_word' id='word_1_1715' title='bbox 1916 2373 2059 2400; x_wconf 88'>capitalismo</span>
+      <span class='ocrx_word' id='word_1_1716' title='bbox 2079 2376 2099 2396; x_wconf 85'>si</span>
+      <span class='ocrx_word' id='word_1_1717' title='bbox 2119 2373 2220 2399; x_wconf 87'>sviluppi</span>
+     </span>
+     <span class='ocr_line' id='line_1_247' title="bbox 1584 2401 2220 2432; baseline 0.003 -9; x_size 27; x_descenders 6; x_ascenders 6">
+      <span class='ocrx_word' id='word_1_1718' title='bbox 1584 2408 1594 2421; x_wconf 91'>e</span>
+      <span class='ocrx_word' id='word_1_1719' title='bbox 1613 2401 1739 2423; x_wconf 86'>sostituisca</span>
+      <span class='ocrx_word' id='word_1_1720' title='bbox 1759 2402 1773 2423; x_wconf 34'>Îl</span>
+      <span class='ocrx_word' id='word_1_1721' title='bbox 1793 2404 1877 2429; x_wconf 92'>regime</span>
+      <span class='ocrx_word' id='word_1_1722' title='bbox 1893 2405 1993 2430; x_wconf 90'>feudalle;</span>
+      <span class='ocrx_word' id='word_1_1723' title='bbox 2013 2407 2125 2428; x_wconf 88'>vollevano</span>
+      <span class='ocrx_word' id='word_1_1724' title='bbox 2145 2405 2220 2432; x_wconf 88'>perciò</span>
+     </span>
+     <span class='ocr_line' id='line_1_248' title="bbox 1584 2433 2219 2460; baseline -0.006 1; x_size 26.063801; x_descenders 5.0638013; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1725' title='bbox 1584 2433 1625 2454; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_1726' title='bbox 1645 2434 1665 2454; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_1727' title='bbox 1687 2434 1757 2455; x_wconf 80'>classe</span>
+      <span class='ocrx_word' id='word_1_1728' title='bbox 1778 2436 1868 2460; x_wconf 36'>ofperaia</span>
+      <span class='ocrx_word' id='word_1_1729' title='bbox 1890 2437 1908 2457; x_wconf 89'>si</span>
+      <span class='ocrx_word' id='word_1_1730' title='bbox 1928 2437 2039 2460; x_wconf 67'>limitasse</span>
+      <span class='ocrx_word' id='word_1_1731' title='bbox 2061 2447 2072 2460; x_wconf 92'>a</span>
+      <span class='ocrx_word' id='word_1_1732' title='bbox 2094 2439 2180 2460; x_wconf 90'>servire</span>
+      <span class='ocrx_word' id='word_1_1733' title='bbox 2199 2438 2219 2458; x_wconf 84'>la</span>
+     </span>
+     <span class='ocr_line' id='line_1_249' title="bbox 1585 2465 2220 2495; baseline 0.009 -10; x_size 24; x_descenders 4; x_ascenders 6">
+      <span class='ocrx_word' id='word_1_1734' title='bbox 1585 2465 1672 2488; x_wconf 91'>passiva</span>
+      <span class='ocrx_word' id='word_1_1735' title='bbox 1692 2472 1765 2486; x_wconf 91'>massa</span>
+      <span class='ocrx_word' id='word_1_1736' title='bbox 1787 2468 1811 2488; x_wconf 81'>dî</span>
+      <span class='ocrx_word' id='word_1_1737' title='bbox 1831 2474 1938 2490; x_wconf 84'>manovra</span>
+      <span class='ocrx_word' id='word_1_1738' title='bbox 1959 2470 1994 2491; x_wconf 90'>del</span>
+      <span class='ocrx_word' id='word_1_1739' title='bbox 2017 2471 2160 2495; x_wconf 83'>capitalismo</span>
+      <span class='ocrx_word' id='word_1_1740' title='bbox 2181 2475 2220 2495; x_wconf 83'>per</span>
+     </span>
+     <span class='ocr_line' id='line_1_250' title="bbox 1584 2497 2220 2523; baseline 0.009 -7; x_size 25; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1741' title='bbox 1584 2498 1700 2521; x_wconf 90'>strappare</span>
+      <span class='ocrx_word' id='word_1_1742' title='bbox 1719 2497 1855 2522; x_wconf 90'>legalmente</span>
+      <span class='ocrx_word' id='word_1_1743' title='bbox 1877 2499 1923 2520; x_wconf 91'>allo</span>
+      <span class='ocrx_word' id='word_1_1744' title='bbox 1943 2508 1979 2522; x_wconf 90'>zar</span>
+      <span class='ocrx_word' id='word_1_1745' title='bbox 2001 2501 2021 2522; x_wconf 90'>le</span>
+      <span class='ocrx_word' id='word_1_1746' title='bbox 2042 2502 2123 2523; x_wconf 91'>libertà</span>
+      <span class='ocrx_word' id='word_1_1747' title='bbox 2144 2507 2220 2522; x_wconf 91'>neces-</span>
+     </span>
+     <span class='ocr_line' id='line_1_251' title="bbox 1585 2527 1847 2554; baseline 0.004 -7; x_size 27; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1748' title='bbox 1585 2527 1640 2548; x_wconf 84'>sarie</span>
+      <span class='ocrx_word' id='word_1_1749' title='bbox 1659 2528 1701 2548; x_wconf 84'>alla</span>
+      <span class='ocrx_word' id='word_1_1750' title='bbox 1718 2528 1847 2554; x_wconf 85'>borghesia.</span>
+     </span>
+    </p>
+
+    <p class='ocr_par' id='par_1_18' lang='ita' title="bbox 1584 2559 2221 3050">
+     <span class='ocr_line' id='line_1_252' title="bbox 1613 2559 2220 2590; baseline -0.005 -3; x_size 32; x_descenders 7; x_ascenders 11">
+      <span class='ocrx_word' id='word_1_1751' title='bbox 1613 2559 1746 2584; x_wconf 89'>Nell’aprile</span>
+      <span class='ocrx_word' id='word_1_1752' title='bbox 1766 2560 1819 2586; x_wconf 90'>1805</span>
+      <span class='ocrx_word' id='word_1_1753' title='bbox 1839 2561 1912 2583; x_wconf 92'>Lenin</span>
+      <span class='ocrx_word' id='word_1_1754' title='bbox 1931 2564 1949 2584; x_wconf 93'>sî</span>
+      <span class='ocrx_word' id='word_1_1755' title='bbox 1969 2565 2020 2585; x_wconf 89'>recò</span>
+      <span class='ocrx_word' id='word_1_1756' title='bbox 2038 2565 2161 2590; x_wconf 60'>all’estero,</span>
+      <span class='ocrx_word' id='word_1_1757' title='bbox 2182 2564 2220 2584; x_wconf 93'>do-</span>
+     </span>
+     <span class='ocr_line' id='line_1_253' title="bbox 1585 2590 2220 2622; baseline -0.005 -3; x_size 24; x_descenders 3; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_1758' title='bbox 1585 2597 1611 2611; x_wconf 91'>ve</span>
+      <span class='ocrx_word' id='word_1_1759' title='bbox 1629 2592 1645 2612; x_wconf 76'>si</span>
+      <span class='ocrx_word' id='word_1_1760' title='bbox 1667 2590 1722 2613; x_wconf 89'>mise</span>
+      <span class='ocrx_word' id='word_1_1761' title='bbox 1741 2591 1762 2611; x_wconf 89'>in</span>
+      <span class='ocrx_word' id='word_1_1762' title='bbox 1783 2598 1891 2618; x_wconf 90'>rapporto</span>
+      <span class='ocrx_word' id='word_1_1763' title='bbox 1907 2596 1942 2616; x_wconf 72'>col</span>
+      <span class='ocrx_word' id='word_1_1764' title='bbox 1961 2602 2052 2622; x_wconf 90'>gruppo</span>
+      <span class='ocrx_word' id='word_1_1765' title='bbox 2072 2605 2081 2616; x_wconf 90'>«</span>
+      <span class='ocrx_word' id='word_1_1766' title='bbox 2092 2596 2220 2618; x_wconf 87'>Liberazio-</span>
+     </span>
+     <span class='ocr_line' id='line_1_254' title="bbox 1586 2622 2220 2650; baseline -0.002 -1; x_size 35.179985; x_descenders 8.179987; x_ascenders 6">
+      <span class='ocrx_word' id='word_1_1767' title='bbox 1586 2628 1613 2642; x_wconf 92'>ne</span>
+      <span class='ocrx_word' id='word_1_1768' title='bbox 1631 2622 1665 2646; x_wconf 82'>del</span>
+      <span class='ocrx_word' id='word_1_1769' title='bbox 1685 2622 1775 2644; x_wconf 35'>Lavoro</span>
+      <span class='ocrx_word' id='word_1_1770' title='bbox 1784 2632 1803 2648; x_wconf 35'>»,</span>
+      <span class='ocrx_word' id='word_1_1771' title='bbox 1823 2625 1918 2649; x_wconf 92'>fondato</span>
+      <span class='ocrx_word' id='word_1_1772' title='bbox 1934 2627 1960 2649; x_wconf 69'>n</span>
+      <span class='ocrx_word' id='word_1_1773' title='bbox 1977 2628 2089 2650; x_wconf 91'>Isvizzera</span>
+      <span class='ocrx_word' id='word_1_1774' title='bbox 2108 2628 2136 2649; x_wconf 92'>da</span>
+      <span class='ocrx_word' id='word_1_1775' title='bbox 2155 2628 2220 2649; x_wconf 92'>Gior-</span>
+     </span>
+     <span class='ocr_line' id='line_1_255' title="bbox 1584 2653 2218 2682; baseline -0.002 -8; x_size 26.453323; x_descenders 5.4533243; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1776' title='bbox 1584 2653 1622 2676; x_wconf 84'>gio</span>
+      <span class='ocrx_word' id='word_1_1777' title='bbox 1645 2653 1781 2679; x_wconf 84'>Plekhanof,</span>
+      <span class='ocrx_word' id='word_1_1778' title='bbox 1806 2655 1873 2677; x_wconf 91'>Viera</span>
+      <span class='ocrx_word' id='word_1_1779' title='bbox 1898 2657 1997 2680; x_wconf 84'>Sassulic</span>
+      <span class='ocrx_word' id='word_1_1780' title='bbox 2023 2659 2119 2681; x_wconf 91'>(celebre</span>
+      <span class='ocrx_word' id='word_1_1781' title='bbox 2143 2667 2181 2682; x_wconf 91'>per</span>
+      <span class='ocrx_word' id='word_1_1782' title='bbox 2205 2659 2218 2676; x_wconf 86'>1!</span>
+     </span>
+     <span class='ocr_line' id='line_1_256' title="bbox 1585 2688 2220 2717; baseline 0.008 -12; x_size 25; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1783' title='bbox 1585 2691 1626 2711; x_wconf 36'>suo</span>
+      <span class='ocrx_word' id='word_1_1784' title='bbox 1645 2688 1757 2707; x_wconf 88'>attentato</span>
+      <span class='ocrx_word' id='word_1_1785' title='bbox 1775 2691 1854 2710; x_wconf 90'>contro</span>
+      <span class='ocrx_word' id='word_1_1786' title='bbox 1873 2689 1891 2710; x_wconf 82'>ill</span>
+      <span class='ocrx_word' id='word_1_1787' title='bbox 1910 2692 2016 2715; x_wconf 90'>generale</span>
+      <span class='ocrx_word' id='word_1_1788' title='bbox 2034 2690 2129 2717; x_wconf 40'>‘Trepof)</span>
+      <span class='ocrx_word' id='word_1_1789' title='bbox 2151 2691 2220 2712; x_wconf 90'>Paolo</span>
+     </span>
+     <span class='ocr_line' id='line_1_257' title="bbox 1586 2715 2220 2748; baseline -0.003 -4; x_size 34; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_1790' title='bbox 1586 2715 1685 2737; x_wconf 89'>Axelrod</span>
+      <span class='ocrx_word' id='word_1_1791' title='bbox 1700 2726 1712 2739; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_1792' title='bbox 1726 2718 1845 2742; x_wconf 80'>onganizzò</span>
+      <span class='ocrx_word' id='word_1_1793' title='bbox 1858 2720 1875 2741; x_wconf 90'>il</span>
+      <span class='ocrx_word' id='word_1_1794' title='bbox 1888 2723 2008 2747; x_wconf 91'>passaggio</span>
+      <span class='ocrx_word' id='word_1_1795' title='bbox 2021 2723 2112 2748; x_wconf 89'>illegale</span>
+      <span class='ocrx_word' id='word_1_1796' title='bbox 2126 2723 2148 2743; x_wconf 92'>in</span>
+      <span class='ocrx_word' id='word_1_1797' title='bbox 2163 2723 2220 2742; x_wconf 90'>Rus-</span>
+     </span>
+     <span class='ocr_line' id='line_1_258' title="bbox 1585 2748 2218 2778; baseline 0.006 -9; x_size 25; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1798' title='bbox 1585 2748 1616 2769; x_wconf 88'>sia</span>
+      <span class='ocrx_word' id='word_1_1799' title='bbox 1632 2748 1690 2769; x_wconf 88'>della</span>
+      <span class='ocrx_word' id='word_1_1800' title='bbox 1707 2749 1837 2772; x_wconf 90'>letteratura</span>
+      <span class='ocrx_word' id='word_1_1801' title='bbox 1855 2752 2028 2778; x_wconf 67'>rivolluzionaria</span>
+      <span class='ocrx_word' id='word_1_1802' title='bbox 2047 2754 2170 2775; x_wconf 84'>marxista:</span>
+      <span class='ocrx_word' id='word_1_1803' title='bbox 2193 2753 2218 2775; x_wconf 95'>ri-</span>
+     </span>
+     <span class='ocr_line' id='line_1_259' title="bbox 1585 2780 2220 2811; baseline 0.008 -12; x_size 27; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1804' title='bbox 1585 2783 1673 2801; x_wconf 70'>tomato</span>
+      <span class='ocrx_word' id='word_1_1805' title='bbox 1686 2787 1697 2800; x_wconf 93'>a</span>
+      <span class='ocrx_word' id='word_1_1806' title='bbox 1710 2780 1859 2807; x_wconf 88'>Pietrogrado</span>
+      <span class='ocrx_word' id='word_1_1807' title='bbox 1871 2785 1909 2805; x_wconf 80'>neli</span>
+      <span class='ocrx_word' id='word_1_1808' title='bbox 1919 2786 2050 2811; x_wconf 91'>settembre,</span>
+      <span class='ocrx_word' id='word_1_1809' title='bbox 2065 2786 2136 2807; x_wconf 91'>fondò</span>
+      <span class='ocrx_word' id='word_1_1810' title='bbox 2149 2785 2179 2806; x_wconf 77'>1’«</span>
+      <span class='ocrx_word' id='word_1_1811' title='bbox 2190 2785 2220 2804; x_wconf 94'>U-</span>
+     </span>
+     <span class='ocr_line' id='line_1_260' title="bbox 1586 2811 2220 2841; baseline 0.005 -8; x_size 27; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1812' title='bbox 1586 2811 1651 2832; x_wconf 90'>nione</span>
+      <span class='ocrx_word' id='word_1_1813' title='bbox 1665 2811 1688 2832; x_wconf 86'>di</span>
+      <span class='ocrx_word' id='word_1_1814' title='bbox 1702 2813 1757 2834; x_wconf 92'>lotta</span>
+      <span class='ocrx_word' id='word_1_1815' title='bbox 1772 2820 1811 2838; x_wconf 92'>per</span>
+      <span class='ocrx_word' id='word_1_1816' title='bbox 1823 2815 1844 2835; x_wconf 78'>la</span>
+      <span class='ocrx_word' id='word_1_1817' title='bbox 1856 2815 1996 2837; x_wconf 73'>liberazione</span>
+      <span class='ocrx_word' id='word_1_1818' title='bbox 2005 2817 2067 2838; x_wconf 90'>della</span>
+      <span class='ocrx_word' id='word_1_1819' title='bbox 2082 2818 2153 2838; x_wconf 90'>classe</span>
+      <span class='ocrx_word' id='word_1_1820' title='bbox 2168 2824 2220 2841; x_wconf 90'>ope-</span>
+     </span>
+     <span class='ocr_line' id='line_1_261' title="bbox 1585 2842 2219 2873; baseline 0.005 -9; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1821' title='bbox 1585 2842 1659 2867; x_wconf 85'>raia»,</span>
+      <span class='ocrx_word' id='word_1_1822' title='bbox 1679 2843 1720 2864; x_wconf 92'>che</span>
+      <span class='ocrx_word' id='word_1_1823' title='bbox 1738 2843 1764 2864; x_wconf 90'>fu</span>
+      <span class='ocrx_word' id='word_1_1824' title='bbox 1781 2851 1828 2866; x_wconf 90'>uno</span>
+      <span class='ocrx_word' id='word_1_1825' title='bbox 1844 2847 1881 2868; x_wconf 91'>dei</span>
+      <span class='ocrx_word' id='word_1_1826' title='bbox 1896 2847 2018 2873; x_wconf 89'>principali</span>
+      <span class='ocrx_word' id='word_1_1827' title='bbox 2037 2848 2112 2869; x_wconf 78'>muchei</span>
+      <span class='ocrx_word' id='word_1_1828' title='bbox 2131 2848 2169 2869; x_wconf 26'>del,</span>
+      <span class='ocrx_word' id='word_1_1829' title='bbox 2186 2848 2219 2868; x_wconf 89'>fu-</span>
+     </span>
+     <span class='ocr_line' id='line_1_262' title="bbox 1586 2874 2220 2904; baseline 0.009 -11; x_size 27; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1830' title='bbox 1586 2876 1636 2894; x_wconf 91'>turo</span>
+      <span class='ocrx_word' id='word_1_1831' title='bbox 1649 2874 1734 2899; x_wconf 90'>partito</span>
+      <span class='ocrx_word' id='word_1_1832' title='bbox 1748 2875 1867 2898; x_wconf 90'>socialista.</span>
+      <span class='ocrx_word' id='word_1_1833' title='bbox 1884 2878 1927 2899; x_wconf 91'>Nel</span>
+      <span class='ocrx_word' id='word_1_1834' title='bbox 1944 2878 2060 2901; x_wconf 61'>dicembre</span>
+      <span class='ocrx_word' id='word_1_1835' title='bbox 2076 2879 2131 2903; x_wconf 93'>1896</span>
+      <span class='ocrx_word' id='word_1_1836' title='bbox 2144 2880 2166 2899; x_wconf 89'>la</span>
+      <span class='ocrx_word' id='word_1_1837' title='bbox 2183 2886 2220 2904; x_wconf 91'>po-</span>
+     </span>
+     <span class='ocr_line' id='line_1_263' title="bbox 1585 2904 2220 2933; baseline -0.006 1; x_size 32.84285; x_descenders 5.8428478; x_ascenders 12">
+      <span class='ocrx_word' id='word_1_1838' title='bbox 1585 2904 1634 2926; x_wconf 86'>lizia</span>
+      <span class='ocrx_word' id='word_1_1839' title='bbox 1657 2906 1741 2926; x_wconf 86'>arrestò</span>
+      <span class='ocrx_word' id='word_1_1840' title='bbox 1762 2906 1782 2927; x_wconf 88'>la</span>
+      <span class='ocrx_word' id='word_1_1841' title='bbox 1804 2909 1963 2933; x_wconf 88'>maggioranza</span>
+      <span class='ocrx_word' id='word_1_1842' title='bbox 1985 2910 2021 2931; x_wconf 88'>dei</span>
+      <span class='ocrx_word' id='word_1_1843' title='bbox 2042 2910 2140 2931; x_wconf 92'>membri</span>
+      <span class='ocrx_word' id='word_1_1844' title='bbox 2162 2910 2220 2931; x_wconf 92'>della</span>
+     </span>
+     <span class='ocr_line' id='line_1_264' title="bbox 1586 2934 2221 2966; baseline -0.002 -4; x_size 27; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_1845' title='bbox 1586 2934 1683 2960; x_wconf 91'>Unione;</span>
+      <span class='ocrx_word' id='word_1_1846' title='bbox 1703 2944 1739 2957; x_wconf 92'>ma</span>
+      <span class='ocrx_word' id='word_1_1847' title='bbox 1760 2939 1833 2960; x_wconf 91'>anche</span>
+      <span class='ocrx_word' id='word_1_1848' title='bbox 1853 2941 1876 2962; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_1849' title='bbox 1897 2941 2003 2966; x_wconf 55'>prigione</span>
+      <span class='ocrx_word' id='word_1_1850' title='bbox 2023 2941 2097 2962; x_wconf 92'>Lenin</span>
+      <span class='ocrx_word' id='word_1_1851' title='bbox 2120 2948 2165 2962; x_wconf 92'>non</span>
+      <span class='ocrx_word' id='word_1_1852' title='bbox 2188 2941 2221 2961; x_wconf 91'>in-</span>
+     </span>
+     <span class='ocr_line' id='line_1_265' title="bbox 1586 2968 2219 2994; baseline -0.003 -1; x_size 29.453323; x_descenders 5.4533243; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_1853' title='bbox 1586 2970 1698 2992; x_wconf 91'>terrompe</span>
+      <span class='ocrx_word' id='word_1_1854' title='bbox 1720 2968 1733 2992; x_wconf 79'>i]</span>
+      <span class='ocrx_word' id='word_1_1855' title='bbox 1759 2976 1800 2991; x_wconf 92'>suo</span>
+      <span class='ocrx_word' id='word_1_1856' title='bbox 1823 2971 1901 2994; x_wconf 91'>lavaro</span>
+      <span class='ocrx_word' id='word_1_1857' title='bbox 1924 2972 2103 2994; x_wconf 90'>rivoluzionario</span>
+      <span class='ocrx_word' id='word_1_1858' title='bbox 2124 2980 2135 2993; x_wconf 92'>e</span>
+      <span class='ocrx_word' id='word_1_1859' title='bbox 2160 2972 2219 2993; x_wconf 91'>invia</span>
+     </span>
+     <span class='ocr_line' id='line_1_266' title="bbox 1585 2998 2210 3031; baseline 0.018 -14; x_size 29; x_descenders 5; x_ascenders 10">
+      <span class='ocrx_word' id='word_1_1860' title='bbox 1585 2998 1692 3031; x_wconf 91'>proclami</span>
+      <span class='ocrx_word' id='word_1_1861' title='bbox 1711 3006 1723 3020; x_wconf 91'>e</span>
+      <span class='ocrx_word' id='word_1_1862' title='bbox 1743 3002 1844 3025; x_wconf 91'>opuscoli</span>
+      <span class='ocrx_word' id='word_1_1863' title='bbox 1864 3003 1883 3023; x_wconf 85'>ai</span>
+      <span class='ocrx_word' id='word_1_1864' title='bbox 1904 3003 2025 3028; x_wconf 91'>compagni</span>
+      <span class='ocrx_word' id='word_1_1865' title='bbox 2046 3004 2132 3024; x_wconf 49'>rimasti</span>
+      <span class='ocrx_word' id='word_1_1866' title='bbox 2152 3004 2175 3024; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_1867' title='bbox 2195 3004 2210 3025; x_wconf 89'>1i</span>
+     </span>
+     <span class='ocr_line' id='line_1_267' title="bbox 1586 3029 1654 3050; baseline 0 0; x_size 27.979254; x_descenders 5.6493211; x_ascenders 7.8267636">
+      <span class='ocrx_word' id='word_1_1868' title='bbox 1586 3029 1654 3050; x_wconf 84'>bertà.</span>
+     </span>
+    </p>
+
+    <p class='ocr_par' id='par_1_19' lang='ita' title="bbox 1753 3079 2049 3111">
+     <span class='ocr_line' id='line_1_268' title="bbox 1753 3079 2049 3111; baseline 0.003 -7; x_size 32; x_descenders 6; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1869' title='bbox 1753 3079 1888 3111; x_wconf 92'>Deportato</span>
+      <span class='ocrx_word' id='word_1_1870' title='bbox 1907 3081 1933 3106; x_wconf 91'>in</span>
+      <span class='ocrx_word' id='word_1_1871' title='bbox 1954 3080 2049 3106; x_wconf 91'>Siberia</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_14' title="bbox 1585 3126 2221 3466">
+    <p class='ocr_par' id='par_1_20' lang='ita' title="bbox 1585 3126 2221 3466">
+     <span class='ocr_line' id='line_1_269' title="bbox 1615 3126 2220 3156; baseline 0.01 -10; x_size 25; x_descenders 4; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1872' title='bbox 1615 3126 1665 3148; x_wconf 90'>Alla</span>
+      <span class='ocrx_word' id='word_1_1873' title='bbox 1682 3127 1727 3150; x_wconf 91'>fine</span>
+      <span class='ocrx_word' id='word_1_1874' title='bbox 1741 3129 1779 3150; x_wconf 91'>del</span>
+      <span class='ocrx_word' id='word_1_1875' title='bbox 1795 3130 1898 3151; x_wconf 66'>febbraio</span>
+      <span class='ocrx_word' id='word_1_1876' title='bbox 1915 3130 1969 3155; x_wconf 92'>1898</span>
+      <span class='ocrx_word' id='word_1_1877' title='bbox 1985 3130 2059 3152; x_wconf 90'>Lenin</span>
+      <span class='ocrx_word' id='word_1_1878' title='bbox 2076 3131 2100 3152; x_wconf 92'>fu</span>
+      <span class='ocrx_word' id='word_1_1879' title='bbox 2118 3131 2220 3156; x_wconf 91'>deporta-</span>
+     </span>
+     <span class='ocr_line' id='line_1_270' title="bbox 1586 3158 2220 3191; baseline 0.006 -13; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1880' title='bbox 1586 3161 1609 3191; x_wconf 91'>to</span>
+      <span class='ocrx_word' id='word_1_1881' title='bbox 1628 3159 1649 3178; x_wconf 80'>in</span>
+      <span class='ocrx_word' id='word_1_1882' title='bbox 1669 3158 1763 3184; x_wconf 86'>Siberia,</span>
+      <span class='ocrx_word' id='word_1_1883' title='bbox 1784 3162 1822 3182; x_wconf 91'>nel</span>
+      <span class='ocrx_word' id='word_1_1884' title='bbox 1839 3161 1934 3186; x_wconf 89'>villagio</span>
+      <span class='ocrx_word' id='word_1_1885' title='bbox 1953 3160 1975 3181; x_wconf 92'>di</span>
+      <span class='ocrx_word' id='word_1_1886' title='bbox 1995 3161 2150 3187; x_wconf 91'>Sciuscenski,</span>
+      <span class='ocrx_word' id='word_1_1887' title='bbox 2170 3168 2220 3187; x_wconf 92'>pro-</span>
+     </span>
+     <span class='ocr_line' id='line_1_271' title="bbox 1587 3189 2220 3218; baseline 0.011 -10; x_size 27; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1888' title='bbox 1587 3189 1658 3210; x_wconf 91'>vincia</span>
+      <span class='ocrx_word' id='word_1_1889' title='bbox 1680 3189 1837 3212; x_wconf 80'>dell’Tenissei.</span>
+      <span class='ocrx_word' id='word_1_1890' title='bbox 1862 3192 1889 3212; x_wconf 93'>In</span>
+      <span class='ocrx_word' id='word_1_1891' title='bbox 1912 3191 1977 3213; x_wconf 91'>esilio</span>
+      <span class='ocrx_word' id='word_1_1892' title='bbox 1998 3193 2043 3218; x_wconf 92'>egli</span>
+      <span class='ocrx_word' id='word_1_1893' title='bbox 2066 3194 2084 3214; x_wconf 87'>si</span>
+      <span class='ocrx_word' id='word_1_1894' title='bbox 2106 3193 2186 3214; x_wconf 90'>dedica</span>
+      <span class='ocrx_word' id='word_1_1895' title='bbox 2209 3198 2220 3211; x_wconf 96'>a</span>
+     </span>
+     <span class='ocr_line' id='line_1_272' title="bbox 1586 3220 2220 3249; baseline 0.011 -11; x_size 28; x_descenders 5; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_1896' title='bbox 1586 3225 1614 3241; x_wconf 78'>un</span>
+      <span class='ocrx_word' id='word_1_1897' title='bbox 1636 3220 1787 3247; x_wconf 89'>ininterrotto,</span>
+      <span class='ocrx_word' id='word_1_1898' title='bbox 1808 3223 1923 3247; x_wconf 90'>profondo</span>
+      <span class='ocrx_word' id='word_1_1899' title='bbox 1939 3223 2018 3245; x_wconf 91'>studio</span>
+      <span class='ocrx_word' id='word_1_1900' title='bbox 2032 3225 2097 3246; x_wconf 89'>dello</span>
+      <span class='ocrx_word' id='word_1_1901' title='bbox 2114 3221 2220 3249; x_wconf 89'>sviluppo</span>
+     </span>
+     <span class='ocr_line' id='line_1_273' title="bbox 1586 3252 2220 3280; baseline 0.009 -10; x_size 25; x_descenders 4; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1902' title='bbox 1586 3252 1716 3273; x_wconf 91'>economico</span>
+      <span class='ocrx_word' id='word_1_1903' title='bbox 1732 3252 1790 3274; x_wconf 89'>della</span>
+      <span class='ocrx_word' id='word_1_1904' title='bbox 1806 3253 1897 3278; x_wconf 91'>Russia,</span>
+      <span class='ocrx_word' id='word_1_1905' title='bbox 1913 3254 1956 3274; x_wconf 93'>che</span>
+      <span class='ocrx_word' id='word_1_1906' title='bbox 1972 3254 2123 3276; x_wconf 91'>determinerà</span>
+      <span class='ocrx_word' id='word_1_1907' title='bbox 2139 3256 2153 3276; x_wconf 89'>il</span>
+      <span class='ocrx_word' id='word_1_1908' title='bbox 2171 3262 2220 3280; x_wconf 91'>pro-</span>
+     </span>
+     <span class='ocr_line' id='line_1_274' title="bbox 1585 3282 2219 3313; baseline 0.005 -11; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1909' title='bbox 1585 3289 1648 3305; x_wconf 89'>cesso</span>
+      <span class='ocrx_word' id='word_1_1910' title='bbox 1668 3282 1690 3302; x_wconf 89'>di</span>
+      <span class='ocrx_word' id='word_1_1911' title='bbox 1711 3283 1819 3309; x_wconf 85'>sviluppo</span>
+      <span class='ocrx_word' id='word_1_1912' title='bbox 1837 3285 1896 3305; x_wconf 91'>della</span>
+      <span class='ocrx_word' id='word_1_1913' title='bbox 1915 3284 2067 3313; x_wconf 82'>rivoluzione</span>
+      <span class='ocrx_word' id='word_1_1914' title='bbox 2089 3294 2101 3307; x_wconf 93'>e</span>
+      <span class='ocrx_word' id='word_1_1915' title='bbox 2122 3286 2188 3312; x_wconf 92'>portò</span>
+      <span class='ocrx_word' id='word_1_1916' title='bbox 2209 3293 2219 3305; x_wconf 96'>a</span>
+     </span>
+     <span class='ocr_line' id='line_1_275' title="bbox 1588 3312 2220 3343; baseline 0.009 -11; x_size 26; x_descenders 5; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1917' title='bbox 1588 3308 1683 3347; x_wconf 89'>termine</span>
+      <span class='ocrx_word' id='word_1_1918' title='bbox 1691 3314 1726 3343; x_wconf 91'>la</span>
+      <span class='ocrx_word' id='word_1_1919' title='bbox 1750 3320 1790 3335; x_wconf 90'>sua</span>
+      <span class='ocrx_word' id='word_1_1920' title='bbox 1813 3314 1901 3339; x_wconf 90'>grande</span>
+      <span class='ocrx_word' id='word_1_1921' title='bbox 1924 3321 2006 3340; x_wconf 91'>opera:</span>
+      <span class='ocrx_word' id='word_1_1922' title='bbox 2035 3324 2045 3336; x_wconf 44'>«</span>
+      <span class='ocrx_word' id='word_1_1923' title='bbox 2049 3316 2091 3339; x_wconf 44'>Lo</span>
+      <span class='ocrx_word' id='word_1_1924' title='bbox 2114 3317 2220 3341; x_wconf 87'>sviluppo</span>
+     </span>
+     <span class='ocr_line' id='line_1_276' title="bbox 1587 3341 2221 3373; baseline 0.008 -10; x_size 27; x_descenders 4; x_ascenders 9">
+      <span class='ocrx_word' id='word_1_1925' title='bbox 1587 3343 1622 3364; x_wconf 90'>del</span>
+      <span class='ocrx_word' id='word_1_1926' title='bbox 1636 3341 1777 3368; x_wconf 92'>capitalismo</span>
+      <span class='ocrx_word' id='word_1_1927' title='bbox 1792 3345 1817 3366; x_wconf 89'>in</span>
+      <span class='ocrx_word' id='word_1_1928' title='bbox 1830 3345 1912 3365; x_wconf 82'>Russia</span>
+      <span class='ocrx_word' id='word_1_1929' title='bbox 1922 3353 1941 3366; x_wconf 82'>».</span>
+      <span class='ocrx_word' id='word_1_1930' title='bbox 1956 3346 1995 3368; x_wconf 92'>Ma</span>
+      <span class='ocrx_word' id='word_1_1931' title='bbox 2010 3347 2138 3373; x_wconf 74'>l’indagine</span>
+      <span class='ocrx_word' id='word_1_1932' title='bbox 2151 3347 2221 3369; x_wconf 92'>scien-</span>
+     </span>
+     <span class='ocr_line' id='line_1_277' title="bbox 1588 3374 2221 3400; baseline 0.006 -6; x_size 26.412552; x_descenders 5.4125509; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1933' title='bbox 1588 3374 1646 3397; x_wconf 92'>tifica</span>
+      <span class='ocrx_word' id='word_1_1934' title='bbox 1663 3382 1707 3395; x_wconf 92'>non</span>
+      <span class='ocrx_word' id='word_1_1935' title='bbox 1723 3376 1745 3397; x_wconf 91'>lo</span>
+      <span class='ocrx_word' id='word_1_1936' title='bbox 1760 3376 1878 3397; x_wconf 88'>allontana</span>
+      <span class='ocrx_word' id='word_1_1937' title='bbox 1893 3376 1930 3397; x_wconf 87'>dal</span>
+      <span class='ocrx_word' id='word_1_1938' title='bbox 1944 3378 2086 3399; x_wconf 92'>movimento</span>
+      <span class='ocrx_word' id='word_1_1939' title='bbox 2101 3378 2221 3400; x_wconf 91'>rivoluzio-</span>
+     </span>
+     <span class='ocr_line' id='line_1_278' title="bbox 1588 3405 2221 3438; baseline 0.011 -13; x_size 29; x_descenders 8; x_ascenders 7">
+      <span class='ocrx_word' id='word_1_1940' title='bbox 1588 3405 1658 3430; x_wconf 87'>nanio,</span>
+      <span class='ocrx_word' id='word_1_1941' title='bbox 1681 3406 1722 3428; x_wconf 91'>che</span>
+      <span class='ocrx_word' id='word_1_1942' title='bbox 1744 3407 1788 3431; x_wconf 92'>egli</span>
+      <span class='ocrx_word' id='word_1_1943' title='bbox 1811 3414 1881 3434; x_wconf 91'>segue</span>
+      <span class='ocrx_word' id='word_1_1944' title='bbox 1918 3410 2092 3438; x_wconf 54'>attentamente</span>
+      <span class='ocrx_word' id='word_1_1945' title='bbox 2104 3401 2125 3442; x_wconf 39'>_</span>
+      <span class='ocrx_word' id='word_1_1946' title='bbox 2134 3416 2221 3434; x_wconf 74'>sempre</span>
+     </span>
+     <span class='ocr_line' id='line_1_279' title="bbox 1588 3436 2221 3466; baseline 0.008 -9; x_size 28; x_descenders 5; x_ascenders 8">
+      <span class='ocrx_word' id='word_1_1947' title='bbox 1588 3436 1748 3460; x_wconf 83'>combattendo</span>
+      <span class='ocrx_word' id='word_1_1948' title='bbox 1765 3438 1822 3463; x_wconf 84'>ogni</span>
+      <span class='ocrx_word' id='word_1_1949' title='bbox 1840 3437 1972 3461; x_wconf 90'>deviazione</span>
+      <span class='ocrx_word' id='word_1_1950' title='bbox 1990 3439 2051 3462; x_wconf 81'>dalla</span>
+      <span class='ocrx_word' id='word_1_1951' title='bbox 2069 3440 2130 3462; x_wconf 91'>linea</span>
+      <span class='ocrx_word' id='word_1_1952' title='bbox 2148 3440 2221 3466; x_wconf 83'>prole-</span>
+     </span>
+    </p>
+   </div>
+   <div class='ocr_carea' id='block_1_15' title="bbox 0 0 2491 3600">
+    <p class='ocr_par' id='par_1_21' lang='ita' title="bbox 0 0 2491 3600">
+     <span class='ocr_line' id='line_1_280' title="bbox 0 0 2491 3600; baseline 0 0; x_size 1800; x_descenders -900; x_ascenders 900">
+      <span class='ocrx_word' id='word_1_1953' title='bbox 0 0 2491 3600; x_wconf 95'> </span>
+     </span>
+    </p>
+   </div>
+  </div>
+ </body>
+</html>


### PR DESCRIPTION
When locating breaks based on hOCR classes, we read the input in blocks of 64k chars. Previously, due to an error in the looping logic, we would not actually read any blocks besides the first one  and set the limit to the end of the first block. This should be fixed now, more blocks are read as needed.