### PR TITLE
Refactor skipping of ignored words to not use recursion.

### DIFF
--- a/src/main/java/com/github/dbmdz/solrocr/formats/alto/AltoParser.java
+++ b/src/main/java/com/github/dbmdz/solrocr/formats/alto/AltoParser.java
@@ -202,18 +202,6 @@ public class AltoParser extends OcrParser {
       }
       this.inHyphenation = false;
     }
-
-    // Boxes without text or coordinates (if either is requested with a feature flag) are ignored
-    // since they break
-    // things downstream
-    boolean ignoreBox =
-        (features.contains(ParsingFeature.TEXT)
-                && (box.getText() == null || box.getText().isEmpty()))
-            || (features.contains(ParsingFeature.COORDINATES)
-                && (box.getLrx() < 0 && box.getLry() < 0 && box.getUlx() < 0 && box.getUly() < 0));
-    if (ignoreBox) {
-      return this.readNext(xmlReader, features);
-    }
     return box;
   }
 

--- a/src/main/java/com/github/dbmdz/solrocr/formats/hocr/HocrParser.java
+++ b/src/main/java/com/github/dbmdz/solrocr/formats/hocr/HocrParser.java
@@ -102,17 +102,6 @@ public class HocrParser extends OcrParser {
         box.setHyphenInfo(null, null);
       }
     }
-
-    // Boxes without text or coordinates (if either is requested with a feature flag) are ignored
-    // since they break things downstream. Skip the current box and continue with next one.
-    boolean ignoreBox =
-        (features.contains(ParsingFeature.TEXT)
-                && (box.getText() == null || box.getText().isEmpty()))
-            || (features.contains(ParsingFeature.COORDINATES)
-                && (box.getLrx() < 0 && box.getLry() < 0 && box.getUlx() < 0 && box.getUly() < 0));
-    if (ignoreBox) {
-      box = this.readNext(xmlReader, features);
-    }
     return box;
   }
 

--- a/src/main/java/com/github/dbmdz/solrocr/formats/miniocr/MiniOcrParser.java
+++ b/src/main/java/com/github/dbmdz/solrocr/formats/miniocr/MiniOcrParser.java
@@ -112,17 +112,6 @@ public class MiniOcrParser extends OcrParser {
         box.setHyphenInfo(null, null);
       }
     }
-
-    // Boxes without text or coordinates (if either is requested with a feature flag) are ignored
-    // since they break things downstream
-    boolean ignoreBox =
-        (features.contains(ParsingFeature.TEXT)
-                && (box.getText() == null || box.getText().isEmpty()))
-            || (features.contains(ParsingFeature.COORDINATES)
-                && (box.getLrx() < 0 && box.getLry() < 0 && box.getUlx() < 0 && box.getUly() < 0));
-    if (ignoreBox) {
-      box = this.readNext(xmlReader, features);
-    }
     return box;
   }
 

--- a/src/main/java/com/github/dbmdz/solrocr/iter/BaseBreakLocator.java
+++ b/src/main/java/com/github/dbmdz/solrocr/iter/BaseBreakLocator.java
@@ -28,9 +28,9 @@ public abstract class BaseBreakLocator implements BreakLocator {
    * block hierarchy, i.e. we often run into the situation there is no match. These cases are the
    * absolute worst case for both {@link String#lastIndexOf(String, int)} and {@link
    * String#indexOf(String, int)}. So why is the latter faster? Well, in recent Hotspot versions, it
-   * is SIMD-accelerated via compiler intrinsics. And the speed-up we get from these worst cases
-   * is significant enough to completely make up for the slightly worse performance in more ideal
-   * cases (~25% slower).
+   * is SIMD-accelerated via compiler intrinsics. And the speed-up we get from these worst cases is
+   * significant enough to completely make up for the slightly worse performance in more ideal cases
+   * (~25% slower).
    */
   protected static int optimizedLastIndexOf(String haystack, String needle, int fromIdx) {
     int from = -1;

--- a/src/test/java/com/github/dbmdz/solrocr/solr/HocrTest.java
+++ b/src/test/java/com/github/dbmdz/solrocr/solr/HocrTest.java
@@ -508,9 +508,25 @@ public class HocrTest extends SolrTestCaseJ4 {
 
   public void testIssue288() throws IOException {
     Path ocrPath = Paths.get("src/test/resources/data/issue_288.hocr");
-    assertU(adoc("ocr_text_stored", new String(Files.readAllBytes(ocrPath), StandardCharsets.UTF_8), "id", "87371"));
+    assertU(
+        adoc(
+            "ocr_text_stored",
+            new String(Files.readAllBytes(ocrPath), StandardCharsets.UTF_8),
+            "id",
+            "87371"));
     assertU(commit());
-    SolrQueryRequest req = xmlQ("q", "il", "hl.snippets", "4096", "hl.weightMatches", "true", "df", "ocr_text_stored", "hl.ocr.fl", "ocr_text_stored");
+    SolrQueryRequest req =
+        xmlQ(
+            "q",
+            "il",
+            "hl.snippets",
+            "4096",
+            "hl.weightMatches",
+            "true",
+            "df",
+            "ocr_text_stored",
+            "hl.ocr.fl",
+            "ocr_text_stored");
     assertQ(req, "count(.//lst[@name=\"87371\"]//arr[@name='snippets']/lst)=19");
   }
 }


### PR DESCRIPTION
For some very broken-but-valid OCR files this could lead to incredibly deep stacks, so we better switch to an iterative solution.