### PR TITLE
Fix compatibility with Solr 9.4 and Lucene 9.8

### DIFF
--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -4,7 +4,7 @@ SOLR_HOST="${SOLR_HOST:-localhost}"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SOLR7_VERSIONS="7.7 7.6 7.5"
 SOLR8_VERSIONS="8.11 8.10 8.9 8.8 8.7 8.6 8.5 8.4 8.3 8.2 8.1 8.0"
-SOLR9_VERSIONS="9.2 9.1 9.0"
+SOLR9_VERSIONS="9.4 9.3 9.2 9.1 9.0"
 SOLR78_PLUGIN_PATH=/tmp/solrocr-solr78
 
 wait_for_solr() {

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
     <version.junit>5.10.1</version.junit>
     <version.mockito>5.8.0</version.mockito>
     <version.slf4j>2.0.2</version.slf4j>
-    <version.solr>9.2.1</version.solr>
-    <version.lucene>9.4.2</version.lucene>
+    <version.solr>9.4.0</version.solr>
+    <version.lucene>9.8.0</version.lucene>
     <!-- DO NOT UPDATE THIS, this is the latest version that works with Java 8 -->
     <version.fmt-maven-plugin>2.9.1</version.fmt-maven-plugin>
     <version.maven-gpg-plugin>3.1.0</version.maven-gpg-plugin>

--- a/src/main/java/com/github/dbmdz/solrocr/util/HighlightTimeout.java
+++ b/src/main/java/com/github/dbmdz/solrocr/util/HighlightTimeout.java
@@ -36,7 +36,6 @@ public class HighlightTimeout implements QueryTimeout {
     return timeoutAt - System.nanoTime() < 0L;
   }
 
-  @Override
   public boolean isTimeoutEnabled() {
     return get() != null;
   }


### PR DESCRIPTION
- Implemented missing methods `BaseCompositeReader` API introduced in Lucene 9.8
- Removed `@Override` on `HighlightTimeout#isTimeoutEnabled`, seems to have been removed from the `QueryTimeout` interface

Luckily no bytecode patching neccessary, integration tests succeed for all supported Solr versions all the way back to Solr 7.7 🥳 