### PR TITLE
Fix regular highlighting in case no hl field can be determined (fixes #396)

### DIFF
--- a/src/main/java/solrocr/OcrHighlightComponent.java
+++ b/src/main/java/solrocr/OcrHighlightComponent.java
@@ -167,7 +167,7 @@ public class OcrHighlightComponent extends SearchComponent
         params.set(
             "hl.fl",
             Arrays.stream(defaultHighlightFields)
-                .filter(fl -> !ocrHlFields.contains(fl))
+                .filter(fl -> fl != null && !ocrHlFields.contains(fl))
                 .collect(Collectors.joining(",")));
       }
       if (Strings.isNullOrEmpty(params.get("hl.fl"))) {


### PR DESCRIPTION
Looks like there's a bug in Solr where when no highlighting field can be determined (from `hl.fl` or the `df` defined for the query parser), the set of highlight fields will contain a single `null` value that triggers an exception down the line, causing the highlight component to fail and the response to return with a 400 error code.

The workaround is to simply set the `hl.fl` paremter for the regular highlighter explicitly, and excluding the `null` value there.