### PR TITLE
Don't fail the whole request when a source pointer can't be read.

### DIFF
--- a/src/main/java/com/github/dbmdz/solrocr/model/SourcePointer.java
+++ b/src/main/java/com/github/dbmdz/solrocr/model/SourcePointer.java
@@ -3,6 +3,7 @@ package com.github.dbmdz.solrocr.model;
 import com.google.common.collect.ImmutableList;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -12,8 +13,11 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SourcePointer {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static class FileSource {
 

--- a/src/main/java/com/github/dbmdz/solrocr/solr/SolrOcrHighlighter.java
+++ b/src/main/java/com/github/dbmdz/solrocr/solr/SolrOcrHighlighter.java
@@ -100,12 +100,14 @@ public class SolrOcrHighlighter extends UnifiedSolrHighlighter {
       SimpleOrderedMap<Object> docMap = (SimpleOrderedMap<Object>) out.get(docId);
       if (docMap == null) {
         docMap = new SimpleOrderedMap<>();
-        out.add(docId, docMap);
       }
       if (ocrSnippets[k] == null) {
         continue;
       }
       docMap.addAll(ocrSnippets[k].toNamedList());
+      if (docMap.size() > 0) {
+        out.add(docId, docMap);
+      }
     }
   }
 

--- a/src/main/java/solrocr/OcrHighlighter.java
+++ b/src/main/java/solrocr/OcrHighlighter.java
@@ -528,14 +528,20 @@ public class OcrHighlighter extends UnifiedHighlighter {
           ocrVals[fieldIdx] = IterableCharSequence.fromString(fieldValue);
           continue;
         }
-        SourcePointer sourcePointer = SourcePointer.parse(fieldValue);
+        SourcePointer sourcePointer = null;
+        try {
+          sourcePointer = SourcePointer.parse(fieldValue);
+        } catch (RuntimeException e) {
+          log.error("Could not parse OCR pointer for document {}: {}", docId, fieldValue, e);
+        }
         if (sourcePointer == null) {
           // None of the files in the pointer exist or were readable, log should have warnings
           ocrVals[fieldIdx] = null;
           continue;
         }
         // If preloading is enabled, start warming the cache for the pointer
-        PageCacheWarmer.getInstance().ifPresent(w -> w.preload(sourcePointer));
+        final SourcePointer finalPtr = sourcePointer;
+        PageCacheWarmer.getInstance().ifPresent(w -> w.preload(finalPtr));
         if (sourcePointer.sources.size() == 1) {
           ocrVals[fieldIdx] =
               new FileBytesCharIterator(

--- a/src/test/java/com/github/dbmdz/solrocr/solr/DistributedTest.java
+++ b/src/test/java/com/github/dbmdz/solrocr/solr/DistributedTest.java
@@ -140,7 +140,7 @@ public class DistributedTest extends BaseDistributedSearchTestCase {
         "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea <em>commodo consequat</em>. Duis aute irure dolor in "
             + "reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ");
     NamedList<?> ocrHls = (NamedList<?>) resp.getResponse().get("ocrHighlighting");
-    assertEquals(2, ocrHls.size());
+    assertEquals(1, ocrHls.size());
     assertEquals(1, ((NamedList<?>) ocrHls.get("31337")).size());
   }
 }


### PR DESCRIPTION
Instead just skip the field and continue with the rest.