### PR TITLE
Release 0.8.5

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,3 +1,17 @@
+## 0.8.5 (2024-04-25)
+[GitHub Release](https://github.com/dbmdz/solr-ocrhighlighting/releases/tag/0.8.5)
+
+**Changed:**
+- Missing files no longer fail the complete search request, instead the OCR
+  highlighting for the document is skipped
+- Add support for Solr 9.5
+- Updated documentation with warning for Solr 9 users to disable security sandboxing
+  when using pointers to external files
+
+**Fixed:**
+- Regular highlighting in case no hl field can be determined works again (#404)
+- Passage building across more than two concatenated files works now (#422)
+
 ## 0.8.4 (2024-01-29)
 [GitHub Release](https://github.com/dbmdz/solr-ocrhighlighting/releases/tag/0.8.4)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>solr-ocrhighlighting</artifactId>
-  <version>0.8.5-SNAPSHOT</version>
+  <version>0.8.5</version>
 
   <name>Solr OCR Highlighting Plugin</name>
   <description>
@@ -30,8 +30,8 @@
       <organizationUrl>https://github.com/dbmdz</organizationUrl>
     </developer>
     <developer>
-      <name>Christoph Lorenz</name>
-      <email>christoph.lorenz@bsb-muenchen.de</email>
+      <name>Katharina Schmid</name>
+      <email>katharina.schmid@bsb-muenchen.de</email>
       <organization>Bavarian State Library</organization>
       <organizationUrl>https://github.com/dbmdz</organizationUrl>
     </developer>


### PR DESCRIPTION
**Changed:**
- Missing files no longer fail the complete search request, instead the OCR highlighting for the document is skipped
- Add support for Solr 9.5
- Updated documentation with warning for Solr 9 users to disable security sandboxing when using pointers to external files

**Fixed:**
- Regular highlighting in case no hl field can be determined works again (#404)
- Passage building across more than two concatenated files works now (#422)