### PR TITLE
miniocr: Make page fragment parsing more robust (#447)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>solr-ocrhighlighting</artifactId>
-  <version>0.9.1</version>
+  <version>0.9.2-SNAPSHOT</version>
 
   <name>Solr OCR Highlighting Plugin</name>
   <description>


### PR DESCRIPTION
The parsing method is now tolerant of differing attribute order and the presence of extra attributes that we don't care about.