### PR TITLE
Fix compatibility with Solr 9.8

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,6 +58,9 @@ In your core's `solrconfig.xml`, you need to:
     This assumes a directory structure where the cores are in
     `$SOLR_HOME/server/solr/$CORE` and the plugin JAR was installed in
     `$SOLR_HOME/contrib/ocrhighlighting/lib`. Adjust the path if you setup differs.
+
+    NOTE: When using Solr >=9.8, you need to start it with `-Dsolr.config.lib.enabled=true`
+          for this to work
   -->
   <lib dir="../../../contrib/ocrhighlighting/lib" regex=".*\.jar" />
 

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -4,7 +4,7 @@ SOLR_HOST="${SOLR_HOST:-localhost}"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SOLR7_VERSIONS="7.7 7.6 7.5"
 SOLR8_VERSIONS="8.11 8.10 8.9 8.8 8.7 8.6 8.5 8.4 8.3 8.2 8.1 8.0"
-SOLR9_VERSIONS="9.7 9.6 9.5 9.4 9.3 9.2 9.1 9.0"
+SOLR9_VERSIONS="9.8 9.7 9.6 9.5 9.4 9.3 9.2 9.1 9.0"
 
 wait_for_solr() {
     status="404"
@@ -45,6 +45,7 @@ for version in $SOLR9_VERSIONS; do
     --name "$container_name" \
     -e SOLR_LOG_LEVEL=ERROR \
     -e SOLR_SECURITY_MANAGER_ENABLED=false \
+    -e SOLR_OPTS="-Dsolr.config.lib.enabled=true" \
     -v "$(pwd)/solr/install-plugin.sh:/docker-entrypoint-initdb.d/install-plugin.sh" \
     -v "$(pwd)/solr/core/v9:/opt/core-config" \
     -v "$(pwd)/data:/ocr-data" \

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
     <version.junit>5.11.3</version.junit>
     <version.mockito>5.14.2</version.mockito>
     <version.slf4j>2.0.16</version.slf4j>
-    <version.solr>9.7.0</version.solr>
+    <version.solr>9.8.0</version.solr>
     <version.lucene>9.11.1</version.lucene>
-    <version.fmt-maven-plugin>2.13</version.fmt-maven-plugin>
+    <version.fmt-maven-plugin>2.25</version.fmt-maven-plugin>
     <version.maven-gpg-plugin>3.2.7</version.maven-gpg-plugin>
     <version.maven-javadoc-plugin>3.11.1</version.maven-javadoc-plugin>
     <version.maven-shade-plugin>3.6.0</version.maven-shade-plugin>
@@ -168,7 +168,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.coveo</groupId>
+        <groupId>com.spotify.fmt</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>${version.fmt-maven-plugin}</version>
         <executions>

--- a/src/main/java/com/github/dbmdz/solrocr/formats/miniocr/MiniOcrFormat.java
+++ b/src/main/java/com/github/dbmdz/solrocr/formats/miniocr/MiniOcrFormat.java
@@ -16,8 +16,7 @@ import java.util.regex.Pattern;
 import javax.xml.stream.XMLStreamException;
 
 public class MiniOcrFormat implements OcrFormat {
-  private static final Pattern pageIdPat =
-      Pattern.compile("(?:xml)?:id=[\"'](?<pageId>.+?)[\"']");
+  private static final Pattern pageIdPat = Pattern.compile("(?:xml)?:id=[\"'](?<pageId>.+?)[\"']");
   private static final Pattern pageDimPat =
       Pattern.compile("wh=[\"'](?<width>\\d+) (?<height>\\d+)[\"']");
   private static final Map<OcrBlock, String> blockTagMapping =

--- a/src/main/java/com/github/dbmdz/solrocr/lucene/filters/SanitizingXmlFilter.java
+++ b/src/main/java/com/github/dbmdz/solrocr/lucene/filters/SanitizingXmlFilter.java
@@ -41,6 +41,7 @@ public class SanitizingXmlFilter extends BaseCharFilter implements SourceAwareRe
    * stored in the instance state.
    */
   private char[] closingTagsTrailer = null;
+
   /** Tracks how much of the trailer has already been written during previous `read` calls. */
   private int closingTagsTrailerIdx = -1;
 

--- a/src/main/java/com/github/dbmdz/solrocr/reader/BaseSourceReader.java
+++ b/src/main/java/com/github/dbmdz/solrocr/reader/BaseSourceReader.java
@@ -24,6 +24,7 @@ public abstract class BaseSourceReader implements SourceReader {
    * BaseSourceReader#maxCacheEntries} slots will ever be non-null
    */
   CachedSection[] cache;
+
   /**
    * Array of length {@link BaseSourceReader#maxCacheEntries} with the indexes of the sections that
    * are currently cached

--- a/src/main/java/com/github/dbmdz/solrocr/reader/StreamDecoder.java
+++ b/src/main/java/com/github/dbmdz/solrocr/reader/StreamDecoder.java
@@ -130,7 +130,7 @@ public class StreamDecoder extends Reader {
       case 2:
         leftoverChar = cb[1];
         haveLeftoverChar = true;
-        // FALL THROUGH
+      // FALL THROUGH
       case 1:
         return cb[0];
       default:


### PR DESCRIPTION
- `<lib>` directives in the core config need to be explicitely enabled (needed for integration tests)
- `IndexSearcher.storedFields()` is now used for Lucene versions >= 9.5 instead of the deprecated `doc` method for retrieving stored field values.
- Update code formatter
- Remove `OcrHighlighter#getTermVectors()`, no longer needed to fulfill the interface