### PR TITLE
Fix errors when a partial response is received during distributed request processing

### DIFF
--- a/src/main/java/solrocr/OcrHighlightComponent.java
+++ b/src/main/java/solrocr/OcrHighlightComponent.java
@@ -211,8 +211,10 @@ public class OcrHighlightComponent extends SearchComponent
             rb.rsp.getResponseHeader().add(OcrHighlighter.PARTIAL_OCR_HIGHLIGHTS, true);
           }
           Object hl = srsp.getSolrResponse().getResponse().get(HL_RESPONSE_FIELD);
-          SolrPluginUtils.copyNamedListIntoArrayByDocPosInResponse(
-              (NamedList) hl, rb.resultIds, (Map.Entry<String, Object>[]) objArr);
+          if (hl != null) {
+            SolrPluginUtils.copyNamedListIntoArrayByDocPosInResponse(
+                (NamedList) hl, rb.resultIds, (Map.Entry<String, Object>[]) objArr);
+          }
         }
       }
       rb.rsp.add(


### PR DESCRIPTION
We falsely assumed that the `ocrHighlighting` was always set on a response where the feature was enabled, but this was not the case when the request processing was previously stopped due to limits.