### PR TITLE
Fix version constraints for package repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ the work, so we can discuss if it's a fit.
 1. Create a PR for the release:
     - Update version in `pom.xml`
     - Update `docs/changes.md` with the release information
+    - If the compatibility with Solr has changed, update the version constraints
+      in `util/update_repo.py`
 2. Wait for PR to be approved and merge
 3. Tag release commit (`<major>.<minor>.<patch>`) and push the tag to GitHub
 4. Make a Release Build:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,9 +17,9 @@ your Solrcloud cluster. All paths are relative to the Solr installation director
 
 - **Add repository** to the local package registry:<br>
   `$ ./bin/solr package add-repo dbmdz.github.io https://dbmdz.github.io/solr`
+  Use https://dbmdz.github.io/solr78 if you're on a Solr version older than 9.0
 - **Install package** in the latest version:<br>
-  `$ ./bin/solr package install ocrhighlighting` if you're on Solr 9, otherwise:
-  `$ ./bin/solr package install ocrhighlighting:0.9.1-solr78`
+  `$ ./bin/solr package install ocrhighlighting`
 
 !!! caution "Be sure to use the `ocrhighlighting:` prefix when specifying classes in your configuration."
     When using the Package Manager, classes from plugins have to be prefixed (separated by a colon) by

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>solr-ocrhighlighting</artifactId>
-  <version>0.9.3</version>
+  <version>0.9.4-SNAPSHOT</version>
 
   <name>Solr OCR Highlighting Plugin</name>
   <description>

--- a/util/update_repo.py
+++ b/util/update_repo.py
@@ -27,7 +27,12 @@ VERSION_CONSTRAINTS_78 = [
     ((0, 4, 0), ("7.5", "8.8")),
     ((0, 7, 0), ("7.5", "8.11")),
 ]
-VERSION_CONSTRAINTS_9 = [((0, 8, 0), ("9.0",))]
+VERSION_CONSTRAINTS_9 = [
+    ((0, 8, 0), ("9.0", "9.3")),
+    ((0, 8, 4), ("9.0", "9.4")),
+    ((0, 8, 5), ("9.0", "9.6")),
+    ((0, 9, 1), ("9.0", "9.8")),
+]
 SPLIT_START_VERSION = (0, 8, 0)
 REPOSITORY_NAME = "ocrhighlighting"
 REPOSITORY_DESCRIPTION = "Highlight various OCR formats directly in Solr."


### PR DESCRIPTION
The version constraint for the releases for Solr 9.x were pinned to 9.0, which caused issues. The constraints have now been adjusted to match the actual compatibility between plugin and Solr versions.

Additionally, the documentation was updated to point to the correct repository URL for Solr versions 7.x and 8.x.