### PR TITLE
Update documentation with requirements for ALTO and page identifiers

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -18,16 +18,23 @@ query parameters](query.md#available-highlighting-parameters) to control how the
 
 **Block type mapping:**
 
-| Block     | hOCR class                  | notes                            |
-| --------- | --------------------------- | -------------------------------- |
-| Word      | `ocrx_word`                 | needs to have a `bbox` attribute with the coordinates on the page |
-| Page      | `ocr_page`                  | needs to have a page identifier, either in `id` attribute or in the `ppageno` or `x_source` entry in the `title` attribute |
-| Block     | `ocr_carea`/`ocrx_block`    |                                  |
-| Section   | `ocr_chapter`/`ocr_section`/<br>`ocr_subsection`/`ocr_subsubsection` | |
-| Paragraph | `ocr_par`                   |                                  |
-| Line      | `ocr_line` or `ocrx_line`   |                                  |
+| Block     | hOCR class                  | notes                                                                                                                                                                                  |
+| --------- | --------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Word      | `ocrx_word`                 | needs to have a `bbox` attribute with the coordinates on the page                                                                                                                      |
+| Page      | `ocr_page`                  | needs to have a page identifier, either in `id` attribute or in the `ppageno` or `x_source` entry in the `title` attribute, **must be unique within a document!** |
+| Block     | `ocr_carea`/`ocrx_block`    |                                                                                                                                                                                        |
+| Section   | `ocr_chapter`/`ocr_section`/<br>`ocr_subsection`/`ocr_subsubsection` |                                                                                                                                                                                        |
+| Paragraph | `ocr_par`                   |                                                                                                                                                                                        |
+| Line      | `ocr_line` or `ocrx_line`   |                                                                                                                                                                                        |
 
 ## ALTO
+
+For ALTO OCR, there are some **requirements** for the XML structure:
+- Must have ALTO as the default namespace and no namespace prefixes for the tags.
+- If using multiple ALTO files per document, the `ID` attribute of the `<Page>` tag must be unique within the document.
+
+If those requirements are not met, you will encounter severe bugs and misbehavior in the
+highlighting phase, please make sure your inputs meet these requirements before you start indexing.
 
 !!! caution
     The coordinates returned by the plugin are **not always pixel values**, since ALTO supports a variety
@@ -37,14 +44,14 @@ query parameters](query.md#available-highlighting-parameters) to control how the
 
 **Block type mapping:**
 
-| Block     | ALTO tag                    | notes                            |
-| --------- | --------------------------- | -------------------------------- |
-| Word      | `<String />`                | needs to have `CONTENT`, `HPOS`, `VPOS`, `WIDTH` and `HEIGHT` attributes |
-| Line      | `<TextLine />`              |                                  |
-| Block     | `<TextBlock />`             |                                  |
-| Page      | `<Page />`                  | needs to have an `ID` attribute with a page identifier |
-| Section   | *not mapped*                |                                  |
-| Paragraph | *not mapped*                |                                  |
+| Block     | ALTO tag                    | notes                                                                                        |
+| --------- | --------------------------- |----------------------------------------------------------------------------------------------|
+| Word      | `<String />`                | needs to have `CONTENT`, `HPOS`, `VPOS`, `WIDTH` and `HEIGHT` attributes                     |
+| Line      | `<TextLine />`              |                                                                                              |
+| Block     | `<TextBlock />`             |                                                                                              |
+| Page      | `<Page />`                  | needs to have an `ID` attribute with a page identifier, **must be unique within a document** |
+| Section   | *not mapped*                |                                                                                              |
+| Paragraph | *not mapped*                |                                                                                              |
 
 
 ## MiniOCR

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -81,6 +81,10 @@ POST http://solrhost:8983/solr/corename/update
 For indexing and highlighting, Solr will load the contents of the `ocrdoc-1_1.xml`, `ocrdoc-1_2.xml` and 
 `ocrdoc-1_2.xml` as a single continuous text.
 
+!!! caution "Page Identifiers"
+    For this use case, you have to **make absolutely sure that the page identifiers  are unique within the
+    document**.  If this requirement is not met, you will get unexpected results during highlighting.
+
 ## Advanced: One or more *partial* files per Solr document
 
 A more complicated situation arises if the Solr documents need to refer to *parts* of one or more files on
@@ -132,6 +136,7 @@ The format of the regions is inspired by [Python's slicing syntax](https://docs.
       that spans from the bottom of one page to the top of the next, you will have to include a region
       for the opening element of the first page so we can determine the page for the first part of the
       article during highlighting
+    - The page identifiers for every page in the document must be unique within it.
 
 
 !!! caution "Byte Offsets"


### PR DESCRIPTION
See #479, non-unique page identifiers and ALTO with namespace prefixes breaks our String-based break location algorithm.