### PR TITLE
Fix order of snippets when highlighting with scoring disabled.

### DIFF
--- a/src/main/java/com/github/dbmdz/solrocr/lucene/OcrFieldHighlighter.java
+++ b/src/main/java/com/github/dbmdz/solrocr/lucene/OcrFieldHighlighter.java
@@ -288,25 +288,27 @@ public class OcrFieldHighlighter {
         passage.reset();
         return passage;
       }
-      // Otherwise, add it to the queue and remove and re-use the lowest-scoring passage, if the
-      // queue is full.
+      // Queue not full, or the passage is better than the worst passage in the queue
       passageQueue.add(passage);
-      queueIsFull = passageQueue.size() > maxPassages;
-      if (queueIsFull) {
+      boolean queueExceedsMax = passageQueue.size() > maxPassages;
+      if (queueExceedsMax) {
+        // If the queue exceeds the max size, we remove the lowest scoring passage and re-use
+        // it, to avoid a heap allocation
         passage = passageQueue.poll();
         passage.reset();
       } else {
         passage = new Passage();
       }
     } else {
-      if (queueIsFull) {
-        // If the queue is full, and we don't score, we just reset the passage and return it.
+      // With scoring disabled, we're only interested in the earliest matches in the doc and ignore
+      // the rest.
+      if (!queueIsFull) {
+        passageQueue.add(passage);
+        passage = new Passage();
+      } else {
         passage.reset();
         return passage;
       }
-      // Otherwise, add it to the queue
-      passageQueue.add(passage);
-      passage = new Passage();
     }
     return passage;
   }

--- a/src/test/java/com/github/dbmdz/solrocr/solr/HocrTest.java
+++ b/src/test/java/com/github/dbmdz/solrocr/solr/HocrTest.java
@@ -504,11 +504,11 @@ public class HocrTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = xmlQ("q", "fenitſchka", "hl.ocr.scorePassages", "off");
     assertQ(
         req,
-        "((//lst[@name='42']//arr[@name='pages'])[1]/lst/str[@name='id'])[1]/text()='page_88'",
-        "((//lst[@name='42']//arr[@name='pages'])[2]/lst/str[@name='id'])[1]/text()='page_89'",
-        "((//lst[@name='42']//arr[@name='pages'])[3]/lst/str[@name='id'])[1]/text()='page_92'",
-        "((//lst[@name='42']//arr[@name='pages'])[4]/lst/str[@name='id'])[1]/text()='page_92'",
-        "((//lst[@name='42']//arr[@name='pages'])[5]/lst/str[@name='id'])[1]/text()='page_97'");
+        "((//lst[@name='42']//arr[@name='pages'])[1]/lst/str[@name='id'])[1]/text()='page_7'",
+        "((//lst[@name='42']//arr[@name='pages'])[2]/lst/str[@name='id'])[1]/text()='page_9'",
+        "((//lst[@name='42']//arr[@name='pages'])[3]/lst/str[@name='id'])[1]/text()='page_12'",
+        "((//lst[@name='42']//arr[@name='pages'])[4]/lst/str[@name='id'])[1]/text()='page_21'",
+        "((//lst[@name='42']//arr[@name='pages'])[5]/lst/str[@name='id'])[1]/text()='page_62'");
   }
 
   public void testEmptyDoc() {


### PR DESCRIPTION
The intention for this feature was to return the snippets in their order of appearance in the highlighted document, with the earliest matches coming first. Due to a mistake in the way this was implemented, the order was correct, but users would get the *last* matches in the document, not the *first* matches in the document.