### PR TITLE
deps: Bump Solr to 9.9.0, Lucene to 9.12.2

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+**Dependencies**
+- Updated Solr to 9.8.0 and Lucene to 9.12.2
+
 ## 0.9.4 (2025-05-14)
 [GitHub Release](https://github.com/dbmdz/solr-ocrhighlighting/releases/tag/0.9.4)
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 **Dependencies**
-- Updated Solr to 9.8.0 and Lucene to 9.12.2
+- Updated Solr to 9.9.0 and Lucene to 9.12.2
 
 ## 0.9.4 (2025-05-14)
 [GitHub Release](https://github.com/dbmdz/solr-ocrhighlighting/releases/tag/0.9.4)

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -4,7 +4,7 @@ SOLR_HOST="${SOLR_HOST:-localhost}"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SOLR7_VERSIONS="7.7 7.6 7.5"
 SOLR8_VERSIONS="8.11 8.10 8.9 8.8 8.7 8.6 8.5 8.4 8.3 8.2 8.1 8.0"
-SOLR9_VERSIONS="9.8 9.7 9.6 9.5 9.4 9.3 9.2 9.1 9.0"
+SOLR9_VERSIONS="9.9 9.8 9.7 9.6 9.5 9.4 9.3 9.2 9.1 9.0"
 
 wait_for_solr() {
     status="404"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>solr-ocrhighlighting</artifactId>
-  <version>0.9.4</version>
+  <version>0.9.5-SNAPSHOT</version>
 
   <name>Solr OCR Highlighting Plugin</name>
   <description>
@@ -56,8 +56,8 @@
     <version.junit>5.12.2</version.junit>
     <version.mockito>5.17.0</version.mockito>
     <version.slf4j>2.0.17</version.slf4j>
-    <version.solr>9.8.1</version.solr>
-    <version.lucene>9.11.1</version.lucene>
+    <version.solr>9.9.0</version.solr>
+    <version.lucene>9.12.2</version.lucene>
     <version.fmt-maven-plugin>2.27</version.fmt-maven-plugin>
     <version.maven-gpg-plugin>3.2.7</version.maven-gpg-plugin>
     <version.maven-javadoc-plugin>3.11.2</version.maven-javadoc-plugin>

--- a/src/main/java/com/github/dbmdz/solrocr/lucene/OcrFieldHighlighter.java
+++ b/src/main/java/com/github/dbmdz/solrocr/lucene/OcrFieldHighlighter.java
@@ -171,7 +171,8 @@ public class OcrFieldHighlighter {
       // snippetLimit
       queueSize = snippetLimit;
     } else if (pageId != null) {
-      // If we're filtering by a page identifier, we want to take *all* hits on that page into account
+      // If we're filtering by a page identifier, we want to take *all* hits on that page into
+      // account
       queueSize = 4096;
     }
     if (queueSize <= 0) {


### PR DESCRIPTION
Integration tests are passing, no API changes since Solr 9.9/Lucene 9.11, no need to put out a release, I think.