### PR TITLE
chore: Update Solr to 9.10.0 and Lucene to 9.12.3

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 **Dependencies**
-- Updated Solr to 9.9.0 and Lucene to 9.12.2
+- Updated Solr to 9.10.0 and Lucene to 9.12.3
 
 ## 0.9.4 (2025-05-14)
 [GitHub Release](https://github.com/dbmdz/solr-ocrhighlighting/releases/tag/0.9.4)

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
     <version.junit>5.13.2</version.junit>
     <version.mockito>5.18.0</version.mockito>
     <version.slf4j>2.0.17</version.slf4j>
-    <version.solr>9.9.0</version.solr>
-    <version.lucene>9.12.2</version.lucene>
+    <version.solr>9.10.0</version.solr>
+    <version.lucene>9.12.3</version.lucene>
     <version.fmt-maven-plugin>2.27</version.fmt-maven-plugin>
     <version.maven-gpg-plugin>3.2.8</version.maven-gpg-plugin>
     <version.maven-javadoc-plugin>3.11.2</version.maven-javadoc-plugin>


### PR DESCRIPTION
No release neccessary since no APIs were changed/removed.